### PR TITLE
feat: first admin in setup, live DATABASE_URL, bootstrap paths

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,20 @@ GIT_TOKEN=""
 # ── Security ───────────────────────────────────────────────────────────────────
 # 32-byte hex string used to encrypt stored project env vars at rest
 ENCRYPTION_KEY=""
+# Enables GET/POST /api/v1/system/update/* and webhook (use a long random value)
+# SELF_UPDATE_SECRET=""
+# Branch to track for git pull (default main)
+# SELF_UPDATE_GIT_BRANCH=main
+# Poll interval in ms (0 = off). When set, logs when origin is ahead; with AUTO_APPLY, upgrades in-process.
+# SELF_UPDATE_POLL_MS=0
+# SELF_UPDATE_AUTO_APPLY=false
+
+# ── Self-update (ops) ───────────────────────────────────────────────────────────
+# After setting SELF_UPDATE_SECRET:
+#   curl -sS -H "Authorization: Bearer $SELF_UPDATE_SECRET" http://127.0.0.1:9090/api/v1/system/update/status
+#   curl -sS -X POST -H "Authorization: Bearer $SELF_UPDATE_SECRET" http://127.0.0.1:9090/api/v1/system/update/apply
+# Or CI: POST .../system/update/webhook?token=$SELF_UPDATE_SECRET
+# Or CLI from repo root: bun run self-update
 
 # ── Validation ─────────────────────────────────────────────────────────────────
 # Max time (ms) to wait for a health check response

--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,8 @@ DATABASE_URL="postgresql://postgres:password@localhost:5432/versiongate"
 PORT=3000
 NODE_ENV=development
 LOG_LEVEL=info
+# Set true when the dashboard is only served over HTTPS (session cookie Secure flag)
+# COOKIE_SECURE=false
 
 # ── Docker ─────────────────────────────────────────────────────────────────────
 DOCKER_NETWORK="versiongate-net"

--- a/.env.example
+++ b/.env.example
@@ -30,7 +30,8 @@ ENCRYPTION_KEY=""
 # SELF_UPDATE_AUTO_APPLY=false
 
 # ── Self-update (ops) ───────────────────────────────────────────────────────────
-# After setting SELF_UPDATE_SECRET:
+# Prefer Settings → “Application updates” in the dashboard to generate SELF_UPDATE_SECRET and run check/apply.
+# With SELF_UPDATE_SECRET set:
 #   curl -sS -H "Authorization: Bearer $SELF_UPDATE_SECRET" http://127.0.0.1:9090/api/v1/system/update/status
 #   curl -sS -X POST -H "Authorization: Bearer $SELF_UPDATE_SECRET" http://127.0.0.1:9090/api/v1/system/update/apply
 # Or CI: POST .../system/update/webhook?token=$SELF_UPDATE_SECRET

--- a/dashboard/src/components/Layout.tsx
+++ b/dashboard/src/components/Layout.tsx
@@ -40,6 +40,7 @@ export function Layout() {
   const [setupGate, setSetupGate] = useState<"loading" | "ready">("loading");
   const [createProjectOpen, setCreateProjectOpen] = useState(false);
   const [projects, setProjects] = useState<Project[]>([]);
+  const [headerUserEmail, setHeaderUserEmail] = useState<string | null>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -73,7 +74,9 @@ export function Layout() {
         }
         if (!s.authenticated) {
           navigate("/login", { replace: true });
+          return;
         }
+        if (s.user?.email) setHeaderUserEmail(s.user.email);
       })
       .catch(() => {
         if (!cancelled) navigate("/login", { replace: true });
@@ -209,6 +212,14 @@ export function Layout() {
                 </div>
               </div>
               <div className="flex items-center gap-2">
+                {headerUserEmail ? (
+                  <span
+                    className="hidden max-w-[200px] truncate text-xs text-muted-foreground sm:inline"
+                    title={headerUserEmail}
+                  >
+                    {headerUserEmail}
+                  </span>
+                ) : null}
                 <button
                   type="button"
                   onClick={() => {

--- a/dashboard/src/components/Layout.tsx
+++ b/dashboard/src/components/Layout.tsx
@@ -17,7 +17,7 @@ import { Separator } from "@/components/ui/separator";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { Toaster } from "@/components/ui/sonner";
 import { useEffect, useState } from "react";
-import { getProjects, getServerStats, getSetupStatus, type Project } from "@/lib/api";
+import { authLogout, getAuthStatus, getProjects, getServerStats, getSetupStatus, type Project } from "@/lib/api";
 import { cn } from "@/lib/utils";
 import { CreateProjectModal } from "@/components/CreateProjectModal";
 import { CreateProjectLaunchContext } from "@/create-project-launch";
@@ -59,6 +59,29 @@ export function Layout() {
       cancelled = true;
     };
   }, [navigate]);
+
+  useEffect(() => {
+    if (setupGate !== "ready") return;
+    let cancelled = false;
+    void getAuthStatus()
+      .then((s) => {
+        if (cancelled) return;
+        if (!s.databaseReady) return;
+        if (!s.hasUsers) {
+          navigate("/login", { replace: true, state: { register: true } });
+          return;
+        }
+        if (!s.authenticated) {
+          navigate("/login", { replace: true });
+        }
+      })
+      .catch(() => {
+        if (!cancelled) navigate("/login", { replace: true });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [setupGate, navigate]);
 
   useEffect(() => {
     let cancelled = false;
@@ -185,14 +208,27 @@ export function Layout() {
                   <span className="hidden text-xs sm:inline">{serverOk ? "Connected" : "Disconnected"}</span>
                 </div>
               </div>
-              <button
-                type="button"
-                onClick={() => setCreateProjectOpen(true)}
-                className="inline-flex h-8 items-center gap-2 rounded-lg border border-primary/30 bg-primary/10 px-3 text-xs font-medium text-primary transition-colors hover:bg-primary/20"
-              >
-                <span className="hidden sm:inline">New project</span>
-                <span className="sm:hidden">Add</span>
-              </button>
+              <div className="flex items-center gap-2">
+                <button
+                  type="button"
+                  onClick={() => {
+                    void authLogout()
+                      .then(() => navigate("/login", { replace: true }))
+                      .catch(() => navigate("/login", { replace: true }));
+                  }}
+                  className="hidden h-8 items-center rounded-lg border border-border/60 bg-transparent px-3 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted/50 sm:inline-flex"
+                >
+                  Sign out
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setCreateProjectOpen(true)}
+                  className="inline-flex h-8 items-center gap-2 rounded-lg border border-primary/30 bg-primary/10 px-3 text-xs font-medium text-primary transition-colors hover:bg-primary/20"
+                >
+                  <span className="hidden sm:inline">New project</span>
+                  <span className="sm:hidden">Add</span>
+                </button>
+              </div>
             </header>
             <div className="flex w-full min-w-0 flex-1 flex-col gap-4 px-4 py-4 md:px-6 md:py-6 lg:px-8">
               {setupGate === "loading" ? (

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -312,6 +312,8 @@ export function patchInstanceEnv(env: Record<string, string>): Promise<{
 export function applySetup(body: {
   domain: string;
   databaseUrl: string;
+  adminEmail: string;
+  adminPassword: string;
   geminiApiKey?: string;
 }): Promise<{ configured: boolean }> {
   return request("POST", "/setup/apply", body);

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -225,6 +225,43 @@ export interface InstanceSettings {
   needsRestart: boolean;
   encryptionKeyConfigured: boolean;
   geminiConfigured: boolean;
+  selfUpdateConfigured: boolean;
+  selfUpdateGitBranch: string;
+  selfUpdatePollMs: number;
+  selfUpdateAutoApply: boolean;
+}
+
+export interface SelfUpdateGitStatus {
+  branch: string;
+  isGitRepo: boolean;
+  currentCommit: string;
+  remoteCommit: string | null;
+  behind: boolean;
+  message?: string;
+}
+
+export interface SelfUpdateSettingsResponse {
+  configured: boolean;
+  branch: string;
+  pollMs: number;
+  autoApply: boolean;
+  git: SelfUpdateGitStatus | null;
+}
+
+export function getSelfUpdateSettings(): Promise<SelfUpdateSettingsResponse> {
+  return request("GET", "/settings/self-update");
+}
+
+export function enableSelfUpdateFromSettings(): Promise<{ message: string }> {
+  return request("POST", "/settings/self-update/enable");
+}
+
+export function checkSelfUpdateFromSettings(): Promise<SelfUpdateGitStatus> {
+  return request("POST", "/settings/self-update/check");
+}
+
+export function applySelfUpdateFromSettings(): Promise<{ ok: boolean; steps: string[]; error?: string }> {
+  return request("POST", "/settings/self-update/apply");
 }
 
 export function getInstanceSettings(): Promise<InstanceSettings> {

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -29,10 +29,17 @@ async function request<T>(method: string, path: string, body?: unknown): Promise
     headers: body !== undefined ? { "Content-Type": "application/json" } : undefined,
     body: body !== undefined ? JSON.stringify(body) : undefined,
     cache: "no-store",
+    credentials: "include",
   });
 
   if (!res.ok) {
     const data = await parseJsonSafe(res);
+    if (res.status === 401 && typeof window !== "undefined") {
+      const p = window.location.pathname;
+      if (!p.startsWith("/login") && !p.startsWith("/setup")) {
+        window.location.assign("/login");
+      }
+    }
     const msg =
       typeof data === "object" && data !== null && "message" in data
         ? String((data as { message?: unknown }).message)
@@ -209,6 +216,33 @@ export interface SetupStatus {
 
 export function getSetupStatus(): Promise<SetupStatus> {
   return request("GET", "/setup/status");
+}
+
+export interface AuthStatus {
+  databaseReady: boolean;
+  hasUsers: boolean;
+  authenticated: boolean;
+  user?: { id: string; email: string };
+}
+
+export function getAuthStatus(): Promise<AuthStatus> {
+  return request("GET", "/auth/status");
+}
+
+export function getAuthMe(): Promise<{ authenticated: boolean; user?: { id: string; email: string } }> {
+  return request("GET", "/auth/me");
+}
+
+export function authRegister(body: { email: string; password: string }): Promise<{ user: { id: string; email: string } }> {
+  return request("POST", "/auth/register", body);
+}
+
+export function authLogin(body: { email: string; password: string }): Promise<{ user: { id: string; email: string } }> {
+  return request("POST", "/auth/login", body);
+}
+
+export function authLogout(): Promise<{ ok: boolean }> {
+  return request("POST", "/auth/logout");
 }
 
 export interface InstanceSettings {

--- a/dashboard/src/main.tsx
+++ b/dashboard/src/main.tsx
@@ -11,12 +11,14 @@ import { Projects } from "@/pages/Projects";
 import { Settings } from "@/pages/Settings";
 import { Setup } from "@/pages/Setup";
 import { Activity } from "@/pages/Activity";
+import { Login } from "@/pages/Login";
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <BrowserRouter>
       <Routes>
         <Route path="/setup" element={<Setup />} />
+        <Route path="/login" element={<Login />} />
         <Route element={<Layout />}>
           <Route path="/" element={<Overview />} />
           <Route path="/projects" element={<Projects />} />

--- a/dashboard/src/pages/Login.tsx
+++ b/dashboard/src/pages/Login.tsx
@@ -1,5 +1,5 @@
 import { type FormEvent, useEffect, useState } from "react";
-import { Link, useLocation, useNavigate } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import { authLogin, authRegister, getAuthStatus } from "@/lib/api";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
@@ -10,10 +10,9 @@ import { Toaster } from "@/components/ui/sonner";
 export function Login() {
   const navigate = useNavigate();
   const location = useLocation();
-  const stateRegister = Boolean((location.state as { register?: boolean } | null)?.register);
-
   const [loading, setLoading] = useState(true);
-  const [registerMode, setRegisterMode] = useState(stateRegister);
+  /** When true, DB is up but User count is 0 — only registration is allowed. */
+  const [bootstrapPending, setBootstrapPending] = useState(false);
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [submitting, setSubmitting] = useState(false);
@@ -31,7 +30,7 @@ export function Login() {
           navigate("/setup", { replace: true });
           return;
         }
-        setRegisterMode(!s.hasUsers);
+        setBootstrapPending(!s.hasUsers);
         setLoading(false);
       })
       .catch(() => {
@@ -49,7 +48,7 @@ export function Login() {
     e.preventDefault();
     setSubmitting(true);
     try {
-      if (registerMode) {
+      if (bootstrapPending) {
         await authRegister({ email: email.trim().toLowerCase(), password });
         toast.success("Admin account created");
       } else {
@@ -73,23 +72,24 @@ export function Login() {
     );
   }
 
+  const title = bootstrapPending ? "Create first administrator" : "Sign in";
+  const subtitle = bootstrapPending
+    ? "Your database is configured but there are no dashboard users yet (for example after a fresh install or restore). Set the first account here, or run bun run create-admin on the server."
+    : "Sign in to manage projects and deployments.";
+
   return (
     <div className="relative min-h-svh overflow-hidden bg-background">
       <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(ellipse_80%_50%_at_50%_-20%,oklch(0.35_0.12_195/0.25),transparent)]" />
       <div className="relative mx-auto flex min-h-svh max-w-lg flex-col justify-center px-4 py-12">
         <div className="mb-8 space-y-2 text-center">
           <p className="text-xs font-semibold uppercase tracking-[0.25em] text-primary">VersionGate</p>
-          <h1 className="text-3xl font-semibold tracking-tight">{registerMode ? "Create admin" : "Sign in"}</h1>
-          <p className="text-sm text-muted-foreground">
-            {registerMode
-              ? "Choose the email and password for the first administrator. This account owns the control plane."
-              : "Sign in to manage projects and deployments."}
-          </p>
+          <h1 className="text-3xl font-semibold tracking-tight">{title}</h1>
+          <p className="text-sm text-muted-foreground">{subtitle}</p>
         </div>
 
         <Card className="border-border/50 bg-card/80 shadow-xl ring-1 ring-border/40 backdrop-blur-sm">
           <CardHeader>
-            <CardTitle>{registerMode ? "Admin registration" : "Credentials"}</CardTitle>
+            <CardTitle>{bootstrapPending ? "Bootstrap (one-time)" : "Credentials"}</CardTitle>
             <CardDescription>
               Password must be at least 10 characters. Session lasts 7 days on this device.
             </CardDescription>
@@ -116,7 +116,7 @@ export function Login() {
                 <Input
                   id="vg-login-password"
                   type="password"
-                  autoComplete={registerMode ? "new-password" : "current-password"}
+                  autoComplete={bootstrapPending ? "new-password" : "current-password"}
                   value={password}
                   onChange={(e) => setPassword(e.target.value)}
                   required
@@ -124,9 +124,9 @@ export function Login() {
                 />
               </div>
               <Button type="submit" className="w-full" disabled={submitting}>
-                {submitting ? "Please wait…" : registerMode ? "Create account" : "Sign in"}
+                {submitting ? "Please wait…" : bootstrapPending ? "Create account" : "Sign in"}
               </Button>
-              {!registerMode ? (
+              {!bootstrapPending ? (
                 <p className="text-center text-xs text-muted-foreground">
                   <Link to="/setup" className="text-primary underline-offset-2 hover:underline">
                     Setup wizard

--- a/dashboard/src/pages/Login.tsx
+++ b/dashboard/src/pages/Login.tsx
@@ -9,7 +9,6 @@ import { Toaster } from "@/components/ui/sonner";
 
 export function Login() {
   const navigate = useNavigate();
-  const location = useLocation();
   const [loading, setLoading] = useState(true);
   /** When true, DB is up but User count is 0 — only registration is allowed. */
   const [bootstrapPending, setBootstrapPending] = useState(false);

--- a/dashboard/src/pages/Login.tsx
+++ b/dashboard/src/pages/Login.tsx
@@ -1,0 +1,143 @@
+import { type FormEvent, useEffect, useState } from "react";
+import { Link, useLocation, useNavigate } from "react-router-dom";
+import { authLogin, authRegister, getAuthStatus } from "@/lib/api";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { toast } from "sonner";
+import { Toaster } from "@/components/ui/sonner";
+
+export function Login() {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const stateRegister = Boolean((location.state as { register?: boolean } | null)?.register);
+
+  const [loading, setLoading] = useState(true);
+  const [registerMode, setRegisterMode] = useState(stateRegister);
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    void getAuthStatus()
+      .then((s) => {
+        if (cancelled) return;
+        if (s.authenticated) {
+          navigate("/", { replace: true });
+          return;
+        }
+        if (!s.databaseReady) {
+          navigate("/setup", { replace: true });
+          return;
+        }
+        setRegisterMode(!s.hasUsers);
+        setLoading(false);
+      })
+      .catch(() => {
+        if (!cancelled) {
+          toast.error("Could not reach the API");
+          setLoading(false);
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [navigate]);
+
+  const onSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    setSubmitting(true);
+    try {
+      if (registerMode) {
+        await authRegister({ email: email.trim().toLowerCase(), password });
+        toast.success("Admin account created");
+      } else {
+        await authLogin({ email: email.trim().toLowerCase(), password });
+        toast.success("Signed in");
+      }
+      navigate("/", { replace: true });
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Request failed");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="flex min-h-svh items-center justify-center bg-background text-muted-foreground">
+        Loading…
+        <Toaster position="top-center" richColors theme="dark" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="relative min-h-svh overflow-hidden bg-background">
+      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(ellipse_80%_50%_at_50%_-20%,oklch(0.35_0.12_195/0.25),transparent)]" />
+      <div className="relative mx-auto flex min-h-svh max-w-lg flex-col justify-center px-4 py-12">
+        <div className="mb-8 space-y-2 text-center">
+          <p className="text-xs font-semibold uppercase tracking-[0.25em] text-primary">VersionGate</p>
+          <h1 className="text-3xl font-semibold tracking-tight">{registerMode ? "Create admin" : "Sign in"}</h1>
+          <p className="text-sm text-muted-foreground">
+            {registerMode
+              ? "Choose the email and password for the first administrator. This account owns the control plane."
+              : "Sign in to manage projects and deployments."}
+          </p>
+        </div>
+
+        <Card className="border-border/50 bg-card/80 shadow-xl ring-1 ring-border/40 backdrop-blur-sm">
+          <CardHeader>
+            <CardTitle>{registerMode ? "Admin registration" : "Credentials"}</CardTitle>
+            <CardDescription>
+              Password must be at least 10 characters. Session lasts 7 days on this device.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <form onSubmit={(e) => void onSubmit(e)} className="space-y-4">
+              <div className="space-y-2">
+                <label htmlFor="vg-login-email" className="text-sm font-medium">
+                  Email
+                </label>
+                <Input
+                  id="vg-login-email"
+                  type="email"
+                  autoComplete="email"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  required
+                />
+              </div>
+              <div className="space-y-2">
+                <label htmlFor="vg-login-password" className="text-sm font-medium">
+                  Password
+                </label>
+                <Input
+                  id="vg-login-password"
+                  type="password"
+                  autoComplete={registerMode ? "new-password" : "current-password"}
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                  required
+                  minLength={10}
+                />
+              </div>
+              <Button type="submit" className="w-full" disabled={submitting}>
+                {submitting ? "Please wait…" : registerMode ? "Create account" : "Sign in"}
+              </Button>
+              {!registerMode ? (
+                <p className="text-center text-xs text-muted-foreground">
+                  <Link to="/setup" className="text-primary underline-offset-2 hover:underline">
+                    Setup wizard
+                  </Link>
+                </p>
+              ) : null}
+            </form>
+          </CardContent>
+        </Card>
+      </div>
+      <Toaster position="top-center" richColors theme="dark" />
+    </div>
+  );
+}

--- a/dashboard/src/pages/Settings.tsx
+++ b/dashboard/src/pages/Settings.tsx
@@ -6,7 +6,18 @@ import { Badge } from "@/components/ui/badge";
 import { Separator } from "@/components/ui/separator";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { getInstanceSettings, getSetupStatus, patchInstanceEnv, type InstanceSettings, type SetupStatus } from "@/lib/api";
+import {
+  applySelfUpdateFromSettings,
+  checkSelfUpdateFromSettings,
+  enableSelfUpdateFromSettings,
+  getInstanceSettings,
+  getSelfUpdateSettings,
+  getSetupStatus,
+  patchInstanceEnv,
+  type InstanceSettings,
+  type SelfUpdateSettingsResponse,
+  type SetupStatus,
+} from "@/lib/api";
 import { toast } from "sonner";
 import { cn } from "@/lib/utils";
 import { DonutChart } from "@/components/charts/DonutChart";
@@ -40,16 +51,25 @@ export function Settings() {
   const [loading, setLoading] = useState(true);
   const [envDraft, setEnvDraft] = useState<Record<string, string>>({});
   const [envSaving, setEnvSaving] = useState(false);
+  const [selfUpdate, setSelfUpdate] = useState<SelfUpdateSettingsResponse | null>(null);
+  const [suOpts, setSuOpts] = useState({ branch: "", pollMs: "", autoApply: "false" });
+  const [suBusy, setSuBusy] = useState<"enable" | "check" | "apply" | "saveOpts" | null>(null);
 
   useEffect(() => {
     let cancelled = false;
     void (async () => {
       setLoading(true);
       try {
-        const [i, s] = await Promise.all([getInstanceSettings(), getSetupStatus()]);
+        const [i, s, su] = await Promise.all([getInstanceSettings(), getSetupStatus(), getSelfUpdateSettings()]);
         if (!cancelled) {
           setInstance(i);
           setSetup(s);
+          setSelfUpdate(su);
+          setSuOpts({
+            branch: su.branch,
+            pollMs: su.pollMs > 0 ? String(su.pollMs) : "",
+            autoApply: su.autoApply ? "true" : "false",
+          });
         }
       } catch (e) {
         toast.error(e instanceof Error ? e.message : "Failed to load settings");
@@ -83,6 +103,88 @@ export function Settings() {
     setEnvDraft((d) => ({ ...d, [key]: value }));
   };
 
+  const refreshSelfUpdate = async () => {
+    const su = await getSelfUpdateSettings();
+    setSelfUpdate(su);
+    setSuOpts({
+      branch: su.branch,
+      pollMs: su.pollMs > 0 ? String(su.pollMs) : "",
+      autoApply: su.autoApply ? "true" : "false",
+    });
+    const i = await getInstanceSettings();
+    setInstance(i);
+  };
+
+  const onEnableSelfUpdate = async () => {
+    setSuBusy("enable");
+    try {
+      const r = await enableSelfUpdateFromSettings();
+      toast.success(r.message);
+      await refreshSelfUpdate();
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Failed to enable");
+    } finally {
+      setSuBusy(null);
+    }
+  };
+
+  const onCheckSelfUpdate = async () => {
+    setSuBusy("check");
+    try {
+      const g = await checkSelfUpdateFromSettings();
+      setSelfUpdate((prev) => (prev ? { ...prev, git: g } : prev));
+      if (g.message) toast.warning(g.message);
+      else if (g.behind) toast.info("A newer revision is available on the remote.");
+      else toast.success("Already up to date.");
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Check failed");
+    } finally {
+      setSuBusy(null);
+    }
+  };
+
+  const onApplySelfUpdate = async () => {
+    if (!window.confirm("Pull latest code, rebuild the dashboard, and reload PM2? The UI may disconnect briefly.")) {
+      return;
+    }
+    setSuBusy("apply");
+    try {
+      const r = await applySelfUpdateFromSettings();
+      if (r.ok) {
+        toast.success("Update applied — PM2 reload scheduled. Refresh this page in a few seconds.");
+        await refreshSelfUpdate();
+      }
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Update failed");
+    } finally {
+      setSuBusy(null);
+    }
+  };
+
+  const onSaveSelfUpdateOpts = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const env: Record<string, string> = {};
+    const b = suOpts.branch.trim();
+    const p = suOpts.pollMs.trim();
+    if (b) env.SELF_UPDATE_GIT_BRANCH = b;
+    if (p !== "") env.SELF_UPDATE_POLL_MS = p;
+    env.SELF_UPDATE_AUTO_APPLY = suOpts.autoApply;
+    if (Object.keys(env).length === 0) {
+      toast.error("Set at least one option.");
+      return;
+    }
+    setSuBusy("saveOpts");
+    try {
+      const r = await patchInstanceEnv(env);
+      toast.success(r.message);
+      await refreshSelfUpdate();
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Save failed");
+    } finally {
+      setSuBusy(null);
+    }
+  };
+
   const onSaveEnv = async (e: React.FormEvent) => {
     e.preventDefault();
     const env: Record<string, string> = {};
@@ -109,7 +211,7 @@ export function Settings() {
     }
   };
 
-  if (loading || !instance || !setup) {
+  if (loading || !instance || !setup || !selfUpdate) {
     return (
       <div className="w-full max-w-4xl space-y-8">
         <Skeleton className="h-10 w-64" />
@@ -161,6 +263,142 @@ export function Settings() {
           </CardContent>
         </Card>
       </div>
+
+      <Card className="border-border/50 bg-card/60 ring-1 ring-border/30">
+        <CardHeader>
+          <CardTitle>Application updates</CardTitle>
+          <CardDescription>
+            Pull new VersionGate commits from git, install dependencies, run migrations, rebuild the dashboard, and reload PM2.
+            No GitHub OAuth — this only updates <span className="font-medium text-foreground">this</span> server&apos;s clone. A random
+            webhook token is created when you enable self-update (stored in <code className="rounded bg-muted px-1 font-mono text-xs">.env</code>,
+            never shown again). Anyone who can open Settings can trigger an update — protect the dashboard network.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          <div className="flex flex-wrap items-center gap-2">
+            <Badge variant={selfUpdate.configured ? "default" : "secondary"} className="font-mono text-xs">
+              {selfUpdate.configured ? "Self-update enabled" : "Not enabled"}
+            </Badge>
+            {!selfUpdate.configured ? (
+              <Button type="button" size="sm" disabled={suBusy !== null} onClick={() => void onEnableSelfUpdate()}>
+                {suBusy === "enable" ? "Enabling…" : "Enable in-dashboard updates"}
+              </Button>
+            ) : null}
+          </div>
+
+          {selfUpdate.configured ? (
+            <>
+              <dl className="space-y-3">
+                <Row label="Tracked branch" value={selfUpdate.branch} />
+                <Row label="Poll interval (ms)" value={selfUpdate.pollMs > 0 ? String(selfUpdate.pollMs) : "off"} />
+                <Row label="Auto-apply on poll" value={boolBadge(selfUpdate.autoApply, "Yes", "No")} />
+              </dl>
+              {selfUpdate.git ? (
+                <div className="rounded-lg border border-border/60 bg-muted/20 px-3 py-2 text-sm">
+                  <p className="font-mono text-xs text-muted-foreground">
+                    Local{" "}
+                    <span className="text-foreground">
+                      {selfUpdate.git.currentCommit ? selfUpdate.git.currentCommit.slice(0, 7) : "—"}
+                    </span>
+                    {selfUpdate.git.remoteCommit ? (
+                      <>
+                        {" "}
+                        · remote <span className="text-foreground">{selfUpdate.git.remoteCommit.slice(0, 7)}</span>
+                      </>
+                    ) : null}
+                  </p>
+                  {selfUpdate.git.message ? (
+                    <p className="mt-1 text-amber-600 dark:text-amber-400">{selfUpdate.git.message}</p>
+                  ) : selfUpdate.git.behind ? (
+                    <p className="mt-1 text-foreground">Remote is ahead — you can update.</p>
+                  ) : selfUpdate.git.isGitRepo ? (
+                    <p className="mt-1 text-muted-foreground">Up to date with origin.</p>
+                  ) : (
+                    <p className="mt-1 text-muted-foreground">Not a git checkout — use your image or package pipeline.</p>
+                  )}
+                </div>
+              ) : (
+                <p className="text-sm text-muted-foreground">Run “Check for updates” to compare with origin.</p>
+              )}
+
+              <div className="flex flex-wrap gap-2">
+                <Button type="button" variant="outline" size="sm" disabled={suBusy !== null} onClick={() => void onCheckSelfUpdate()}>
+                  {suBusy === "check" ? "Checking…" : "Check for updates"}
+                </Button>
+                <Button
+                  type="button"
+                  size="sm"
+                  disabled={
+                    suBusy !== null || !selfUpdate.git?.isGitRepo || !selfUpdate.git.behind || Boolean(selfUpdate.git.message)
+                  }
+                  onClick={() => void onApplySelfUpdate()}
+                >
+                  {suBusy === "apply" ? "Updating…" : "Update and restart PM2"}
+                </Button>
+              </div>
+
+              <Separator className="bg-border/50" />
+
+              <form onSubmit={(e) => void onSaveSelfUpdateOpts(e)} className="space-y-4">
+                <p className="text-sm text-muted-foreground">
+                  Options are written to <code className="rounded bg-muted px-1 font-mono text-xs">.env</code>. Polling uses the
+                  secret you generated; increase the interval to reduce git fetch noise.
+                </p>
+                <div className="grid gap-4 sm:grid-cols-3">
+                  <div className="space-y-2">
+                    <label className="text-xs font-medium text-muted-foreground" htmlFor="su-branch">
+                      SELF_UPDATE_GIT_BRANCH
+                    </label>
+                    <Input
+                      id="su-branch"
+                      value={suOpts.branch}
+                      onChange={(e) => setSuOpts((o) => ({ ...o, branch: e.target.value }))}
+                      placeholder="main"
+                      autoComplete="off"
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <label className="text-xs font-medium text-muted-foreground" htmlFor="su-poll">
+                      SELF_UPDATE_POLL_MS
+                    </label>
+                    <Input
+                      id="su-poll"
+                      value={suOpts.pollMs}
+                      onChange={(e) => setSuOpts((o) => ({ ...o, pollMs: e.target.value }))}
+                      placeholder="0 = off"
+                      inputMode="numeric"
+                      autoComplete="off"
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <label className="text-xs font-medium text-muted-foreground" htmlFor="su-auto">
+                      SELF_UPDATE_AUTO_APPLY
+                    </label>
+                    <select
+                      id="su-auto"
+                      value={suOpts.autoApply}
+                      onChange={(e) => setSuOpts((o) => ({ ...o, autoApply: e.target.value }))}
+                      className="h-8 w-full rounded-lg border border-input bg-transparent px-2.5 text-sm outline-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 dark:bg-input/30"
+                    >
+                      <option value="false">false</option>
+                      <option value="true">true</option>
+                    </select>
+                  </div>
+                </div>
+                <Button type="submit" size="sm" variant="secondary" disabled={suBusy !== null}>
+                  {suBusy === "saveOpts" ? "Saving…" : "Save self-update options"}
+                </Button>
+              </form>
+            </>
+          ) : (
+            <p className="text-sm text-muted-foreground">
+              Enable to generate <code className="rounded bg-muted px-1 font-mono text-xs">SELF_UPDATE_SECRET</code> and unlock
+              check/apply actions. You can still use <code className="rounded bg-muted px-1 font-mono text-xs">bun run self-update</code>{" "}
+              from SSH without this.
+            </p>
+          )}
+        </CardContent>
+      </Card>
 
       <Card className="border-border/50 bg-card/60 ring-1 ring-border/30">
         <CardHeader>

--- a/dashboard/src/pages/Settings.tsx
+++ b/dashboard/src/pages/Settings.tsx
@@ -225,7 +225,7 @@ export function Settings() {
     <div className="w-full max-w-4xl space-y-10">
       <PageHeader
         title="Settings"
-        description="Instance diagnostics, optional updates to the server .env file, and how secrets are handled. Secret values are never read back from the API."
+        description="Instance diagnostics, optional updates to the server .env file, and how secrets are handled. Secret values are never read back from the API. Sign in is required once an admin account exists."
       />
 
       <div className="grid gap-4 lg:grid-cols-3">

--- a/dashboard/src/pages/Setup.tsx
+++ b/dashboard/src/pages/Setup.tsx
@@ -19,6 +19,8 @@ export function Setup() {
   const [submitting, setSubmitting] = useState(false);
   const [domain, setDomain] = useState(defaultDomain);
   const [databaseUrl, setDatabaseUrl] = useState("");
+  const [adminEmail, setAdminEmail] = useState("");
+  const [adminPassword, setAdminPassword] = useState("");
   const [geminiApiKey, setGeminiApiKey] = useState("");
 
   const refresh = async () => {
@@ -45,7 +47,7 @@ export function Setup() {
 
   useEffect(() => {
     if (ready) {
-      navigate("/login", { replace: true, state: { register: true } });
+      navigate("/", { replace: true });
     }
   }, [ready, navigate]);
 
@@ -56,9 +58,13 @@ export function Setup() {
       await applySetup({
         domain: domain.trim(),
         databaseUrl: databaseUrl.trim(),
+        adminEmail: adminEmail.trim(),
+        adminPassword,
         geminiApiKey: geminiApiKey.trim() || undefined,
       });
-      toast.success("Configuration saved. Restart the API and worker to load the new database URL.");
+      toast.success(
+        "Setup complete — you're signed in. If deploy jobs don't run, restart the worker (e.g. pm2 restart versiongate-worker)."
+      );
       await refresh();
     } catch (err) {
       toast.error(err instanceof Error ? err.message : "Setup failed");
@@ -92,9 +98,10 @@ export function Setup() {
             <CardHeader className="pb-2">
               <CardTitle className="text-base text-amber-200">Restart required</CardTitle>
               <CardDescription className="text-amber-200/80">
-                Configuration was saved, but this process has not loaded{" "}
-                <code className="rounded bg-muted px-1 py-0.5 text-xs text-foreground">DATABASE_URL</code> yet. Restart
-                the API and worker, for example:{" "}
+                <code className="rounded bg-muted px-1 py-0.5 text-xs text-foreground">DATABASE_URL</code> is in{" "}
+                <code className="rounded bg-muted px-1 py-0.5 text-xs text-foreground">.env</code> but this API process
+                has not loaded it yet (unusual). Restart the API; restart the worker too so deploy jobs use the
+                database:{" "}
                 <code className="mt-1 block rounded bg-muted px-2 py-1 text-xs text-foreground">
                   pm2 restart versiongate-api versiongate-worker
                 </code>
@@ -136,6 +143,35 @@ export function Setup() {
                   placeholder="postgresql://user:pass@localhost:5432/versiongate"
                   autoComplete="off"
                   required
+                />
+              </div>
+              <div className="space-y-2">
+                <label htmlFor="vg-admin-email" className="text-sm font-medium">
+                  Admin email
+                </label>
+                <Input
+                  id="vg-admin-email"
+                  type="email"
+                  value={adminEmail}
+                  onChange={(e) => setAdminEmail(e.target.value)}
+                  placeholder="you@example.com"
+                  autoComplete="email"
+                  required
+                />
+              </div>
+              <div className="space-y-2">
+                <label htmlFor="vg-admin-password" className="text-sm font-medium">
+                  Admin password
+                </label>
+                <Input
+                  id="vg-admin-password"
+                  type="password"
+                  value={adminPassword}
+                  onChange={(e) => setAdminPassword(e.target.value)}
+                  placeholder="At least 10 characters"
+                  autoComplete="new-password"
+                  required
+                  minLength={10}
                 />
               </div>
               <div className="space-y-2">

--- a/dashboard/src/pages/Setup.tsx
+++ b/dashboard/src/pages/Setup.tsx
@@ -45,7 +45,7 @@ export function Setup() {
 
   useEffect(() => {
     if (ready) {
-      navigate("/", { replace: true });
+      navigate("/login", { replace: true, state: { register: true } });
     }
   }, [ready, navigate]);
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "prisma:studio": "prisma studio",
     "lint": "eslint src --ext .ts",
     "typecheck": "tsc --noEmit",
-    "preflight": "bun run scripts/preflight.ts"
+    "preflight": "bun run scripts/preflight.ts",
+    "self-update": "bun run scripts/self-update.ts"
   },
   "dependencies": {
     "@fastify/sensible": "^5.5.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "lint": "eslint src --ext .ts",
     "typecheck": "tsc --noEmit",
     "preflight": "bun run scripts/preflight.ts",
-    "self-update": "bun run scripts/self-update.ts"
+    "self-update": "bun run scripts/self-update.ts",
+    "create-admin": "bun scripts/create-admin.ts"
   },
   "dependencies": {
     "@fastify/sensible": "^5.5.0",

--- a/prisma/migrations/20260411120000_add_auth_users_sessions/migration.sql
+++ b/prisma/migrations/20260411120000_add_auth_users_sessions/migration.sql
@@ -1,0 +1,33 @@
+-- CreateTable
+CREATE TABLE "User" (
+    "id" TEXT NOT NULL,
+    "email" TEXT NOT NULL,
+    "passwordHash" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "User_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Session" (
+    "id" TEXT NOT NULL,
+    "tokenHash" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "expiresAt" TIMESTAMP(3) NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Session_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "User_email_key" ON "User"("email");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Session_tokenHash_key" ON "Session"("tokenHash");
+
+-- CreateIndex
+CREATE INDEX "Session_userId_idx" ON "Session"("userId");
+
+-- AddForeignKey
+ALTER TABLE "Session" ADD CONSTRAINT "Session_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -20,6 +20,26 @@ enum DeploymentColor {
   GREEN
 }
 
+model User {
+  id           String    @id @default(cuid())
+  email        String    @unique
+  passwordHash String
+  createdAt    DateTime  @default(now())
+  updatedAt    DateTime  @updatedAt
+  sessions     Session[]
+}
+
+model Session {
+  id        String   @id @default(cuid())
+  tokenHash String   @unique
+  userId    String
+  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  expiresAt DateTime
+  createdAt DateTime @default(now())
+
+  @@index([userId])
+}
+
 model Project {
   id          String       @id @default(cuid())
   name        String       @unique

--- a/scripts/create-admin.ts
+++ b/scripts/create-admin.ts
@@ -1,0 +1,64 @@
+#!/usr/bin/env bun
+/**
+ * Create the first dashboard user when the User table is empty.
+ * Loads `.env` like the API (DATABASE_URL required).
+ *
+ *   bun run create-admin you@example.com 'your-secure-password'
+ */
+import "../src/config/env";
+import { disconnectPrisma } from "../src/prisma/client";
+import prisma from "../src/prisma/client";
+import {
+  AUTH_MIN_PASSWORD_LENGTH,
+  hashPassword,
+  isValidEmail,
+} from "../src/services/auth.service";
+
+const emailRaw = process.argv[2];
+const password = process.argv[3];
+
+if (!emailRaw || !password) {
+  console.error("Usage: bun run create-admin <email> <password>");
+  console.error(`Password must be at least ${AUTH_MIN_PASSWORD_LENGTH} characters.`);
+  process.exit(1);
+}
+
+const email = emailRaw.trim().toLowerCase();
+
+if (!process.env.DATABASE_URL?.trim()) {
+  console.error("DATABASE_URL is not set. Add it to .env or the environment, then retry.");
+  process.exit(1);
+}
+
+if (!isValidEmail(email)) {
+  console.error("Invalid email.");
+  process.exit(1);
+}
+
+if (password.length < AUTH_MIN_PASSWORD_LENGTH) {
+  console.error(`Password must be at least ${AUTH_MIN_PASSWORD_LENGTH} characters.`);
+  process.exit(1);
+}
+
+try {
+  const n = await prisma.user.count();
+  if (n > 0) {
+    console.error(
+      "At least one user already exists. Sign in at the dashboard; this script only bootstraps an empty database."
+    );
+    process.exit(1);
+  }
+
+  const passwordHash = await hashPassword(password);
+  await prisma.user.create({
+    data: { email, passwordHash },
+  });
+
+  console.log(`Created administrator ${email}. Open the dashboard and sign in.`);
+} catch (e) {
+  const msg = e instanceof Error ? e.message : String(e);
+  console.error("Failed:", msg);
+  process.exit(1);
+} finally {
+  await disconnectPrisma();
+}

--- a/scripts/self-update.ts
+++ b/scripts/self-update.ts
@@ -1,0 +1,19 @@
+#!/usr/bin/env bun
+/**
+ * On-host upgrade (same steps as POST /api/v1/system/update/apply).
+ * Run from repo root: `bun run self-update`
+ */
+import { config } from "../src/config/env";
+import { applySelfUpdate } from "../src/services/self-update.service";
+
+const brIdx = process.argv.indexOf("--branch");
+const branch =
+  brIdx >= 0 && process.argv[brIdx + 1] ? process.argv[brIdx + 1]! : config.selfUpdateGitBranch;
+
+const result = await applySelfUpdate(branch);
+if (result.ok) {
+  console.log(JSON.stringify(result, null, 2));
+  process.exit(0);
+}
+console.error(JSON.stringify(result, null, 2));
+process.exit(1);

--- a/src/app.ts
+++ b/src/app.ts
@@ -15,6 +15,8 @@ import { settingsRoutes } from "./routes/settings.routes";
 import { logsRoutes } from "./routes/logs.route";
 import { jobRoutes } from "./routes/job.routes";
 import { requireDatabaseConfigured } from "./middleware/require-database";
+import { requireApiAuth } from "./middleware/require-api-auth";
+import { authRoutes } from "./routes/auth.routes";
 
 export async function buildApp(): Promise<FastifyInstance> {
   const app = Fastify({
@@ -37,6 +39,7 @@ export async function buildApp(): Promise<FastifyInstance> {
     /^\/api\/v1\/system\/server-stats$/,
     /^\/api\/v1\/system\/server-dashboard$/,
     /^\/api\/v1\/setup\/status$/,
+    /^\/api\/v1\/auth\/status$/,
     /^\/api\/v1\/settings\/instance$/,
     /^\/api\/v1\/projects$/,
     /^\/api\/v1\/deployments$/,
@@ -55,6 +58,8 @@ export async function buildApp(): Promise<FastifyInstance> {
     if (/\/metrics$/.test(pathname) || /\/logs$/.test(pathname)) return true;
     return false;
   };
+
+  app.addHook("preHandler", requireApiAuth);
 
   app.addHook("onResponse", async (req, reply) => {
     const pathname = pathOnly(req.url);
@@ -103,6 +108,8 @@ export async function buildApp(): Promise<FastifyInstance> {
   });
 
   // ── API Routes (registered before static — order matters) ──────────────────
+  await app.register(authRoutes, { prefix: "/api/v1" });
+
   const dbRoutes = async (instance: FastifyInstance): Promise<void> => {
     instance.addHook("preHandler", requireDatabaseConfigured);
   };

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -42,4 +42,14 @@ export const config = {
     maxLatencyMs: 2000,
     maxRetries: 15, // 30 seconds total — accommodates slow-booting apps
   },
+  /** Long random string. Enables GET/POST `/api/v1/system/update/*` (Bearer auth). */
+  selfUpdateSecret: optionalEnv("SELF_UPDATE_SECRET", "").trim(),
+  /** Tracked branch for git fetch/merge (must match your deploy remote). */
+  selfUpdateGitBranch: optionalEnv("SELF_UPDATE_GIT_BRANCH", "main"),
+  /** If > 0, periodically fetch origin and log or auto-apply (see SELF_UPDATE_AUTO_APPLY). */
+  selfUpdatePollMs: Math.max(0, parseInt(optionalEnv("SELF_UPDATE_POLL_MS", "0"), 10) || 0),
+  /** When true with SELF_UPDATE_POLL_MS, runs apply when origin is ahead (fast-forward only). */
+  selfUpdateAutoApply:
+    optionalEnv("SELF_UPDATE_AUTO_APPLY", "").toLowerCase() === "true" ||
+    optionalEnv("SELF_UPDATE_AUTO_APPLY", "") === "1",
 } as const;

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -52,6 +52,8 @@ export const config = {
   selfUpdateAutoApply:
     optionalEnv("SELF_UPDATE_AUTO_APPLY", "").toLowerCase() === "true" ||
     optionalEnv("SELF_UPDATE_AUTO_APPLY", "") === "1",
+  /** Session cookie `Secure` flag — enable when the UI is HTTPS-only. */
+  cookieSecure: optionalEnv("COOKIE_SECURE", "").toLowerCase() === "true",
 } as const;
 
 /** Live values (updated when .env is patched at runtime). */

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -53,3 +53,26 @@ export const config = {
     optionalEnv("SELF_UPDATE_AUTO_APPLY", "").toLowerCase() === "true" ||
     optionalEnv("SELF_UPDATE_AUTO_APPLY", "") === "1",
 } as const;
+
+/** Live values (updated when .env is patched at runtime). */
+export function selfUpdateSecretLive(): string {
+  return (process.env.SELF_UPDATE_SECRET ?? "").trim();
+}
+
+export function selfUpdateBranchLive(): string {
+  const b = (process.env.SELF_UPDATE_GIT_BRANCH ?? config.selfUpdateGitBranch).trim();
+  return b || "main";
+}
+
+export function selfUpdatePollMsLive(): number {
+  const raw = process.env.SELF_UPDATE_POLL_MS;
+  const n = raw !== undefined ? parseInt(raw, 10) : config.selfUpdatePollMs;
+  return Number.isFinite(n) && n > 0 ? n : 0;
+}
+
+export function selfUpdateAutoApplyLive(): boolean {
+  const v = (process.env.SELF_UPDATE_AUTO_APPLY ?? "").toLowerCase();
+  if (v === "true" || v === "1") return true;
+  if (v === "false" || v === "0") return false;
+  return config.selfUpdateAutoApply;
+}

--- a/src/controllers/auth.controller.ts
+++ b/src/controllers/auth.controller.ts
@@ -3,6 +3,7 @@ import { config } from "../config/env";
 import { logger } from "../utils/logger";
 import prisma from "../prisma/client";
 import {
+  AUTH_MIN_PASSWORD_LENGTH,
   SESSION_MAX_AGE_SEC,
   createSession,
   deleteSessionByRawToken,
@@ -17,10 +18,8 @@ import {
   getSessionTokenFromRequest,
 } from "../utils/cookie";
 
-const MIN_PASSWORD = 10;
-
 export async function authStatusHandler(req: FastifyRequest, reply: FastifyReply): Promise<void> {
-  if (!config.databaseUrl?.trim()) {
+  if (!process.env.DATABASE_URL?.trim()) {
     reply.code(200).send({
       databaseReady: false,
       hasUsers: false,
@@ -58,7 +57,7 @@ export async function authRegisterHandler(
   req: FastifyRequest<{ Body: AuthBody }>,
   reply: FastifyReply
 ): Promise<void> {
-  if (!config.databaseUrl?.trim()) {
+  if (!process.env.DATABASE_URL?.trim()) {
     reply.code(503).send({ error: "ServiceUnavailable", message: "Database not configured" });
     return;
   }
@@ -76,10 +75,10 @@ export async function authRegisterHandler(
     reply.code(400).send({ error: "ValidationError", message: "Invalid email" });
     return;
   }
-  if (password.length < MIN_PASSWORD) {
+  if (password.length < AUTH_MIN_PASSWORD_LENGTH) {
     reply.code(400).send({
       error: "ValidationError",
-      message: `Password must be at least ${MIN_PASSWORD} characters`,
+      message: `Password must be at least ${AUTH_MIN_PASSWORD_LENGTH} characters`,
     });
     return;
   }
@@ -98,7 +97,7 @@ export async function authLoginHandler(
   req: FastifyRequest<{ Body: AuthBody }>,
   reply: FastifyReply
 ): Promise<void> {
-  if (!config.databaseUrl?.trim()) {
+  if (!process.env.DATABASE_URL?.trim()) {
     reply.code(503).send({ error: "ServiceUnavailable", message: "Database not configured" });
     return;
   }

--- a/src/controllers/auth.controller.ts
+++ b/src/controllers/auth.controller.ts
@@ -1,0 +1,135 @@
+import type { FastifyReply, FastifyRequest } from "fastify";
+import { config } from "../config/env";
+import { logger } from "../utils/logger";
+import prisma from "../prisma/client";
+import {
+  SESSION_MAX_AGE_SEC,
+  createSession,
+  deleteSessionByRawToken,
+  getUserFromSessionToken,
+  hashPassword,
+  isValidEmail,
+  verifyPassword,
+} from "../services/auth.service";
+import {
+  buildClearSessionCookie,
+  buildSetSessionCookie,
+  getSessionTokenFromRequest,
+} from "../utils/cookie";
+
+const MIN_PASSWORD = 10;
+
+export async function authStatusHandler(req: FastifyRequest, reply: FastifyReply): Promise<void> {
+  if (!config.databaseUrl?.trim()) {
+    reply.code(200).send({
+      databaseReady: false,
+      hasUsers: false,
+      authenticated: false,
+    });
+    return;
+  }
+
+  try {
+    const hasUsers = (await prisma.user.count()) > 0;
+    const raw = getSessionTokenFromRequest(req.headers.cookie);
+    const user = await getUserFromSessionToken(raw);
+    reply.code(200).send({
+      databaseReady: true,
+      hasUsers,
+      authenticated: !!user,
+      user: user ?? undefined,
+    });
+  } catch (err) {
+    logger.warn({ err }, "authStatus: database error");
+    reply.code(200).send({
+      databaseReady: true,
+      hasUsers: false,
+      authenticated: false,
+    });
+  }
+}
+
+interface AuthBody {
+  email: string;
+  password: string;
+}
+
+export async function authRegisterHandler(
+  req: FastifyRequest<{ Body: AuthBody }>,
+  reply: FastifyReply
+): Promise<void> {
+  if (!config.databaseUrl?.trim()) {
+    reply.code(503).send({ error: "ServiceUnavailable", message: "Database not configured" });
+    return;
+  }
+
+  const count = await prisma.user.count();
+  if (count > 0) {
+    reply.code(403).send({ error: "Forbidden", message: "An admin account already exists" });
+    return;
+  }
+
+  const email = typeof req.body?.email === "string" ? req.body.email.trim().toLowerCase() : "";
+  const password = typeof req.body?.password === "string" ? req.body.password : "";
+
+  if (!isValidEmail(email)) {
+    reply.code(400).send({ error: "ValidationError", message: "Invalid email" });
+    return;
+  }
+  if (password.length < MIN_PASSWORD) {
+    reply.code(400).send({
+      error: "ValidationError",
+      message: `Password must be at least ${MIN_PASSWORD} characters`,
+    });
+    return;
+  }
+
+  const passwordHash = await hashPassword(password);
+  const user = await prisma.user.create({
+    data: { email, passwordHash },
+  });
+
+  const token = await createSession(user.id);
+  reply.header("Set-Cookie", buildSetSessionCookie(token, SESSION_MAX_AGE_SEC, config.cookieSecure));
+  reply.code(201).send({ user: { id: user.id, email: user.email } });
+}
+
+export async function authLoginHandler(
+  req: FastifyRequest<{ Body: AuthBody }>,
+  reply: FastifyReply
+): Promise<void> {
+  if (!config.databaseUrl?.trim()) {
+    reply.code(503).send({ error: "ServiceUnavailable", message: "Database not configured" });
+    return;
+  }
+
+  const email = typeof req.body?.email === "string" ? req.body.email.trim().toLowerCase() : "";
+  const password = typeof req.body?.password === "string" ? req.body.password : "";
+
+  const user = await prisma.user.findUnique({ where: { email } });
+  if (!user || !(await verifyPassword(password, user.passwordHash))) {
+    reply.code(401).send({ error: "Unauthorized", message: "Invalid email or password" });
+    return;
+  }
+
+  const token = await createSession(user.id);
+  reply.header("Set-Cookie", buildSetSessionCookie(token, SESSION_MAX_AGE_SEC, config.cookieSecure));
+  reply.code(200).send({ user: { id: user.id, email: user.email } });
+}
+
+export async function authLogoutHandler(req: FastifyRequest, reply: FastifyReply): Promise<void> {
+  const raw = getSessionTokenFromRequest(req.headers.cookie);
+  await deleteSessionByRawToken(raw);
+  reply.header("Set-Cookie", buildClearSessionCookie(config.cookieSecure));
+  reply.code(200).send({ ok: true });
+}
+
+export async function authMeHandler(req: FastifyRequest, reply: FastifyReply): Promise<void> {
+  const raw = getSessionTokenFromRequest(req.headers.cookie);
+  const user = await getUserFromSessionToken(raw);
+  if (!user) {
+    reply.code(401).send({ authenticated: false });
+    return;
+  }
+  reply.code(200).send({ authenticated: true, user });
+}

--- a/src/controllers/self-update.controller.ts
+++ b/src/controllers/self-update.controller.ts
@@ -1,0 +1,85 @@
+import type { FastifyReply, FastifyRequest } from "fastify";
+import { config } from "../config/env";
+import { logger } from "../utils/logger";
+import {
+  applySelfUpdate,
+  getSelfUpdateStatus,
+  selfUpdateTokensMatch,
+} from "../services/self-update.service";
+
+function unauthorized(reply: FastifyReply): void {
+  reply.code(401).send({ error: "Unauthorized", message: "Invalid or missing credentials" });
+}
+
+function featureDisabled(reply: FastifyReply): void {
+  reply.code(503)
+    .send({ error: "NotConfigured", message: "Set SELF_UPDATE_SECRET in .env to enable self-update endpoints" });
+}
+
+function bearerToken(req: FastifyRequest): string | undefined {
+  const h = req.headers.authorization;
+  if (!h?.startsWith("Bearer ")) return undefined;
+  return h.slice("Bearer ".length).trim();
+}
+
+export async function selfUpdateStatusHandler(req: FastifyRequest, reply: FastifyReply): Promise<void> {
+  if (!config.selfUpdateSecret) {
+    featureDisabled(reply);
+    return;
+  }
+  const token = bearerToken(req);
+  if (!token || !selfUpdateTokensMatch(token, config.selfUpdateSecret)) {
+    unauthorized(reply);
+    return;
+  }
+  const status = await getSelfUpdateStatus(config.selfUpdateGitBranch);
+  reply.code(200).send(status);
+}
+
+export async function selfUpdateApplyHandler(req: FastifyRequest, reply: FastifyReply): Promise<void> {
+  if (!config.selfUpdateSecret) {
+    featureDisabled(reply);
+    return;
+  }
+  const token = bearerToken(req);
+  if (!token || !selfUpdateTokensMatch(token, config.selfUpdateSecret)) {
+    unauthorized(reply);
+    return;
+  }
+  const result = await applySelfUpdate(config.selfUpdateGitBranch);
+  if (!result.ok) {
+    reply.code(500).send(result);
+    return;
+  }
+  reply.code(200).send(result);
+}
+
+/** Fire-and-forget hook for CI or cron: `POST ?token=...` (same value as SELF_UPDATE_SECRET). */
+export async function selfUpdateWebhookHandler(req: FastifyRequest, reply: FastifyReply): Promise<void> {
+  if (!config.selfUpdateSecret) {
+    featureDisabled(reply);
+    return;
+  }
+  const q = req.query as { token?: string };
+  const token = typeof q.token === "string" ? q.token : "";
+  if (!selfUpdateTokensMatch(token, config.selfUpdateSecret)) {
+    unauthorized(reply);
+    return;
+  }
+
+  const status = await getSelfUpdateStatus(config.selfUpdateGitBranch);
+  if (!status.isGitRepo || status.message) {
+    reply.code(200).send({ ok: false, skipped: true, reason: status.message ?? "Not a git repo" });
+    return;
+  }
+  if (!status.behind) {
+    reply.code(200).send({ ok: true, skipped: true, reason: "Already up to date" });
+    return;
+  }
+
+  void applySelfUpdate(config.selfUpdateGitBranch).then((r) => {
+    logger.info(r, "Self-update webhook apply finished");
+  });
+
+  reply.code(202).send({ ok: true, accepted: true, message: "Update started" });
+}

--- a/src/controllers/self-update.controller.ts
+++ b/src/controllers/self-update.controller.ts
@@ -1,5 +1,5 @@
 import type { FastifyReply, FastifyRequest } from "fastify";
-import { config } from "../config/env";
+import { selfUpdateBranchLive, selfUpdateSecretLive } from "../config/env";
 import { logger } from "../utils/logger";
 import {
   applySelfUpdate,
@@ -23,30 +23,32 @@ function bearerToken(req: FastifyRequest): string | undefined {
 }
 
 export async function selfUpdateStatusHandler(req: FastifyRequest, reply: FastifyReply): Promise<void> {
-  if (!config.selfUpdateSecret) {
+  const secret = selfUpdateSecretLive();
+  if (!secret) {
     featureDisabled(reply);
     return;
   }
   const token = bearerToken(req);
-  if (!token || !selfUpdateTokensMatch(token, config.selfUpdateSecret)) {
+  if (!token || !selfUpdateTokensMatch(token, secret)) {
     unauthorized(reply);
     return;
   }
-  const status = await getSelfUpdateStatus(config.selfUpdateGitBranch);
+  const status = await getSelfUpdateStatus(selfUpdateBranchLive());
   reply.code(200).send(status);
 }
 
 export async function selfUpdateApplyHandler(req: FastifyRequest, reply: FastifyReply): Promise<void> {
-  if (!config.selfUpdateSecret) {
+  const secret = selfUpdateSecretLive();
+  if (!secret) {
     featureDisabled(reply);
     return;
   }
   const token = bearerToken(req);
-  if (!token || !selfUpdateTokensMatch(token, config.selfUpdateSecret)) {
+  if (!token || !selfUpdateTokensMatch(token, secret)) {
     unauthorized(reply);
     return;
   }
-  const result = await applySelfUpdate(config.selfUpdateGitBranch);
+  const result = await applySelfUpdate(selfUpdateBranchLive());
   if (!result.ok) {
     reply.code(500).send(result);
     return;
@@ -56,18 +58,19 @@ export async function selfUpdateApplyHandler(req: FastifyRequest, reply: Fastify
 
 /** Fire-and-forget hook for CI or cron: `POST ?token=...` (same value as SELF_UPDATE_SECRET). */
 export async function selfUpdateWebhookHandler(req: FastifyRequest, reply: FastifyReply): Promise<void> {
-  if (!config.selfUpdateSecret) {
+  const secret = selfUpdateSecretLive();
+  if (!secret) {
     featureDisabled(reply);
     return;
   }
   const q = req.query as { token?: string };
   const token = typeof q.token === "string" ? q.token : "";
-  if (!selfUpdateTokensMatch(token, config.selfUpdateSecret)) {
+  if (!selfUpdateTokensMatch(token, secret)) {
     unauthorized(reply);
     return;
   }
 
-  const status = await getSelfUpdateStatus(config.selfUpdateGitBranch);
+  const status = await getSelfUpdateStatus(selfUpdateBranchLive());
   if (!status.isGitRepo || status.message) {
     reply.code(200).send({ ok: false, skipped: true, reason: status.message ?? "Not a git repo" });
     return;
@@ -77,7 +80,7 @@ export async function selfUpdateWebhookHandler(req: FastifyRequest, reply: Fasti
     return;
   }
 
-  void applySelfUpdate(config.selfUpdateGitBranch).then((r) => {
+  void applySelfUpdate(selfUpdateBranchLive()).then((r) => {
     logger.info(r, "Self-update webhook apply finished");
   });
 

--- a/src/controllers/settings.controller.ts
+++ b/src/controllers/settings.controller.ts
@@ -55,10 +55,10 @@ export async function getInstanceSettingsHandler(
 
   const dbFromFile = readDatabaseUrlFromFile();
   const databaseUrlInEnvFile = Boolean(dbFromFile && dbFromFile.length > 0);
-  const databaseUrlLoaded = Boolean(config.databaseUrl && config.databaseUrl.trim().length > 0);
+  const databaseUrlLoaded = Boolean(process.env.DATABASE_URL?.trim());
 
   let databaseReachable = false;
-  const urlToPing = databaseUrlLoaded ? config.databaseUrl : dbFromFile;
+  const urlToPing = databaseUrlLoaded ? process.env.DATABASE_URL!.trim() : dbFromFile;
   if (urlToPing) {
     databaseReachable = await canConnectToDatabase(urlToPing);
   }

--- a/src/controllers/settings.controller.ts
+++ b/src/controllers/settings.controller.ts
@@ -1,10 +1,19 @@
+import { randomBytes } from "crypto";
 import { readFileSync, existsSync } from "fs";
 import { join } from "path";
 import { FastifyRequest, FastifyReply } from "fastify";
-import { config } from "../config/env";
+import {
+  config,
+  selfUpdateAutoApplyLive,
+  selfUpdateBranchLive,
+  selfUpdatePollMsLive,
+  selfUpdateSecretLive,
+} from "../config/env";
 import { envFilePath, projectRoot } from "../utils/paths";
 import { mergeIntoDotenv, writeEnvWithBackup } from "../utils/env-file";
 import { logger } from "../utils/logger";
+import { applySelfUpdate, getSelfUpdateStatus } from "../services/self-update.service";
+import { kickSelfUpdatePoll } from "../services/self-update-poll";
 
 const DB_URL_REGEX = /^DATABASE_URL\s*=\s*"?([^"\n\r]+)"?\s*$/m;
 
@@ -73,6 +82,10 @@ export async function getInstanceSettingsHandler(
     needsRestart,
     encryptionKeyConfigured,
     geminiConfigured,
+    selfUpdateConfigured: Boolean(selfUpdateSecretLive()),
+    selfUpdateGitBranch: selfUpdateBranchLive(),
+    selfUpdatePollMs: selfUpdatePollMsLive(),
+    selfUpdateAutoApply: selfUpdateAutoApplyLive(),
   });
 }
 
@@ -90,6 +103,10 @@ const PATCHABLE_ENV_KEYS = new Set([
   "PORT",
   "MONIX_PATH",
   "MONIX_PORT",
+  "SELF_UPDATE_SECRET",
+  "SELF_UPDATE_GIT_BRANCH",
+  "SELF_UPDATE_POLL_MS",
+  "SELF_UPDATE_AUTO_APPLY",
 ]);
 
 interface PatchEnvBody {
@@ -146,6 +163,36 @@ export async function patchInstanceEnvHandler(
     return reply.code(400).send({ error: "ValidationError", message: "MONIX_PORT must be a positive integer" });
   }
 
+  if (updates.SELF_UPDATE_POLL_MS !== undefined) {
+    const t = updates.SELF_UPDATE_POLL_MS.trim();
+    if (!/^\d+$/.test(t)) {
+      return reply.code(400).send({ error: "ValidationError", message: "SELF_UPDATE_POLL_MS must be a non-negative integer" });
+    }
+    updates.SELF_UPDATE_POLL_MS = t;
+  }
+
+  if (updates.SELF_UPDATE_AUTO_APPLY !== undefined) {
+    const v = updates.SELF_UPDATE_AUTO_APPLY.toLowerCase();
+    if (!["true", "false", "1", "0"].includes(v)) {
+      return reply.code(400).send({
+        error: "ValidationError",
+        message: "SELF_UPDATE_AUTO_APPLY must be true, false, 1, or 0",
+      });
+    }
+    updates.SELF_UPDATE_AUTO_APPLY = v === "true" || v === "1" ? "true" : "false";
+  }
+
+  if (updates.SELF_UPDATE_GIT_BRANCH !== undefined) {
+    const b = updates.SELF_UPDATE_GIT_BRANCH.trim();
+    if (!b || !/^[a-zA-Z0-9/._-]+$/.test(b)) {
+      return reply.code(400).send({
+        error: "ValidationError",
+        message: "SELF_UPDATE_GIT_BRANCH must be a non-empty branch name",
+      });
+    }
+    updates.SELF_UPDATE_GIT_BRANCH = b;
+  }
+
   try {
     const next = mergeIntoDotenv(updates);
     writeEnvWithBackup(next);
@@ -155,8 +202,96 @@ export async function patchInstanceEnvHandler(
     return reply.code(500).send({ error: "WriteError", message: msg });
   }
 
+  const selfKeys = [
+    "SELF_UPDATE_SECRET",
+    "SELF_UPDATE_GIT_BRANCH",
+    "SELF_UPDATE_POLL_MS",
+    "SELF_UPDATE_AUTO_APPLY",
+  ] as const;
+  let touchedSelf = false;
+  for (const k of selfKeys) {
+    if (updates[k] !== undefined) {
+      process.env[k] = updates[k];
+      touchedSelf = true;
+    }
+  }
+  if (touchedSelf) {
+    kickSelfUpdatePoll();
+  }
+
   return reply.code(200).send({
     message: "Environment file updated. Restart the API and worker to apply changes.",
     keysWritten: Object.keys(updates),
   });
+}
+
+export async function getSelfUpdateSettingsHandler(_req: FastifyRequest, reply: FastifyReply): Promise<void> {
+  const branch = selfUpdateBranchLive();
+  let git: Awaited<ReturnType<typeof getSelfUpdateStatus>> | null = null;
+  if (selfUpdateSecretLive()) {
+    try {
+      git = await getSelfUpdateStatus(branch);
+    } catch {
+      git = null;
+    }
+  }
+  reply.code(200).send({
+    configured: Boolean(selfUpdateSecretLive()),
+    branch,
+    pollMs: selfUpdatePollMsLive(),
+    autoApply: selfUpdateAutoApplyLive(),
+    git,
+  });
+}
+
+export async function postSelfUpdateEnableHandler(_req: FastifyRequest, reply: FastifyReply): Promise<void> {
+  if (selfUpdateSecretLive()) {
+    return reply.code(400).send({
+      error: "AlreadyEnabled",
+      message:
+        "SELF_UPDATE_SECRET is already set. Remove it from .env to regenerate, or paste a new secret using the env editor.",
+    });
+  }
+  const secret = randomBytes(32).toString("hex");
+  try {
+    const next = mergeIntoDotenv({ SELF_UPDATE_SECRET: secret });
+    writeEnvWithBackup(next);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    logger.error({ err }, "postSelfUpdateEnable: write failed");
+    return reply.code(500).send({ error: "WriteError", message: msg });
+  }
+  process.env.SELF_UPDATE_SECRET = secret;
+  kickSelfUpdatePoll();
+  logger.info("Self-update enabled from Settings (secret written to .env, not logged)");
+  reply.code(200).send({
+    message:
+      "Self-update enabled. The secret was saved to .env and is not shown again. Use “Check for updates” below, or call the webhook with that token.",
+  });
+}
+
+export async function postSelfUpdateCheckHandler(_req: FastifyRequest, reply: FastifyReply): Promise<void> {
+  if (!selfUpdateSecretLive()) {
+    return reply.code(400).send({
+      error: "NotConfigured",
+      message: "Enable self-update first, or set SELF_UPDATE_SECRET in .env",
+    });
+  }
+  const status = await getSelfUpdateStatus(selfUpdateBranchLive());
+  reply.code(200).send(status);
+}
+
+export async function postSelfUpdateApplyHandler(_req: FastifyRequest, reply: FastifyReply): Promise<void> {
+  if (!selfUpdateSecretLive()) {
+    return reply.code(400).send({
+      error: "NotConfigured",
+      message: "Enable self-update first, or set SELF_UPDATE_SECRET in .env",
+    });
+  }
+  const result = await applySelfUpdate(selfUpdateBranchLive());
+  if (!result.ok) {
+    reply.code(500).send(result);
+    return;
+  }
+  reply.code(200).send(result);
 }

--- a/src/controllers/setup.controller.ts
+++ b/src/controllers/setup.controller.ts
@@ -3,14 +3,27 @@ import { accessSync, constants, existsSync, mkdirSync, readFileSync, writeFileSy
 import { execSync } from "child_process";
 import { randomBytes } from "crypto";
 import { join } from "path";
+import { PrismaClient } from "@prisma/client";
 import { logger } from "../utils/logger";
 import { config } from "../config/env";
 import { envFilePath, projectRoot } from "../utils/paths";
 import { runPrismaSchemaSync } from "../utils/prisma-schema-sync";
+import { reconnectPrismaAfterSetup } from "../prisma/client";
+import { notifySetupApplied } from "../services/post-setup-hooks";
+import {
+  AUTH_MIN_PASSWORD_LENGTH,
+  createSessionWithClient,
+  hashPassword,
+  isValidEmail,
+  SESSION_MAX_AGE_SEC,
+} from "../services/auth.service";
+import { buildSetSessionCookie } from "../utils/cookie";
 
 interface SetupApplyBody {
   domain: string;
   databaseUrl: string;
+  adminEmail: string;
+  adminPassword: string;
   geminiApiKey?: string;
 }
 
@@ -117,9 +130,8 @@ export async function getSetupStatusHandler(
     }
   }
 
-  /** `.env` was written but this process was started before DATABASE_URL was loaded — requires restart. */
-  const needsRestart =
-    configured && (!config.databaseUrl || config.databaseUrl.trim().length === 0);
+  /** `.env` exists but this process has no DATABASE_URL (e.g. not applied in-process yet). */
+  const needsRestart = configured && !process.env.DATABASE_URL?.trim();
 
   return reply.code(200).send({ configured, dbConnected, needsRestart });
 }
@@ -128,7 +140,7 @@ export async function applySetupHandler(
   req: FastifyRequest<{ Body: SetupApplyBody }>,
   reply: FastifyReply
 ): Promise<void> {
-  const { domain, databaseUrl, geminiApiKey } = req.body;
+  const { domain, databaseUrl, adminEmail, adminPassword, geminiApiKey } = req.body;
 
   if (!databaseUrl || databaseUrl.trim().length === 0) {
     return reply.code(400).send({ error: "BadRequest", message: "databaseUrl is required" });
@@ -136,6 +148,19 @@ export async function applySetupHandler(
 
   if (!domain || domain.trim().length === 0) {
     return reply.code(400).send({ error: "BadRequest", message: "domain is required" });
+  }
+
+  const email =
+    typeof adminEmail === "string" ? adminEmail.trim().toLowerCase() : "";
+  const password = typeof adminPassword === "string" ? adminPassword : "";
+  if (!isValidEmail(email)) {
+    return reply.code(400).send({ error: "BadRequest", message: "Invalid admin email" });
+  }
+  if (password.length < AUTH_MIN_PASSWORD_LENGTH) {
+    return reply.code(400).send({
+      error: "BadRequest",
+      message: `Admin password must be at least ${AUTH_MIN_PASSWORD_LENGTH} characters`,
+    });
   }
 
   const normalizedDomain = domain.trim().toLowerCase();
@@ -227,6 +252,36 @@ ENCRYPTION_KEY="${encryptionKey}"
       message: "Database migration failed: " + msg,
     });
   }
+
+  // 3b. Create first admin and session (dedicated client — global Prisma not wired yet)
+  const setupPrisma = new PrismaClient({ datasources: { db: { url: databaseUrl } } });
+  let sessionToken: string;
+  try {
+    const passwordHash = await hashPassword(password);
+    const user = await setupPrisma.user.create({
+      data: { email, passwordHash },
+    });
+    sessionToken = await createSessionWithClient(setupPrisma, user.id);
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    logger.error({ err: msg }, "Setup: failed to create admin user");
+    await setupPrisma.$disconnect().catch(() => {});
+    return reply.code(500).send({
+      error: "SetupError",
+      message: "Failed to create admin account: " + msg,
+    });
+  }
+  await setupPrisma.$disconnect().catch(() => {});
+
+  process.env.DATABASE_URL = databaseUrl;
+  process.env.ENCRYPTION_KEY = encryptionKey;
+  await reconnectPrismaAfterSetup();
+  notifySetupApplied();
+
+  reply.header(
+    "Set-Cookie",
+    buildSetSessionCookie(sessionToken, SESSION_MAX_AGE_SEC, config.cookieSecure)
+  );
 
   // 4. Write Nginx config (best-effort — may not have permissions)
   try {

--- a/src/middleware/require-api-auth.ts
+++ b/src/middleware/require-api-auth.ts
@@ -1,5 +1,4 @@
 import type { FastifyReply, FastifyRequest } from "fastify";
-import { config } from "../config/env";
 import prisma from "../prisma/client";
 import { getUserFromSessionToken } from "../services/auth.service";
 import { getSessionTokenFromRequest } from "../utils/cookie";
@@ -36,7 +35,7 @@ export async function requireApiAuth(req: AuthedRequest, reply: FastifyReply): P
   if (!path.startsWith("/api/v1/")) return;
   if (isPublicApiPath(path)) return;
 
-  if (!config.databaseUrl?.trim()) {
+  if (!process.env.DATABASE_URL?.trim()) {
     return;
   }
 

--- a/src/middleware/require-api-auth.ts
+++ b/src/middleware/require-api-auth.ts
@@ -1,0 +1,68 @@
+import type { FastifyReply, FastifyRequest } from "fastify";
+import { config } from "../config/env";
+import prisma from "../prisma/client";
+import { getUserFromSessionToken } from "../services/auth.service";
+import { getSessionTokenFromRequest } from "../utils/cookie";
+
+function pathOnly(url: string): string {
+  const i = url.indexOf("?");
+  return i === -1 ? url : url.slice(0, i);
+}
+
+function isPublicApiPath(path: string): boolean {
+  if (path.startsWith("/api/v1/setup/")) return true;
+  if (path.startsWith("/api/v1/auth/")) return true;
+  if (path.startsWith("/api/v1/webhooks/")) return true;
+  if (
+    path === "/api/v1/system/update/status" ||
+    path === "/api/v1/system/update/apply" ||
+    path === "/api/v1/system/update/webhook"
+  ) {
+    return true;
+  }
+  return false;
+}
+
+export type AuthedRequest = FastifyRequest & {
+  authUser?: { id: string; email: string };
+};
+
+/**
+ * Requires a valid session cookie once at least one dashboard user exists.
+ * Before the first user is registered, all API routes stay open (bootstrap window).
+ */
+export async function requireApiAuth(req: AuthedRequest, reply: FastifyReply): Promise<void> {
+  const path = pathOnly(req.url);
+  if (!path.startsWith("/api/v1/")) return;
+  if (isPublicApiPath(path)) return;
+
+  if (!config.databaseUrl?.trim()) {
+    return;
+  }
+
+  try {
+    const userCount = await prisma.user.count();
+    if (userCount === 0) {
+      return;
+    }
+  } catch {
+    await reply.code(503).send({
+      error: "ServiceUnavailable",
+      message: "Database unavailable for authentication.",
+    });
+    return;
+  }
+
+  const raw = getSessionTokenFromRequest(req.headers.cookie);
+  const user = await getUserFromSessionToken(raw);
+  if (!user) {
+    await reply.code(401).send({
+      error: "Unauthorized",
+      message: "Sign in required",
+      code: "AUTH_REQUIRED",
+    });
+    return;
+  }
+
+  req.authUser = user;
+}

--- a/src/middleware/require-database.ts
+++ b/src/middleware/require-database.ts
@@ -1,6 +1,4 @@
 import { FastifyReply, FastifyRequest } from "fastify";
-import { config } from "../config/env";
-
 /**
  * Ensures DATABASE_URL is set (loaded from .env into config).
  * Use on routes that call Prisma; setup and health endpoints stay available without a DB.
@@ -9,7 +7,7 @@ export async function requireDatabaseConfigured(
   _req: FastifyRequest,
   reply: FastifyReply
 ): Promise<void> {
-  if (config.databaseUrl?.trim()) return;
+  if (process.env.DATABASE_URL?.trim()) return;
 
   await reply.code(503).send({
     error: "ServiceUnavailable",

--- a/src/prisma/client.ts
+++ b/src/prisma/client.ts
@@ -1,20 +1,57 @@
 import { PrismaClient } from "@prisma/client";
 import { logger } from "../utils/logger";
 
-const prisma = new PrismaClient({
-  log: [
-    { emit: "event", level: "query" },
-    { emit: "event", level: "error" },
-    { emit: "event", level: "warn" },
-  ],
-});
+function createPrisma(): PrismaClient {
+  const client = new PrismaClient({
+    log: [
+      { emit: "event", level: "query" },
+      { emit: "event", level: "error" },
+      { emit: "event", level: "warn" },
+    ],
+  });
 
-prisma.$on("error", (e) => {
-  logger.error({ msg: e.message, target: e.target }, "Prisma error");
-});
+  client.$on("error", (e) => {
+    logger.error({ msg: e.message, target: e.target }, "Prisma error");
+  });
 
-prisma.$on("warn", (e) => {
-  logger.warn({ msg: e.message, target: e.target }, "Prisma warning");
-});
+  client.$on("warn", (e) => {
+    logger.warn({ msg: e.message, target: e.target }, "Prisma warning");
+  });
+
+  return client;
+}
+
+let _client: PrismaClient | null = null;
+
+function ensureClient(): PrismaClient {
+  if (!_client) {
+    _client = createPrisma();
+  }
+  return _client;
+}
+
+/** Call after first-time setup writes DATABASE_URL so this process uses the new connection. */
+export async function reconnectPrismaAfterSetup(): Promise<void> {
+  if (_client) {
+    await _client.$disconnect().catch(() => {});
+    _client = null;
+  }
+}
+
+export async function disconnectPrisma(): Promise<void> {
+  await reconnectPrismaAfterSetup();
+}
+
+export const prisma = new Proxy({} as PrismaClient, {
+  get(_, prop) {
+    if (prop === "then") return undefined;
+    const c = ensureClient();
+    const v = (c as unknown as Record<string | symbol, unknown>)[prop];
+    if (typeof v === "function") {
+      return (v as (...args: unknown[]) => unknown).bind(c);
+    }
+    return v;
+  },
+}) as PrismaClient;
 
 export default prisma;

--- a/src/routes/auth.routes.ts
+++ b/src/routes/auth.routes.ts
@@ -1,0 +1,16 @@
+import { FastifyInstance } from "fastify";
+import {
+  authLoginHandler,
+  authLogoutHandler,
+  authMeHandler,
+  authRegisterHandler,
+  authStatusHandler,
+} from "../controllers/auth.controller";
+
+export async function authRoutes(app: FastifyInstance): Promise<void> {
+  app.get("/auth/status", { handler: authStatusHandler });
+  app.get("/auth/me", { handler: authMeHandler });
+  app.post("/auth/register", { handler: authRegisterHandler });
+  app.post("/auth/login", { handler: authLoginHandler });
+  app.post("/auth/logout", { handler: authLogoutHandler });
+}

--- a/src/routes/settings.routes.ts
+++ b/src/routes/settings.routes.ts
@@ -1,8 +1,19 @@
 import { FastifyInstance } from "fastify";
-import { getInstanceSettingsHandler, patchInstanceEnvHandler } from "../controllers/settings.controller";
+import {
+  getInstanceSettingsHandler,
+  patchInstanceEnvHandler,
+  getSelfUpdateSettingsHandler,
+  postSelfUpdateEnableHandler,
+  postSelfUpdateCheckHandler,
+  postSelfUpdateApplyHandler,
+} from "../controllers/settings.controller";
 
 export async function settingsRoutes(app: FastifyInstance): Promise<void> {
   app.get("/settings/instance", { handler: getInstanceSettingsHandler });
+  app.get("/settings/self-update", { handler: getSelfUpdateSettingsHandler });
+  app.post("/settings/self-update/enable", { handler: postSelfUpdateEnableHandler });
+  app.post("/settings/self-update/check", { handler: postSelfUpdateCheckHandler });
+  app.post("/settings/self-update/apply", { handler: postSelfUpdateApplyHandler });
   app.patch("/settings/env", {
     schema: {
       body: {

--- a/src/routes/setup.routes.ts
+++ b/src/routes/setup.routes.ts
@@ -22,10 +22,12 @@ export async function setupRoutes(app: FastifyInstance): Promise<void> {
     schema: {
       body: {
         type: "object",
-        required: ["domain", "databaseUrl"],
+        required: ["domain", "databaseUrl", "adminEmail", "adminPassword"],
         properties: {
           domain: { type: "string", minLength: 1 },
           databaseUrl: { type: "string", minLength: 1 },
+          adminEmail: { type: "string", minLength: 3 },
+          adminPassword: { type: "string", minLength: 1 },
           geminiApiKey: { type: "string" },
         },
       },

--- a/src/routes/system.routes.ts
+++ b/src/routes/system.routes.ts
@@ -1,7 +1,13 @@
 import { FastifyInstance } from "fastify";
 import { reconcileHandler, getServerStatsHandler, getServerDashboardHandler } from "../controllers/system.controller";
 import { preflightHandler } from "../controllers/preflight.controller";
+import {
+  selfUpdateApplyHandler,
+  selfUpdateStatusHandler,
+  selfUpdateWebhookHandler,
+} from "../controllers/self-update.controller";
 import { requireDatabaseConfigured } from "../middleware/require-database";
+import { config } from "../config/env";
 
 export async function systemRoutes(app: FastifyInstance): Promise<void> {
   /** Host compatibility (Docker, Git, network, …) — no database required. */
@@ -10,6 +16,12 @@ export async function systemRoutes(app: FastifyInstance): Promise<void> {
   app.get("/server/stats", { handler: getServerStatsHandler });
   app.get("/system/server-stats", { handler: getServerStatsHandler });
   app.get("/system/server-dashboard", { handler: getServerDashboardHandler });
+
+  if (config.selfUpdateSecret) {
+    app.get("/system/update/status", { handler: selfUpdateStatusHandler });
+    app.post("/system/update/apply", { handler: selfUpdateApplyHandler });
+    app.post("/system/update/webhook", { handler: selfUpdateWebhookHandler });
+  }
 
   app.post("/system/reconcile", {
     preHandler: requireDatabaseConfigured,

--- a/src/routes/system.routes.ts
+++ b/src/routes/system.routes.ts
@@ -7,8 +7,6 @@ import {
   selfUpdateWebhookHandler,
 } from "../controllers/self-update.controller";
 import { requireDatabaseConfigured } from "../middleware/require-database";
-import { config } from "../config/env";
-
 export async function systemRoutes(app: FastifyInstance): Promise<void> {
   /** Host compatibility (Docker, Git, network, …) — no database required. */
   app.get("/system/preflight", { handler: preflightHandler });
@@ -17,11 +15,9 @@ export async function systemRoutes(app: FastifyInstance): Promise<void> {
   app.get("/system/server-stats", { handler: getServerStatsHandler });
   app.get("/system/server-dashboard", { handler: getServerDashboardHandler });
 
-  if (config.selfUpdateSecret) {
-    app.get("/system/update/status", { handler: selfUpdateStatusHandler });
-    app.post("/system/update/apply", { handler: selfUpdateApplyHandler });
-    app.post("/system/update/webhook", { handler: selfUpdateWebhookHandler });
-  }
+  app.get("/system/update/status", { handler: selfUpdateStatusHandler });
+  app.post("/system/update/apply", { handler: selfUpdateApplyHandler });
+  app.post("/system/update/webhook", { handler: selfUpdateWebhookHandler });
 
   app.post("/system/reconcile", {
     preHandler: requireDatabaseConfigured,

--- a/src/server.ts
+++ b/src/server.ts
@@ -71,6 +71,35 @@ async function start(): Promise<void> {
     if (!config.databaseUrl) {
       logger.info("Setup wizard available at http://0.0.0.0:" + PORT + "/setup");
     }
+
+    if (config.selfUpdateSecret && config.selfUpdatePollMs > 0) {
+      const pollMs = config.selfUpdatePollMs;
+      logger.info(
+        { pollMs, autoApply: config.selfUpdateAutoApply, branch: config.selfUpdateGitBranch },
+        "Self-update polling enabled"
+      );
+      setInterval(() => {
+        void (async () => {
+          try {
+            const { getSelfUpdateStatus, applySelfUpdate } = await import("./services/self-update.service");
+            const s = await getSelfUpdateStatus(config.selfUpdateGitBranch);
+            if (!s.isGitRepo || s.message || !s.behind) return;
+            if (config.selfUpdateAutoApply) {
+              logger.info({ branch: config.selfUpdateGitBranch }, "Self-update poll: applying (auto)");
+              const r = await applySelfUpdate(config.selfUpdateGitBranch);
+              if (!r.ok) logger.warn({ err: r.error }, "Self-update poll: apply failed");
+            } else {
+              logger.info(
+                { branch: config.selfUpdateGitBranch, local: s.currentCommit, remote: s.remoteCommit },
+                "Self-update: origin is ahead — set SELF_UPDATE_AUTO_APPLY=true or POST /api/v1/system/update/apply"
+              );
+            }
+          } catch (err) {
+            logger.warn({ err }, "Self-update poll error");
+          }
+        })();
+      }, pollMs);
+    }
   } catch (err) {
     logger.fatal({ err }, "Failed to start server");
     await prisma.$disconnect();

--- a/src/server.ts
+++ b/src/server.ts
@@ -2,15 +2,34 @@ import { buildApp } from "./app";
 import { config } from "./config/env";
 import { logger } from "./utils/logger";
 import { runPrismaSchemaSync } from "./utils/prisma-schema-sync";
-import prisma from "./prisma/client";
+import { disconnectPrisma } from "./prisma/client";
 import { ReconciliationService } from "./services/reconciliation.service";
 import { ContainerMonitorService } from "./services/container-monitor.service";
+import { registerAfterSetup } from "./services/post-setup-hooks";
 import { systemMetrics } from "./controllers/system.controller";
 import { kickSelfUpdatePoll, stopSelfUpdatePoll } from "./services/self-update-poll";
+
+function databaseUrlLive(): string {
+  return process.env.DATABASE_URL?.trim() ?? "";
+}
 
 async function start(): Promise<void> {
   const app = await buildApp();
   const monitor = new ContainerMonitorService();
+
+  registerAfterSetup(() => {
+    if (!databaseUrlLive()) return;
+    monitor.start();
+    void (async () => {
+      try {
+        const reconciliation = new ReconciliationService();
+        const report = await reconciliation.reconcile();
+        logger.info(report, "Post-setup reconciliation complete");
+      } catch (err) {
+        logger.warn({ err }, "Post-setup reconciliation failed");
+      }
+    })();
+  });
 
   // Graceful shutdown
   const shutdown = async (signal: string): Promise<void> => {
@@ -19,7 +38,7 @@ async function start(): Promise<void> {
     systemMetrics.stop();
     monitor.stop();
     await app.close();
-    await prisma.$disconnect();
+    await disconnectPrisma();
     process.exit(0);
   };
 
@@ -31,13 +50,13 @@ async function start(): Promise<void> {
 
     // Run reconciliation before accepting requests — cleans up any crashed deploys
     // Skip if database is not configured (setup wizard not completed yet)
-    if (config.databaseUrl) {
+    if (databaseUrlLive()) {
       try {
         logger.info("Applying database migrations…");
         runPrismaSchemaSync({ mode: config.prismaSchemaSync });
       } catch (err) {
         logger.fatal({ err }, "Database migration failed — check DATABASE_URL and migration files");
-        await prisma.$disconnect();
+        await disconnectPrisma();
         process.exit(1);
       }
 
@@ -63,21 +82,21 @@ async function start(): Promise<void> {
       "VersionGate Engine is running"
     );
 
-    if (config.databaseUrl) {
+    if (databaseUrlLive()) {
       monitor.start();
     } else {
       logger.warn("DATABASE_URL not set — container monitor disabled until database is configured");
     }
     systemMetrics.start();
 
-    if (!config.databaseUrl) {
+    if (!databaseUrlLive()) {
       logger.info("Setup wizard available at http://0.0.0.0:" + PORT + "/setup");
     }
 
     kickSelfUpdatePoll();
   } catch (err) {
     logger.fatal({ err }, "Failed to start server");
-    await prisma.$disconnect();
+    await disconnectPrisma();
     process.exit(1);
   }
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -6,6 +6,7 @@ import prisma from "./prisma/client";
 import { ReconciliationService } from "./services/reconciliation.service";
 import { ContainerMonitorService } from "./services/container-monitor.service";
 import { systemMetrics } from "./controllers/system.controller";
+import { kickSelfUpdatePoll, stopSelfUpdatePoll } from "./services/self-update-poll";
 
 async function start(): Promise<void> {
   const app = await buildApp();
@@ -14,6 +15,7 @@ async function start(): Promise<void> {
   // Graceful shutdown
   const shutdown = async (signal: string): Promise<void> => {
     logger.info({ signal }, "Shutting down");
+    stopSelfUpdatePoll();
     systemMetrics.stop();
     monitor.stop();
     await app.close();
@@ -72,34 +74,7 @@ async function start(): Promise<void> {
       logger.info("Setup wizard available at http://0.0.0.0:" + PORT + "/setup");
     }
 
-    if (config.selfUpdateSecret && config.selfUpdatePollMs > 0) {
-      const pollMs = config.selfUpdatePollMs;
-      logger.info(
-        { pollMs, autoApply: config.selfUpdateAutoApply, branch: config.selfUpdateGitBranch },
-        "Self-update polling enabled"
-      );
-      setInterval(() => {
-        void (async () => {
-          try {
-            const { getSelfUpdateStatus, applySelfUpdate } = await import("./services/self-update.service");
-            const s = await getSelfUpdateStatus(config.selfUpdateGitBranch);
-            if (!s.isGitRepo || s.message || !s.behind) return;
-            if (config.selfUpdateAutoApply) {
-              logger.info({ branch: config.selfUpdateGitBranch }, "Self-update poll: applying (auto)");
-              const r = await applySelfUpdate(config.selfUpdateGitBranch);
-              if (!r.ok) logger.warn({ err: r.error }, "Self-update poll: apply failed");
-            } else {
-              logger.info(
-                { branch: config.selfUpdateGitBranch, local: s.currentCommit, remote: s.remoteCommit },
-                "Self-update: origin is ahead — set SELF_UPDATE_AUTO_APPLY=true or POST /api/v1/system/update/apply"
-              );
-            }
-          } catch (err) {
-            logger.warn({ err }, "Self-update poll error");
-          }
-        })();
-      }, pollMs);
-    }
+    kickSelfUpdatePoll();
   } catch (err) {
     logger.fatal({ err }, "Failed to start server");
     await prisma.$disconnect();

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -1,5 +1,6 @@
 import { createHash, randomBytes, scrypt, timingSafeEqual } from "crypto";
 import { promisify } from "util";
+import type { PrismaClient } from "@prisma/client";
 import prisma from "../prisma/client";
 
 const scryptAsync = promisify(scrypt);
@@ -7,6 +8,9 @@ const scryptAsync = promisify(scrypt);
 const SESSION_MAX_AGE_SEC = 7 * 24 * 60 * 60;
 
 export { SESSION_MAX_AGE_SEC };
+
+/** Minimum password length for dashboard accounts (register, setup admin). */
+export const AUTH_MIN_PASSWORD_LENGTH = 10;
 
 export async function hashPassword(plain: string): Promise<string> {
   const salt = randomBytes(16);
@@ -38,6 +42,17 @@ export async function createSession(userId: string): Promise<string> {
   const tokenHash = hashToken(raw);
   const expiresAt = new Date(Date.now() + SESSION_MAX_AGE_SEC * 1000);
   await prisma.session.create({
+    data: { tokenHash, userId, expiresAt },
+  });
+  return raw;
+}
+
+/** Used during first-time setup before the global Prisma client is reconnected. */
+export async function createSessionWithClient(client: PrismaClient, userId: string): Promise<string> {
+  const raw = randomBytes(32).toString("base64url");
+  const tokenHash = hashToken(raw);
+  const expiresAt = new Date(Date.now() + SESSION_MAX_AGE_SEC * 1000);
+  await client.session.create({
     data: { tokenHash, userId, expiresAt },
   });
   return raw;

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -1,0 +1,71 @@
+import { createHash, randomBytes, scrypt, timingSafeEqual } from "crypto";
+import { promisify } from "util";
+import prisma from "../prisma/client";
+
+const scryptAsync = promisify(scrypt);
+
+const SESSION_MAX_AGE_SEC = 7 * 24 * 60 * 60;
+
+export { SESSION_MAX_AGE_SEC };
+
+export async function hashPassword(plain: string): Promise<string> {
+  const salt = randomBytes(16);
+  const derived = (await scryptAsync(plain, salt, 64)) as Buffer;
+  return `${salt.toString("hex")}:${derived.toString("hex")}`;
+}
+
+export async function verifyPassword(plain: string, stored: string): Promise<boolean> {
+  const parts = stored.split(":");
+  if (parts.length !== 2) return false;
+  const [saltHex, hashHex] = parts;
+  try {
+    const salt = Buffer.from(saltHex, "hex");
+    const expected = Buffer.from(hashHex, "hex");
+    const derived = (await scryptAsync(plain, salt, 64)) as Buffer;
+    if (derived.length !== expected.length) return false;
+    return timingSafeEqual(derived, expected);
+  } catch {
+    return false;
+  }
+}
+
+function hashToken(raw: string): string {
+  return createHash("sha256").update(raw, "utf8").digest("hex");
+}
+
+export async function createSession(userId: string): Promise<string> {
+  const raw = randomBytes(32).toString("base64url");
+  const tokenHash = hashToken(raw);
+  const expiresAt = new Date(Date.now() + SESSION_MAX_AGE_SEC * 1000);
+  await prisma.session.create({
+    data: { tokenHash, userId, expiresAt },
+  });
+  return raw;
+}
+
+export async function deleteSessionByRawToken(raw: string | undefined): Promise<void> {
+  if (!raw) return;
+  await prisma.session.deleteMany({ where: { tokenHash: hashToken(raw) } });
+}
+
+export async function getUserFromSessionToken(
+  rawToken: string | undefined
+): Promise<{ id: string; email: string } | null> {
+  if (!rawToken) return null;
+  const tokenHash = hashToken(rawToken);
+  const row = await prisma.session.findUnique({
+    where: { tokenHash },
+    include: { user: true },
+  });
+  if (!row) return null;
+  if (row.expiresAt < new Date()) {
+    await prisma.session.delete({ where: { id: row.id } }).catch(() => null);
+    return null;
+  }
+  return { id: row.user.id, email: row.user.email };
+}
+
+export function isValidEmail(email: string): boolean {
+  const t = email.trim().toLowerCase();
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(t);
+}

--- a/src/services/post-setup-hooks.ts
+++ b/src/services/post-setup-hooks.ts
@@ -1,0 +1,18 @@
+import { logger } from "../utils/logger";
+
+const callbacks: (() => void)[] = [];
+
+/** Register once from server bootstrap — runs when first-time setup finishes in-process. */
+export function registerAfterSetup(cb: () => void): void {
+  callbacks.push(cb);
+}
+
+export function notifySetupApplied(): void {
+  for (const cb of callbacks) {
+    try {
+      cb();
+    } catch (err) {
+      logger.error({ err }, "post-setup hook failed");
+    }
+  }
+}

--- a/src/services/self-update-poll.ts
+++ b/src/services/self-update-poll.ts
@@ -1,0 +1,68 @@
+import {
+  selfUpdateAutoApplyLive,
+  selfUpdateBranchLive,
+  selfUpdatePollMsLive,
+  selfUpdateSecretLive,
+} from "../config/env";
+import { logger } from "../utils/logger";
+import { applySelfUpdate, getSelfUpdateStatus } from "./self-update.service";
+
+let timer: ReturnType<typeof setTimeout> | null = null;
+
+function scheduleNext(): void {
+  if (timer) {
+    clearTimeout(timer);
+    timer = null;
+  }
+  const secret = selfUpdateSecretLive();
+  const ms = selfUpdatePollMsLive();
+  if (!secret || ms <= 0) return;
+  timer = setTimeout(() => void runTick(), ms);
+}
+
+async function runTick(): Promise<void> {
+  timer = null;
+  try {
+    const branch = selfUpdateBranchLive();
+    const s = await getSelfUpdateStatus(branch);
+    if (!s.isGitRepo || s.message || !s.behind) {
+      scheduleNext();
+      return;
+    }
+    if (selfUpdateAutoApplyLive()) {
+      logger.info({ branch }, "Self-update poll: applying (auto)");
+      const r = await applySelfUpdate(branch);
+      if (!r.ok) logger.warn({ err: r.error }, "Self-update poll: apply failed");
+    } else {
+      logger.info(
+        { branch, local: s.currentCommit, remote: s.remoteCommit },
+        "Self-update: origin is ahead — apply from Settings or POST /api/v1/system/update/apply"
+      );
+    }
+  } catch (err) {
+    logger.warn({ err }, "Self-update poll error");
+  } finally {
+    scheduleNext();
+  }
+}
+
+/** (Re)start polling from current process env — call after enabling self-update or changing poll interval in .env. */
+export function kickSelfUpdatePoll(): void {
+  if (timer) {
+    clearTimeout(timer);
+    timer = null;
+  }
+  const secret = selfUpdateSecretLive();
+  const ms = selfUpdatePollMsLive();
+  if (secret && ms > 0) {
+    logger.info({ pollMs: ms, autoApply: selfUpdateAutoApplyLive(), branch: selfUpdateBranchLive() }, "Self-update poll scheduled");
+  }
+  scheduleNext();
+}
+
+export function stopSelfUpdatePoll(): void {
+  if (timer) {
+    clearTimeout(timer);
+    timer = null;
+  }
+}

--- a/src/services/self-update.service.ts
+++ b/src/services/self-update.service.ts
@@ -117,7 +117,7 @@ export async function applySelfUpdate(branch: string): Promise<SelfUpdateApplyRe
     await execFileAsync("bunx", ["prisma", "generate"], { cwd: projectRoot });
     steps.push("prisma generate");
 
-    if (config.databaseUrl) {
+    if (process.env.DATABASE_URL?.trim()) {
       runPrismaSchemaSync({ mode: config.prismaSchemaSync });
       steps.push(`prisma schema sync (${config.prismaSchemaSync})`);
     } else {

--- a/src/services/self-update.service.ts
+++ b/src/services/self-update.service.ts
@@ -1,0 +1,142 @@
+import { createHash, timingSafeEqual } from "crypto";
+import { existsSync } from "fs";
+import { join } from "path";
+import { spawn } from "child_process";
+import { execFileAsync } from "../utils/exec";
+import { projectRoot } from "../utils/paths";
+import { config } from "../config/env";
+import { logger } from "../utils/logger";
+import { runPrismaSchemaSync } from "../utils/prisma-schema-sync";
+
+let applyBusy = false;
+
+export interface SelfUpdateStatus {
+  branch: string;
+  isGitRepo: boolean;
+  currentCommit: string;
+  remoteCommit: string | null;
+  behind: boolean;
+  message?: string;
+}
+
+export interface SelfUpdateApplyResult {
+  ok: boolean;
+  steps: string[];
+  error?: string;
+}
+
+/** Constant-time string compare (length-independent via SHA-256). */
+export function selfUpdateTokensMatch(a: string, b: string): boolean {
+  const ha = createHash("sha256").update(a, "utf8").digest();
+  const hb = createHash("sha256").update(b, "utf8").digest();
+  return timingSafeEqual(ha, hb);
+}
+
+function ecosystemPath(): string {
+  return join(projectRoot, "ecosystem.config.cjs");
+}
+
+function schedulePm2Reload(): void {
+  const child = spawn("pm2", ["reload", ecosystemPath(), "--update-env"], {
+    cwd: projectRoot,
+    detached: true,
+    stdio: "ignore",
+    env: process.env,
+  });
+  child.unref();
+}
+
+/**
+ * Compare local HEAD to origin/{branch} after `git fetch origin {branch}`.
+ */
+export async function getSelfUpdateStatus(branch: string): Promise<SelfUpdateStatus> {
+  const gitDir = join(projectRoot, ".git");
+  if (!existsSync(gitDir)) {
+    return {
+      branch,
+      isGitRepo: false,
+      currentCommit: "",
+      remoteCommit: null,
+      behind: false,
+      message: "This install is not a git clone — use your package or image pipeline to update.",
+    };
+  }
+
+  try {
+    const headOut = await execFileAsync("git", ["rev-parse", "HEAD"], { cwd: projectRoot });
+    const head = headOut.stdout.trim();
+    await execFileAsync("git", ["fetch", "origin", branch], { cwd: projectRoot });
+    const remoteOut = await execFileAsync("git", ["rev-parse", `origin/${branch}`], { cwd: projectRoot });
+    const remote = remoteOut.stdout.trim();
+    return {
+      branch,
+      isGitRepo: true,
+      currentCommit: head,
+      remoteCommit: remote,
+      behind: head !== remote,
+    };
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    logger.warn({ err: msg, branch }, "Self-update: status check failed");
+    return {
+      branch,
+      isGitRepo: true,
+      currentCommit: "",
+      remoteCommit: null,
+      behind: false,
+      message: msg,
+    };
+  }
+}
+
+/**
+ * Fast-forward merge from origin, install deps, prisma generate + migrate, build dashboard, then PM2 reload (detached).
+ */
+export async function applySelfUpdate(branch: string): Promise<SelfUpdateApplyResult> {
+  const gitDir = join(projectRoot, ".git");
+  if (!existsSync(gitDir)) {
+    return { ok: false, steps: [], error: "Not a git repository" };
+  }
+  if (applyBusy) {
+    return { ok: false, steps: [], error: "Update already in progress" };
+  }
+
+  applyBusy = true;
+  const steps: string[] = [];
+
+  try {
+    await execFileAsync("git", ["fetch", "origin", branch], { cwd: projectRoot });
+    steps.push(`git fetch origin ${branch}`);
+
+    await execFileAsync("git", ["merge", "--ff-only", `origin/${branch}`], { cwd: projectRoot });
+    steps.push(`git merge --ff-only origin/${branch}`);
+
+    await execFileAsync("bun", ["install"], { cwd: projectRoot });
+    steps.push("bun install");
+
+    await execFileAsync("bunx", ["prisma", "generate"], { cwd: projectRoot });
+    steps.push("prisma generate");
+
+    if (config.databaseUrl) {
+      runPrismaSchemaSync({ mode: config.prismaSchemaSync });
+      steps.push(`prisma schema sync (${config.prismaSchemaSync})`);
+    } else {
+      steps.push("prisma schema sync (skipped — no DATABASE_URL)");
+    }
+
+    await execFileAsync("bun", ["run", "build"], { cwd: projectRoot });
+    steps.push("bun run build");
+
+    schedulePm2Reload();
+    steps.push("pm2 reload (detached)");
+
+    logger.info({ branch, steps }, "Self-update completed — PM2 reload scheduled");
+    return { ok: true, steps };
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    logger.error({ err: msg, branch, steps }, "Self-update failed");
+    return { ok: false, steps, error: msg };
+  } finally {
+    applyBusy = false;
+  }
+}

--- a/src/utils/cookie.ts
+++ b/src/utils/cookie.ts
@@ -1,0 +1,39 @@
+const COOKIE_NAME = "vg_session";
+
+export function parseCookies(header: string | undefined): Record<string, string> {
+  const out: Record<string, string> = {};
+  if (!header) return out;
+  for (const part of header.split(";")) {
+    const idx = part.indexOf("=");
+    if (idx === -1) continue;
+    const k = part.slice(0, idx).trim();
+    const v = part.slice(idx + 1).trim();
+    if (k) out[k] = decodeURIComponent(v);
+  }
+  return out;
+}
+
+export function getSessionTokenFromRequest(cookieHeader: string | undefined): string | undefined {
+  const c = parseCookies(cookieHeader)[COOKIE_NAME];
+  return c?.length ? c : undefined;
+}
+
+export function buildSetSessionCookie(token: string, maxAgeSec: number, secure: boolean): string {
+  const parts = [
+    `${COOKIE_NAME}=${encodeURIComponent(token)}`,
+    "Path=/",
+    "HttpOnly",
+    "SameSite=Lax",
+    `Max-Age=${maxAgeSec}`,
+ ];
+  if (secure) parts.push("Secure");
+  return parts.join("; ");
+}
+
+export function buildClearSessionCookie(secure: boolean): string {
+  const parts = [`${COOKIE_NAME}=`, "Path=/", "HttpOnly", "SameSite=Lax", "Max-Age=0"];
+  if (secure) parts.push("Secure");
+  return parts.join("; ");
+}
+
+export { COOKIE_NAME };

--- a/src/utils/exec.ts
+++ b/src/utils/exec.ts
@@ -31,10 +31,13 @@ export async function execAsync(command: string): Promise<ExecResult> {
 export async function execFileAsync(
   cmd: string,
   args: string[],
-  extra?: Pick<ExecFileOptions, "env">
+  extra?: Pick<ExecFileOptions, "env" | "cwd">
 ): Promise<ExecResult> {
   try {
     const opts: ExecFileOptions = { maxBuffer: 50 * 1024 * 1024 };
+    if (extra?.cwd) {
+      opts.cwd = extra.cwd;
+    }
     if (extra?.env) {
       opts.env = { ...process.env, ...extra.env };
     }

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -1,6 +1,5 @@
 import { logger } from "../utils/logger";
-import { config } from "../config/env";
-import prisma from "../prisma/client";
+import { disconnectPrisma } from "../prisma/client";
 import { appendLog, claimNextJob, failJob, recoverStuckJobs } from "../services/job-queue";
 import { runDeployJob } from "./handlers/deploy.handler";
 import { runRollbackJob } from "./handlers/rollback.handler";
@@ -79,7 +78,7 @@ async function main(): Promise<void> {
     if (inFlight) {
       await inFlight.catch(() => null);
     }
-    await prisma.$disconnect();
+    await disconnectPrisma();
     process.exit(0);
   };
 
@@ -89,7 +88,7 @@ async function main(): Promise<void> {
   await loop();
 }
 
-if (!config.databaseUrl?.trim()) {
+if (!process.env.DATABASE_URL?.trim()) {
   logger.warn(
     "DATABASE_URL not set — worker idle. Complete setup at /setup, then restart the worker (e.g. pm2 restart versiongate-worker)."
   );


### PR DESCRIPTION
## Summary

Improves how the **first dashboard administrator** is created and removes the post-setup refresh/restart confusion for the API when `DATABASE_URL` is applied from the setup wizard.

## Problem

- After saving setup, the API often still behaved as if the database was not configured until restart (`needsRestart`, double refresh).
- Operators upgrading or with an empty `User` table needed a clear path besides re-running the full setup wizard.
- No documented headless way to create the first user on the server.

## What changed

### Backend
- **`POST /setup/apply`** now requires `adminEmail` and `adminPassword`. After migrations it creates the first `User` + `Session`, sets `Set-Cookie`, updates `process.env.DATABASE_URL` / `ENCRYPTION_KEY`, reconnects Prisma, and runs **post-setup hooks** (container monitor + reconciliation) without requiring an API restart for the dashboard.
- **`GET /setup/status`**: `needsRestart` reflects `process.env.DATABASE_URL` in this process.
- **Auth, DB middleware, settings instance metadata, self-update migrate step**: use `process.env.DATABASE_URL?.trim()` where live wiring matters (avoids stale `config` snapshot from startup).
- **Prisma client**: lazy proxy + `reconnectPrismaAfterSetup` / `disconnectPrisma` for shutdown paths.
- **Worker**: `disconnectPrisma` on shutdown; DB gate uses `process.env.DATABASE_URL` (worker still needs restart after first setup if it started without DB).

### Dashboard
- **Setup**: admin email/password fields; redirect to `/` after success; toast mentions restarting the **worker** if deploy jobs do not run.
- **Login**: when the database is ready but **no users exist**, the page is clearly **Create first administrator** (bootstrap) and uses `POST /auth/register` (unchanged server rule: allowed only when user count is 0). When users exist, only **Sign in** is shown.
- **Layout**: header shows signed-in email.

### CLI
- **`bun run create-admin <email> <password>`**: creates the first user when the `User` table is empty (loads `.env` like the API). Use if you prefer SSH over the browser.

## After merge (operators)

1. `git pull`, `bun install`, `bun run build`, migrate if needed, **restart API + worker**.
2. **No users yet**: open **Login** — you should see **Create first administrator**, or run `bun run create-admin …` on the host.
3. **New install**: use **Setup** and fill admin fields there (cookie logs you in).

## Breaking change

Any automation that calls `POST /setup/apply` must send `adminEmail` and `adminPassword`.

## RiskLow for existing installs with users; empty-user DBs gain a clearer login + CLI path.


Made with [Cursor](https://cursor.com)