### PR TITLE
Fix GitHub workflows for JSON-backed issue creation and Bun CI

### DIFF
--- a/.github/workflows/create-planned-issues.yml
+++ b/.github/workflows/create-planned-issues.yml
@@ -63,6 +63,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: create-labels
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
       - name: Create issues
         uses: actions/github-script@v7
         with:


### PR DESCRIPTION
## Summary
- add `.github/issues-data.json` with the 12 planned issue definitions moved out of workflow YAML
- update `create-planned-issues.yml` to read issues from the JSON file via `fs.readFileSync(...)`
- add `actions/checkout@v4` to the `create-issues` job so the JSON file exists on the runner
- replace `ci.yml` with a Bun-based pipeline (`setup-bun`, root `bun install`, dashboard build, `bunx prisma generate`)

## Testing
- Not run (not requested)