### PR TITLE
fix: fall back to sudo for nginx reload when worker is non-root

### DIFF
--- a/src/services/traffic.service.ts
+++ b/src/services/traffic.service.ts
@@ -35,9 +35,10 @@ export class TrafficService {
     // Atomically move tmp → config
     await fs.rename(tmpPath, configPath);
 
-    // Reload Nginx; restore backup on failure
+    // Reload Nginx; restore backup on failure.
+    // Master often runs as root while the worker runs as a normal user — try passwordless sudo.
     try {
-      await execFileAsync("nginx", ["-s", "reload"]);
+      await this.reloadNginx();
       logger.info({ port }, "Nginx reloaded — traffic switched");
     } catch (err) {
       logger.error({ err }, "Nginx reload failed — restoring backup");
@@ -62,5 +63,15 @@ export class TrafficService {
       `  server 127.0.0.1:${port};`,
       "}",
     ].join("\n") + "\n";
+  }
+
+  private async reloadNginx(): Promise<void> {
+    try {
+      await execFileAsync("nginx", ["-s", "reload"]);
+      return;
+    } catch (directErr) {
+      logger.debug({ err: directErr }, "nginx reload as current user failed — trying sudo -n");
+    }
+    await execFileAsync("sudo", ["-n", "/usr/sbin/nginx", "-s", "reload"]);
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
When nginx runs as root (typical) but the VersionGate worker runs as a normal user, `nginx -s reload` cannot signal the master process and deploys fail at the traffic-switch step after a successful health check.

This change tries a direct reload first, then falls back to `sudo -n /usr/sbin/nginx -s reload` so hosts can grant a narrow NOPASSWD sudoers rule (e.g. only that command) without running the whole worker as root.

**Testing:** Deployed project `whoami-demo` (traefik/whoami) end-to-end; job completed with upstream updated and `/health` returning 200 on the assigned host port.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cf513870-1565-4099-a046-4aa0a595d5ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cf513870-1565-4099-a046-4aa0a595d5ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

