### PR TITLE
feat(dashboard): clearer blue/green slots and traffic flow UI

### DIFF
--- a/dashboard/src/components/BlueGreenTrafficCard.tsx
+++ b/dashboard/src/components/BlueGreenTrafficCard.tsx
@@ -1,0 +1,241 @@
+import type { Deployment, Project } from "@/lib/api";
+import { Badge } from "@/components/ui/badge";
+import { Button, buttonVariants } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { SlotBadge } from "@/components/SlotBadge";
+import { cn } from "@/lib/utils";
+import {
+  type DeploymentColor,
+  healthCheckUrl,
+  latestDeploymentForColor,
+  publicServiceUrl,
+} from "@/lib/deployment-display";
+
+type SlotPhase = "live" | "deploying" | "idle";
+
+function slotPhase(
+  color: DeploymentColor,
+  active: Deployment | undefined,
+  deploying: Deployment | undefined
+): SlotPhase {
+  if (active?.color === color) return "live";
+  if (deploying?.color === color) return "deploying";
+  return "idle";
+}
+
+function phaseBadge(phase: SlotPhase): { label: string; className: string } {
+  switch (phase) {
+    case "live":
+      return { label: "Receiving traffic", className: "border-emerald-500/40 bg-emerald-600/15 text-emerald-200" };
+    case "deploying":
+      return { label: "Deploy in progress", className: "border-amber-500/40 bg-amber-500/15 text-amber-200" };
+    default:
+      return { label: "Idle slot", className: "border-border/60 bg-muted/25 text-muted-foreground" };
+  }
+}
+
+function statusLine(d: Deployment | undefined): string | null {
+  if (!d) return null;
+  if (d.status === "ACTIVE") return `v${d.version} active`;
+  if (d.status === "DEPLOYING") return `v${d.version} deploying`;
+  if (d.status === "FAILED") return d.errorMessage ? `v${d.version} failed` : `v${d.version} failed`;
+  if (d.status === "ROLLED_BACK") return `v${d.version} retired`;
+  return `v${d.version} ${d.status.toLowerCase()}`;
+}
+
+interface BlueGreenTrafficCardProps {
+  project: Project;
+  deployments: Deployment[];
+  active: Deployment | undefined;
+  deploying: Deployment | undefined;
+  liveHostPort: number | null;
+  liveUrl: string | null;
+  onCopy: (text: string, label: string) => void;
+}
+
+export function BlueGreenTrafficCard({
+  project,
+  deployments,
+  active,
+  deploying,
+  liveHostPort,
+  liveUrl,
+  onCopy,
+}: BlueGreenTrafficCardProps) {
+  const bluePort = project.basePort;
+  const greenPort = project.basePort + 1;
+  const blueUrl = publicServiceUrl(bluePort);
+  const greenUrl = publicServiceUrl(greenPort);
+  const latestBlue = latestDeploymentForColor(deployments, "BLUE");
+  const latestGreen = latestDeploymentForColor(deployments, "GREEN");
+
+  const nginxNote =
+    "Nginx upstream points at the live slot’s host port. Direct links below hit each slot even when idle.";
+
+  return (
+    <Card className="border-border/50 bg-card/60 ring-1 ring-border/25">
+      <CardHeader className="space-y-3">
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+          <div>
+            <CardTitle>Blue / green slots</CardTitle>
+            <CardDescription className="mt-1 max-w-2xl">
+              Two fixed host ports per project. A deploy builds into the <span className="font-medium text-foreground">idle</span> slot;
+              after the health check passes, traffic switches and the old container is stopped.
+            </CardDescription>
+          </div>
+        </div>
+
+        {/* Traffic flow */}
+        <div className="rounded-xl border border-border/50 bg-muted/20 px-4 py-3">
+          <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Traffic flow</p>
+          <div className="mt-2 flex flex-wrap items-center gap-2 text-sm">
+            <span className="rounded-md border border-border/60 bg-background/80 px-2 py-1 font-mono text-xs">Clients</span>
+            <span className="text-muted-foreground" aria-hidden>
+              →
+            </span>
+            <span className="rounded-md border border-violet-500/30 bg-violet-500/10 px-2 py-1 font-mono text-xs text-violet-200">
+              Nginx
+            </span>
+            <span className="text-muted-foreground" aria-hidden>
+              →
+            </span>
+            {liveHostPort != null && liveUrl ? (
+              <span className="rounded-md border border-emerald-500/35 bg-emerald-500/10 px-2 py-1 font-mono text-xs text-emerald-100">
+                :{liveHostPort} ({active?.color ?? "—"})
+              </span>
+            ) : (
+              <span className="rounded-md border border-dashed border-border/60 px-2 py-1 font-mono text-xs text-muted-foreground">
+                no active slot yet
+              </span>
+            )}
+            <span className="text-muted-foreground" aria-hidden>
+              →
+            </span>
+            <span className="rounded-md border border-border/60 bg-background/80 px-2 py-1 font-mono text-xs">
+              container :{project.appPort}
+            </span>
+          </div>
+          <p className="mt-2 text-xs text-muted-foreground">{nginxNote}</p>
+        </div>
+      </CardHeader>
+
+      <CardContent className="grid gap-4 sm:grid-cols-2">
+        {(
+          [
+            {
+              color: "BLUE" as const,
+              port: bluePort,
+              url: blueUrl,
+              latest: latestBlue,
+            },
+            {
+              color: "GREEN" as const,
+              port: greenPort,
+              url: greenUrl,
+              latest: latestGreen,
+            },
+          ] as const
+        ).map(({ color, port, url, latest }) => {
+          const phase = slotPhase(color, active, deploying);
+          const pb = phaseBadge(phase);
+          const healthUrl = healthCheckUrl(project, port);
+          const isLive = phase === "live";
+          const isDeploying = phase === "deploying";
+
+          return (
+            <div
+              key={color}
+              className={cn(
+                "relative overflow-hidden rounded-xl border p-4 transition-colors",
+                color === "BLUE" && "border-sky-500/30 bg-gradient-to-br from-sky-500/[0.07] to-transparent",
+                color === "GREEN" && "border-emerald-500/30 bg-gradient-to-br from-emerald-500/[0.07] to-transparent",
+                isLive && "ring-1 ring-emerald-500/35",
+                isDeploying && "ring-1 ring-amber-500/35"
+              )}
+            >
+              <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
+                <div className="flex items-center gap-2">
+                  <SlotBadge color={color} />
+                  <Badge variant="outline" className={cn("text-[10px] font-semibold uppercase", pb.className)}>
+                    {pb.label}
+                  </Badge>
+                </div>
+                <span className="font-mono text-xs tabular-nums text-muted-foreground">host:{port}</span>
+              </div>
+
+              <p className="break-all font-mono text-sm text-foreground">{url.replace(/^https?:\/\//, "")}</p>
+
+              <dl className="mt-3 space-y-1.5 text-xs">
+                <div className="flex justify-between gap-2">
+                  <dt className="text-muted-foreground">Docker map</dt>
+                  <dd className="font-mono text-right text-foreground">
+                    {port} → {project.appPort}
+                  </dd>
+                </div>
+                {latest ? (
+                  <>
+                    <div className="flex justify-between gap-2">
+                      <dt className="text-muted-foreground">Last on this slot</dt>
+                      <dd className="text-right">
+                        <span className="font-mono text-foreground">{statusLine(latest)}</span>
+                      </dd>
+                    </div>
+                    <div className="flex justify-between gap-2">
+                      <dt className="text-muted-foreground">Container</dt>
+                      <dd className="max-w-[min(100%,14rem)] truncate font-mono text-right text-muted-foreground" title={latest.containerName}>
+                        {latest.containerName}
+                      </dd>
+                    </div>
+                    <div className="flex justify-between gap-2">
+                      <dt className="text-muted-foreground">Image</dt>
+                      <dd className="max-w-[min(100%,14rem)] truncate font-mono text-right text-muted-foreground" title={latest.imageTag}>
+                        {latest.imageTag}
+                      </dd>
+                    </div>
+                  </>
+                ) : (
+                  <p className="text-muted-foreground">No deployment has used this slot yet.</p>
+                )}
+              </dl>
+
+              <div className="mt-4 flex flex-wrap gap-2">
+                <Button type="button" variant="outline" size="sm" className="h-8 text-xs" onClick={() => onCopy(url, "App URL")}>
+                  Copy app URL
+                </Button>
+                <Button type="button" variant="outline" size="sm" className="h-8 text-xs" onClick={() => onCopy(healthUrl, "Health URL")}>
+                  Copy health URL
+                </Button>
+                <a href={url} target="_blank" rel="noreferrer" className={buttonVariants({ variant: "secondary", size: "sm", className: "h-8 text-xs" })}>
+                  Open app
+                </a>
+                <a
+                  href={healthUrl}
+                  target="_blank"
+                  rel="noreferrer"
+                  className={buttonVariants({ variant: "ghost", size: "sm", className: "h-8 text-xs" })}
+                >
+                  Health
+                </a>
+              </div>
+            </div>
+          );
+        })}
+      </CardContent>
+
+      {liveUrl && active && (
+        <CardContent className="border-t border-border/40 pt-4">
+          <p className="text-sm text-muted-foreground">
+            <span className="font-medium text-foreground">Live right now:</span>{" "}
+            <span className="font-mono text-foreground">{liveUrl}</span>
+            <span className="mx-1 text-muted-foreground">·</span>
+            slot <SlotBadge color={active.color} />
+            <span className="mx-1 text-muted-foreground">·</span>
+            host <span className="font-mono">{liveHostPort}</span>
+            <span className="mx-1 text-muted-foreground">·</span>
+            map <span className="font-mono">{liveHostPort}:{project.appPort}</span>
+          </p>
+        </CardContent>
+      )}
+    </Card>
+  );
+}

--- a/dashboard/src/lib/deployment-display.ts
+++ b/dashboard/src/lib/deployment-display.ts
@@ -6,6 +6,23 @@ export function isDeploymentColor(c: string): c is DeploymentColor {
   return c === "BLUE" || c === "GREEN";
 }
 
+/** Most recent deployment row for a color (by `createdAt`). */
+export function latestDeploymentForColor(
+  deployments: Deployment[],
+  color: DeploymentColor
+): Deployment | undefined {
+  const rows = deployments.filter((d) => d.color === color);
+  if (rows.length === 0) return undefined;
+  return rows.reduce((a, b) => (new Date(b.createdAt) > new Date(a.createdAt) ? b : a));
+}
+
+/** Full URL to hit the app health check on a host slot (browser / curl). */
+export function healthCheckUrl(project: Project, hostPort: number): string {
+  const base = publicServiceUrl(hostPort).replace(/\/$/, "");
+  const path = project.healthPath.startsWith("/") ? project.healthPath : `/${project.healthPath}`;
+  return `${base}${path}`;
+}
+
 /** Published host port for blue/green (maps to Docker publish). */
 export function hostPortForSlot(project: Project, color: string): number {
   if (color === "GREEN") return project.basePort + 1;

--- a/dashboard/src/pages/Overview.tsx
+++ b/dashboard/src/pages/Overview.tsx
@@ -21,7 +21,13 @@ import { StatCard } from "@/components/StatCard";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { useLaunchCreateProject } from "@/create-project-launch";
-import { getDisplayDeployment, hostPortForSlot, publicServiceUrl } from "@/lib/deployment-display";
+import {
+  getDeployingDeployment,
+  getDisplayDeployment,
+  hostPortForSlot,
+  latestDeploymentForColor,
+  publicServiceUrl,
+} from "@/lib/deployment-display";
 import { DeleteProjectDialog } from "@/components/DeleteProjectDialog";
 import {
   DropdownMenu,
@@ -277,14 +283,19 @@ export function Overview() {
             </div>
             <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
               {projects.map((p) => {
+                const mine = deployments.filter((d) => d.projectId === p.id);
                 const row = getDisplayDeployment(p.id, deployments);
                 const st = projectStatus(p.id, deployments);
                 const job = latestJobs[p.id];
                 const hostPort = row ? hostPortForSlot(p, row.color) : null;
                 const hostUrl = hostPort != null ? publicServiceUrl(hostPort) : null;
-                const lastDeploy = deployments
-                  .filter((d) => d.projectId === p.id)
-                  .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())[0];
+                const active = mine.find((d) => d.status === "ACTIVE");
+                const deploying = getDeployingDeployment(p.id, deployments);
+                const bluePort = p.basePort;
+                const greenPort = p.basePort + 1;
+                const blueLatest = latestDeploymentForColor(mine, "BLUE");
+                const greenLatest = latestDeploymentForColor(mine, "GREEN");
+                const lastDeploy = mine.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())[0];
 
                 return (
                   <Card
@@ -332,21 +343,73 @@ export function Overview() {
                         <span className="font-mono">{p.repoUrl.replace(/^https?:\/\/(www\.)?/, "")}</span>
                       </div>
 
-                      <div className="flex flex-wrap items-center gap-2">
-                        {row && <SlotBadge color={row.color} />}
-                        {hostUrl ? (
-                          <a
-                            href={hostUrl}
-                            target="_blank"
-                            rel="noreferrer"
-                            onClick={(e) => e.stopPropagation()}
-                            className="relative z-20 truncate font-mono text-xs text-primary underline-offset-2 hover:underline"
-                          >
-                            {hostUrl.replace(/^https?:\/\//, "")} (open)
-                          </a>
-                        ) : (
-                          <span className="text-xs text-muted-foreground/50">Not deployed</span>
-                        )}
+                      <div className="space-y-2">
+                        <div className="flex flex-wrap items-center gap-2">
+                          {row && <SlotBadge color={row.color} />}
+                          {hostUrl ? (
+                            <a
+                              href={hostUrl}
+                              target="_blank"
+                              rel="noreferrer"
+                              onClick={(e) => e.stopPropagation()}
+                              className="relative z-20 truncate font-mono text-xs text-primary underline-offset-2 hover:underline"
+                            >
+                              Live {hostUrl.replace(/^https?:\/\//, "")}
+                            </a>
+                          ) : (
+                            <span className="text-xs text-muted-foreground/50">Not deployed</span>
+                          )}
+                        </div>
+                        <div className="grid grid-cols-2 gap-2 text-[10px] leading-tight">
+                          {(["BLUE", "GREEN"] as const).map((c) => {
+                            const port = c === "BLUE" ? bluePort : greenPort;
+                            const u = publicServiceUrl(port);
+                            const isLive = active?.color === c;
+                            const isDeploy = deploying?.color === c;
+                            const latest = c === "BLUE" ? blueLatest : greenLatest;
+                            return (
+                              <div
+                                key={c}
+                                className={`rounded-md border px-2 py-1.5 ${
+                                  c === "BLUE"
+                                    ? "border-sky-500/25 bg-sky-500/[0.06]"
+                                    : "border-emerald-500/25 bg-emerald-500/[0.06]"
+                                }`}
+                              >
+                                <div className="flex items-center justify-between gap-1">
+                                  <span className="font-mono font-semibold text-foreground">{c === "BLUE" ? "Blue" : "Green"}</span>
+                                  {isLive ? (
+                                    <Badge className="h-4 bg-emerald-600/90 px-1 py-0 text-[9px] leading-none text-white hover:bg-emerald-600">
+                                      LIVE
+                                    </Badge>
+                                  ) : isDeploy ? (
+                                    <Badge variant="outline" className="h-4 border-amber-500/40 px-1 py-0 text-[9px] text-amber-200">
+                                      DEPLOY
+                                    </Badge>
+                                  ) : (
+                                    <span className="text-muted-foreground">idle</span>
+                                  )}
+                                </div>
+                                <a
+                                  href={u}
+                                  target="_blank"
+                                  rel="noreferrer"
+                                  onClick={(e) => e.stopPropagation()}
+                                  className="relative z-20 mt-0.5 block truncate font-mono text-muted-foreground hover:text-primary hover:underline"
+                                >
+                                  :{port}
+                                </a>
+                                {latest ? (
+                                  <p className="mt-0.5 truncate text-muted-foreground" title={latest.containerName}>
+                                    v{latest.version} · {latest.status === "ACTIVE" ? "active" : latest.status.toLowerCase()}
+                                  </p>
+                                ) : (
+                                  <p className="mt-0.5 text-muted-foreground/70">—</p>
+                                )}
+                              </div>
+                            );
+                          })}
+                        </div>
                       </div>
 
                       <div className="flex items-center gap-4 border-t border-border/30 pt-3 text-xs text-muted-foreground">

--- a/dashboard/src/pages/ProjectDetail.tsx
+++ b/dashboard/src/pages/ProjectDetail.tsx
@@ -21,7 +21,8 @@ import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
 import { toast } from "sonner";
 import { Separator } from "@/components/ui/separator";
-import { hostPortForSlot, publicServiceUrl } from "@/lib/deployment-display";
+import { BlueGreenTrafficCard } from "@/components/BlueGreenTrafficCard";
+import { getDeployingDeployment, hostPortForSlot, publicServiceUrl } from "@/lib/deployment-display";
 
 function copyText(text: string, label: string) {
   void navigator.clipboard.writeText(text).then(
@@ -107,7 +108,7 @@ export function ProjectDetail() {
   }
 
   const active = deployments.find((d) => d.status === "ACTIVE");
-  const deploying = deployments.find((d) => d.status === "DEPLOYING");
+  const deploying = id ? getDeployingDeployment(id, deployments) : undefined;
   const displayStatus = deploying
     ? "DEPLOYING"
     : active
@@ -120,8 +121,6 @@ export function ProjectDetail() {
 
   const liveHostPort = active ? hostPortForSlot(project, active.color) : null;
   const liveUrl = liveHostPort != null ? publicServiceUrl(liveHostPort) : null;
-  const blueUrl = publicServiceUrl(project.basePort);
-  const greenUrl = publicServiceUrl(project.basePort + 1);
   const totalDeploys = deployments.length;
   const lastDeploy = deployments[0];
 
@@ -247,62 +246,15 @@ export function ProjectDetail() {
         </div>
       ) : null}
 
-      <Card className="border-border/50 bg-card/60 ring-1 ring-border/25">
-        <CardHeader>
-          <CardTitle>Traffic slots</CardTitle>
-          <CardDescription>
-            Blue uses host port <span className="font-mono">{project.basePort}</span>, green uses{" "}
-            <span className="font-mono">{project.basePort + 1}</span>. Public traffic follows whichever deployment is{" "}
-            <span className="font-medium text-foreground">ACTIVE</span>.
-          </CardDescription>
-        </CardHeader>
-        <CardContent className="grid gap-4 sm:grid-cols-2">
-          <div className="rounded-xl border border-sky-500/25 bg-sky-500/5 p-4">
-            <div className="mb-3 flex items-center justify-between gap-2">
-              <SlotBadge color="BLUE" />
-              {active?.color === "BLUE" && <Badge className="bg-emerald-600/90 text-white hover:bg-emerald-600">LIVE</Badge>}
-            </div>
-            <p className="font-mono text-sm text-foreground">{blueUrl?.replace(/^https?:\/\//, "")}</p>
-            <div className="mt-3 flex flex-wrap gap-2">
-              <Button type="button" variant="outline" size="sm" className="h-7 text-xs" onClick={() => blueUrl && copyText(blueUrl, "URL")}>
-                Copy URL
-              </Button>
-              {blueUrl && (
-                <a href={blueUrl} target="_blank" rel="noreferrer" className={buttonVariants({ variant: "secondary", size: "sm", className: "h-7 text-xs" })}>
-                  Open
-                </a>
-              )}
-            </div>
-          </div>
-          <div className="rounded-xl border border-emerald-500/25 bg-emerald-500/5 p-4">
-            <div className="mb-3 flex items-center justify-between gap-2">
-              <SlotBadge color="GREEN" />
-              {active?.color === "GREEN" && <Badge className="bg-emerald-600/90 text-white hover:bg-emerald-600">LIVE</Badge>}
-            </div>
-            <p className="font-mono text-sm text-foreground">{greenUrl?.replace(/^https?:\/\//, "")}</p>
-            <div className="mt-3 flex flex-wrap gap-2">
-              <Button type="button" variant="outline" size="sm" className="h-7 text-xs" onClick={() => greenUrl && copyText(greenUrl, "URL")}>
-                Copy URL
-              </Button>
-              {greenUrl && (
-                <a href={greenUrl} target="_blank" rel="noreferrer" className={buttonVariants({ variant: "secondary", size: "sm", className: "h-7 text-xs" })}>
-                  Open
-                </a>
-              )}
-            </div>
-          </div>
-        </CardContent>
-        {liveUrl && active && (
-          <CardContent className="border-t border-border/40 pt-4">
-            <p className="text-sm text-muted-foreground">
-              Current traffic: <SlotBadge color={active.color} /> pointing to{" "}
-              <span className="font-mono text-foreground">{liveUrl}</span> (host port{" "}
-              <span className="font-mono">{liveHostPort}</span> mapped to container port{" "}
-              <span className="font-mono">{project.appPort}</span>).
-            </p>
-          </CardContent>
-        )}
-      </Card>
+      <BlueGreenTrafficCard
+        project={project}
+        deployments={deployments}
+        active={active}
+        deploying={deploying}
+        liveHostPort={liveHostPort}
+        liveUrl={liveUrl}
+        onCopy={copyText}
+      />
 
       <Card className="border-border/50 bg-card/60 ring-1 ring-border/25">
         <CardHeader>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Improves how blue/green deployment slots are explained and inspected in the dashboard.

**Project detail**
- New `BlueGreenTrafficCard` replaces the old “Traffic slots” card with a short traffic-flow strip (Clients → Nginx → live host port → container app port), slot cards that show **Receiving traffic** vs **Deploy in progress** vs **Idle**, Docker port map, last deployment on that slot (version/status), container name, image tag, and actions to copy app URL, copy health-check URL, open app, and open health.

**Overview**
- Each project card shows a compact **two-column** blue/green summary: LIVE / DEPLOY / idle, clickable host port, and latest version + status per slot.

**Shared helpers**
- `latestDeploymentForColor` and `healthCheckUrl` in `deployment-display.ts` for consistent slot metadata and health links.

**Testing:** `cd dashboard && bun run build` (tsc + vite) passes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cf513870-1565-4099-a046-4aa0a595d5ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cf513870-1565-4099-a046-4aa0a595d5ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

