### PR TITLE
feat: Environment model — deployments scoped to environments

### DIFF
--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -83,7 +83,22 @@ export interface Deployment {
   color: string;
   status: DeploymentStatus;
   errorMessage?: string | null;
+  /** Derived from the parent environment for dashboard filtering */
   projectId: string;
+  environmentId?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface EnvironmentRow {
+  id: string;
+  name: string;
+  projectId: string;
+  branch: string;
+  serverHost: string;
+  basePort: number;
+  appPort: number;
+  lockedAt: string | null;
   createdAt: string;
   updatedAt: string;
 }
@@ -147,11 +162,18 @@ export function deleteProject(id: string): Promise<void> {
   return request("DELETE", `/projects/${id}`);
 }
 
-export function triggerDeploy(projectId: string): Promise<{ jobId: string; status: string }> {
-  return request("POST", "/deploy", { projectId });
+export function triggerDeploy(
+  projectId: string,
+  environmentId?: string
+): Promise<{ jobId: string; status: string; environmentId?: string }> {
+  return request("POST", "/deploy", { projectId, ...(environmentId ? { environmentId } : {}) });
 }
 
-export function rollback(projectId: string): Promise<{ jobId: string; status: string }> {
+export function listEnvironments(projectId: string): Promise<{ environments: EnvironmentRow[] }> {
+  return request("GET", `/projects/${projectId}/environments`);
+}
+
+export function rollback(projectId: string): Promise<{ jobId: string; status: string; environmentId?: string }> {
   return request("POST", `/projects/${projectId}/rollback`);
 }
 

--- a/prisma/migrations/20260419120000_environment_model/migration.sql
+++ b/prisma/migrations/20260419120000_environment_model/migration.sql
@@ -1,0 +1,58 @@
+-- CreateTable
+CREATE TABLE "Environment" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "projectId" TEXT NOT NULL,
+    "branch" TEXT NOT NULL,
+    "serverHost" TEXT NOT NULL DEFAULT 'localhost',
+    "basePort" INTEGER NOT NULL,
+    "appPort" INTEGER NOT NULL,
+    "lockedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Environment_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "Environment_projectId_name_key" ON "Environment"("projectId", "name");
+CREATE INDEX "Environment_projectId_idx" ON "Environment"("projectId");
+ALTER TABLE "Environment" ADD CONSTRAINT "Environment_projectId_fkey" FOREIGN KEY ("projectId") REFERENCES "Project"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- One default environment per project (production) — mirrors former project-level deploy target
+INSERT INTO "Environment" ("id", "name", "projectId", "branch", "serverHost", "basePort", "appPort", "lockedAt", "createdAt", "updatedAt")
+SELECT
+  'env_prod_' || "id",
+  'production',
+  "id",
+  "branch",
+  'localhost',
+  "basePort",
+  "appPort",
+  "lockedAt",
+  CURRENT_TIMESTAMP,
+  CURRENT_TIMESTAMP
+FROM "Project";
+
+ALTER TABLE "Project" DROP COLUMN IF EXISTS "lockedAt";
+
+-- Move deployments from Project to Environment
+ALTER TABLE "Deployment" ADD COLUMN "environmentId" TEXT;
+
+UPDATE "Deployment" AS d
+SET "environmentId" = e.id
+FROM "Environment" AS e
+WHERE e."projectId" = d."projectId" AND e.name = 'production';
+
+ALTER TABLE "Deployment" ALTER COLUMN "environmentId" SET NOT NULL;
+
+ALTER TABLE "Deployment" DROP CONSTRAINT "Deployment_projectId_fkey";
+DROP INDEX IF EXISTS "Deployment_projectId_idx";
+ALTER TABLE "Deployment" DROP COLUMN "projectId";
+
+CREATE INDEX "Deployment_environmentId_idx" ON "Deployment"("environmentId");
+ALTER TABLE "Deployment" ADD CONSTRAINT "Deployment_environmentId_fkey" FOREIGN KEY ("environmentId") REFERENCES "Environment"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- Optional job → environment link (filled for new deploy/rollback jobs)
+ALTER TABLE "Job" ADD COLUMN "environmentId" TEXT;
+CREATE INDEX "Job_environmentId_idx" ON "Job"("environmentId");
+ALTER TABLE "Job" ADD CONSTRAINT "Job_environmentId_fkey" FOREIGN KEY ("environmentId") REFERENCES "Environment"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -41,24 +41,43 @@ model Session {
 }
 
 model Project {
-  id          String       @id @default(cuid())
-  name        String       @unique
+  id          String        @id @default(cuid())
+  name        String        @unique
   repoUrl     String
-  branch      String       @default("main")
+  branch      String        @default("main")
   localPath   String
   appPort     Int
-  healthPath  String       @default("/health")
+  healthPath  String        @default("/health")
   basePort    Int
-  buildContext  String       @default(".")
+  buildContext  String      @default(".")
   webhookSecret String?     @unique
   env           Json        @default("{}")
-  lockedAt      DateTime?
-  createdAt   DateTime     @default(now())
-  updatedAt   DateTime     @updatedAt
-  deployments Deployment[]
+  createdAt   DateTime      @default(now())
+  updatedAt   DateTime      @updatedAt
+  environments Environment[]
   jobs        Job[]
 
   @@index([name])
+}
+
+/// Runtime target for deployments (e.g. production). Blueprint for staging/dev in later sprint work.
+model Environment {
+  id          String   @id @default(cuid())
+  name        String
+  projectId   String
+  project     Project  @relation(fields: [projectId], references: [id], onDelete: Cascade)
+  branch      String
+  serverHost  String   @default("localhost")
+  basePort    Int
+  appPort     Int
+  lockedAt    DateTime?
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+  deployments Deployment[]
+  jobs        Job[]
+
+  @@unique([projectId, name])
+  @@index([projectId])
 }
 
 // Run after schema changes: bunx prisma migrate dev --name add_job_queue
@@ -68,6 +87,8 @@ model Job {
   status       String    @default("PENDING") // PENDING, RUNNING, COMPLETE, FAILED, CANCELLED
   projectId    String
   project      Project   @relation(fields: [projectId], references: [id], onDelete: Cascade)
+  environmentId String?
+  environment   Environment? @relation(fields: [environmentId], references: [id], onDelete: SetNull)
   deploymentId String?
   payload      Json
   result       Json?
@@ -79,6 +100,7 @@ model Job {
   updatedAt    DateTime  @updatedAt
 
   @@index([projectId])
+  @@index([environmentId])
   @@index([status])
 }
 
@@ -91,12 +113,12 @@ model Deployment {
   color         DeploymentColor
   status        DeploymentStatus @default(PENDING)
   errorMessage  String?
-  projectId     String
-  project       Project          @relation(fields: [projectId], references: [id])
+  environmentId String
+  environment   Environment      @relation(fields: [environmentId], references: [id], onDelete: Cascade)
   createdAt     DateTime         @default(now())
   updatedAt     DateTime         @updatedAt
 
   @@index([status])
   @@index([createdAt])
-  @@index([projectId])
+  @@index([environmentId])
 }

--- a/src/controllers/deployment.controller.ts
+++ b/src/controllers/deployment.controller.ts
@@ -2,21 +2,43 @@ import { FastifyRequest, FastifyReply } from "fastify";
 import { DeploymentService } from "../services/deployment.service";
 import { enqueueJob } from "../services/job-queue";
 import { logger } from "../utils/logger";
+import { EnvironmentRepository, DEFAULT_ENVIRONMENT_NAME } from "../repositories/environment.repository";
 
 const deploymentService = new DeploymentService();
+const envRepo = new EnvironmentRepository();
 
 interface DeployBody {
   projectId: string;
+  environmentId?: string;
+}
+
+async function resolveEnvironmentId(projectId: string, environmentId?: string): Promise<string | null> {
+  if (environmentId) {
+    const env = await envRepo.findById(environmentId);
+    if (!env || env.projectId !== projectId) return null;
+    return env.id;
+  }
+  const def = await envRepo.findDefaultForProject(projectId);
+  return def?.id ?? null;
 }
 
 export async function deployHandler(
   req: FastifyRequest<{ Body: DeployBody }>,
   reply: FastifyReply
 ): Promise<void> {
-  const { projectId } = req.body;
-  const jobId = await enqueueJob("DEPLOY", projectId, {});
-  logger.info({ projectId, jobId }, "API: deploy enqueued");
-  reply.code(202).send({ jobId, status: "PENDING" });
+  const { projectId, environmentId: bodyEnvId } = req.body;
+  const resolved = await resolveEnvironmentId(projectId, bodyEnvId);
+  if (!resolved) {
+    return reply.code(400).send({
+      error: "ValidationError",
+      message: bodyEnvId
+        ? `Environment not found or does not belong to project`
+        : `Project has no "${DEFAULT_ENVIRONMENT_NAME}" environment`,
+    });
+  }
+  const jobId = await enqueueJob("DEPLOY", projectId, {}, resolved);
+  logger.info({ projectId, environmentId: resolved, jobId }, "API: deploy enqueued");
+  reply.code(202).send({ jobId, status: "PENDING", environmentId: resolved });
 }
 
 export async function listDeploymentsHandler(

--- a/src/controllers/environment.controller.ts
+++ b/src/controllers/environment.controller.ts
@@ -1,0 +1,23 @@
+import { FastifyRequest, FastifyReply } from "fastify";
+import { ProjectRepository } from "../repositories/project.repository";
+import { EnvironmentRepository } from "../repositories/environment.repository";
+
+const projectRepo = new ProjectRepository();
+const envRepo = new EnvironmentRepository();
+
+interface ProjectParams {
+  id: string;
+}
+
+export async function listEnvironmentsHandler(
+  req: FastifyRequest<{ Params: ProjectParams }>,
+  reply: FastifyReply
+): Promise<void> {
+  const project = await projectRepo.findById(req.params.id);
+  if (!project) {
+    return reply.code(404).send({ error: "NotFound", message: "Project not found" });
+  }
+
+  const environments = await envRepo.findAllForProject(req.params.id);
+  reply.code(200).send({ environments });
+}

--- a/src/controllers/metrics.controller.ts
+++ b/src/controllers/metrics.controller.ts
@@ -1,11 +1,13 @@
 import { FastifyRequest, FastifyReply } from "fastify";
 import { DeploymentRepository } from "../repositories/deployment.repository";
 import { ProjectRepository } from "../repositories/project.repository";
+import { EnvironmentRepository } from "../repositories/environment.repository";
 import { getContainerStats, getContainerLogs } from "../utils/docker";
 import { logger } from "../utils/logger";
 
 const deploymentRepo = new DeploymentRepository();
 const projectRepo = new ProjectRepository();
+const envRepo = new EnvironmentRepository();
 
 interface ProjectParams {
   id: string;
@@ -58,7 +60,8 @@ export async function getProjectMetricsHandler(
     return reply.code(404).send({ error: "NotFound", message: "Project not found" });
   }
 
-  const active = await deploymentRepo.findActiveForProject(req.params.id);
+  const defaultEnv = await envRepo.findDefaultForProject(req.params.id);
+  const active = defaultEnv ? await deploymentRepo.findActiveForEnvironment(defaultEnv.id) : null;
   if (!active) {
     return reply.code(200).send({ ...EMPTY_METRICS, timestamp: new Date().toISOString() });
   }
@@ -101,8 +104,12 @@ export async function getProjectLogsHandler(
 
   // Prefer the active deployment; fall back to the most recent one of any
   // status so failed container logs are still visible in the dashboard.
-  const active = await deploymentRepo.findActiveForProject(req.params.id);
-  const target = active ?? (await deploymentRepo.findAllForProject(req.params.id))[0] ?? null;
+  const defaultEnv = await envRepo.findDefaultForProject(req.params.id);
+  const active = defaultEnv ? await deploymentRepo.findActiveForEnvironment(defaultEnv.id) : null;
+  const target =
+    active ??
+    (defaultEnv ? (await deploymentRepo.findAllForEnvironment(defaultEnv.id))[0] : null) ??
+    null;
 
   if (!target) {
     return reply.code(200).send({ lines: [], containerName: null });

--- a/src/controllers/project.controller.ts
+++ b/src/controllers/project.controller.ts
@@ -3,6 +3,7 @@ import path from "path";
 import { randomBytes } from "crypto";
 import { ProjectRepository } from "../repositories/project.repository";
 import { DeploymentRepository } from "../repositories/deployment.repository";
+import { EnvironmentRepository } from "../repositories/environment.repository";
 import { freeHostPort, removeContainer, stopContainer } from "../utils/docker";
 import { enqueueJob } from "../services/job-queue";
 import { config } from "../config/env";
@@ -11,6 +12,7 @@ import { validateEnvObject } from "../utils/env";
 
 const projectRepo = new ProjectRepository();
 const deploymentRepo = new DeploymentRepository();
+const envRepo = new EnvironmentRepository();
 
 interface CreateProjectBody {
   name: string;
@@ -129,9 +131,16 @@ export async function rollbackProjectHandler(
   reply: FastifyReply
 ): Promise<void> {
   const projectId = req.params.id;
-  const jobId = await enqueueJob("ROLLBACK", projectId, {});
-  logger.info({ projectId, jobId }, "API: rollback enqueued");
-  reply.code(202).send({ jobId, status: "PENDING" });
+  const defaultEnv = await envRepo.findDefaultForProject(projectId);
+  if (!defaultEnv) {
+    return reply.code(400).send({
+      error: "ValidationError",
+      message: "Project has no default environment",
+    });
+  }
+  const jobId = await enqueueJob("ROLLBACK", projectId, {}, defaultEnv.id);
+  logger.info({ projectId, environmentId: defaultEnv.id, jobId }, "API: rollback enqueued");
+  reply.code(202).send({ jobId, status: "PENDING", environmentId: defaultEnv.id });
 }
 
 export async function updateProjectHandler(

--- a/src/controllers/webhook.controller.ts
+++ b/src/controllers/webhook.controller.ts
@@ -1,9 +1,11 @@
 import { FastifyRequest, FastifyReply } from "fastify";
 import { ProjectRepository } from "../repositories/project.repository";
+import { EnvironmentRepository } from "../repositories/environment.repository";
 import { enqueueJob } from "../services/job-queue";
 import { logger } from "../utils/logger";
 
 const projectRepo = new ProjectRepository();
+const envRepo = new EnvironmentRepository();
 
 interface WebhookParams {
   secret: string;
@@ -36,14 +38,29 @@ export async function githubWebhookHandler(
   // Only deploy when pushed to the configured branch
   const ref = req.body?.ref ?? "";
   const pushedBranch = ref.replace("refs/heads/", "");
-  if (pushedBranch && pushedBranch !== project.branch) {
-    logger.info({ projectId: project.id, pushedBranch, configuredBranch: project.branch }, "Webhook: branch mismatch — skipping");
-    return reply.code(200).send({ skipped: true, reason: `Push to '${pushedBranch}', project tracks '${project.branch}'` });
+  const defaultEnv = await envRepo.findDefaultForProject(project.id);
+  if (!defaultEnv) {
+    logger.error({ projectId: project.id }, "Webhook: no default environment — skipping deploy");
+    return reply.code(500).send({ error: "Misconfigured", message: "Project has no default environment" });
   }
 
-  logger.info({ projectId: project.id, projectName: project.name, ref }, "Webhook: triggering auto-deploy");
+  if (pushedBranch && pushedBranch !== defaultEnv.branch) {
+    logger.info(
+      { projectId: project.id, pushedBranch, configuredBranch: defaultEnv.branch },
+      "Webhook: branch mismatch — skipping"
+    );
+    return reply.code(200).send({
+      skipped: true,
+      reason: `Push to '${pushedBranch}', environment tracks '${defaultEnv.branch}'`,
+    });
+  }
 
-  enqueueJob("DEPLOY", project.id, {}).catch((err) => {
+  logger.info(
+    { projectId: project.id, projectName: project.name, environmentId: defaultEnv.id, ref },
+    "Webhook: triggering auto-deploy"
+  );
+
+  enqueueJob("DEPLOY", project.id, {}, defaultEnv.id).catch((err) => {
     logger.error({ projectId: project.id, err }, "Webhook: failed to enqueue deploy job");
   });
 

--- a/src/repositories/deployment.repository.ts
+++ b/src/repositories/deployment.repository.ts
@@ -10,34 +10,33 @@ export class DeploymentRepository {
     return prisma.deployment.findUnique({ where: { id } });
   }
 
-  // ── Project-scoped queries ─────────────────────────────────────────────────
+  // ── Environment-scoped queries ───────────────────────────────────────────
 
-  async findActiveForProject(projectId: string): Promise<Deployment | null> {
+  async findActiveForEnvironment(environmentId: string): Promise<Deployment | null> {
     return prisma.deployment.findFirst({
-      where: { projectId, status: DeploymentStatus.ACTIVE },
+      where: { environmentId, status: DeploymentStatus.ACTIVE },
       orderBy: { createdAt: "desc" },
     });
   }
 
-  async findDeployingForProject(projectId: string): Promise<Deployment | null> {
+  async findDeployingForEnvironment(environmentId: string): Promise<Deployment | null> {
     return prisma.deployment.findFirst({
-      where: { projectId, status: DeploymentStatus.DEPLOYING },
+      where: { environmentId, status: DeploymentStatus.DEPLOYING },
       orderBy: { createdAt: "desc" },
     });
   }
 
   /**
-   * Finds the most recently ROLLED_BACK deployment for a project whose version
-   * is strictly lower than the current active version. This ensures correct
-   * rollback targets even after multiple sequential deploy/rollback cycles.
+   * Finds the most recently ROLLED_BACK deployment for an environment whose version
+   * is strictly lower than the current active version.
    */
-  async findPreviousForProject(
-    projectId: string,
+  async findPreviousForEnvironment(
+    environmentId: string,
     currentVersion: number
   ): Promise<Deployment | null> {
     return prisma.deployment.findFirst({
       where: {
-        projectId,
+        environmentId,
         status: DeploymentStatus.ROLLED_BACK,
         version: { lt: currentVersion },
       },
@@ -45,16 +44,26 @@ export class DeploymentRepository {
     });
   }
 
-  async findAllForProject(projectId: string): Promise<Deployment[]> {
+  async findAllForEnvironment(environmentId: string): Promise<Deployment[]> {
     return prisma.deployment.findMany({
-      where: { projectId },
+      where: { environmentId },
       orderBy: { createdAt: "desc" },
     });
   }
 
-  async getNextVersionForProject(projectId: string): Promise<number> {
+  /** All deployments for a project (via environments). */
+  async findAllForProject(projectId: string): Promise<(Deployment & { projectId: string })[]> {
+    const rows = await prisma.deployment.findMany({
+      where: { environment: { projectId } },
+      include: { environment: { select: { projectId: true } } },
+      orderBy: { createdAt: "desc" },
+    });
+    return rows.map(({ environment, ...d }) => ({ ...d, projectId: environment.projectId }));
+  }
+
+  async getNextVersionForEnvironment(environmentId: string): Promise<number> {
     const latest = await prisma.deployment.findFirst({
-      where: { projectId },
+      where: { environmentId },
       orderBy: { version: "desc" },
       select: { version: true },
     });
@@ -63,25 +72,33 @@ export class DeploymentRepository {
 
   // ── Reconciliation queries ─────────────────────────────────────────────────
 
-  /** All deployments stuck mid-deploy — used by crash recovery on startup. */
   async findAllDeploying(): Promise<Deployment[]> {
     return prisma.deployment.findMany({ where: { status: DeploymentStatus.DEPLOYING } });
   }
 
-  /** All ACTIVE deployments with their project — used to audit container health. */
   async findAllActiveWithProjects(): Promise<(Deployment & { project: Project })[]> {
-    return prisma.deployment.findMany({
+    const rows = await prisma.deployment.findMany({
       where: { status: DeploymentStatus.ACTIVE },
-      include: { project: true },
-    }) as Promise<(Deployment & { project: Project })[]>;
+      include: {
+        environment: {
+          include: { project: true },
+        },
+      },
+    });
+    return rows.map((d) => {
+      const { environment, ...rest } = d;
+      return { ...rest, project: environment.project };
+    }) as (Deployment & { project: Project })[];
   }
 
-  // ── Global queries (kept for status endpoint) ──────────────────────────────
+  // ── Global queries (kept for status endpoint) ────────────────────────────
 
-  async findAll(): Promise<Deployment[]> {
-    return prisma.deployment.findMany({
+  async findAll(): Promise<(Deployment & { projectId: string })[]> {
+    const rows = await prisma.deployment.findMany({
+      include: { environment: { select: { projectId: true } } },
       orderBy: { createdAt: "desc" },
     });
+    return rows.map(({ environment, ...d }) => ({ ...d, projectId: environment.projectId }));
   }
 
   async updateStatus(

--- a/src/repositories/environment.repository.ts
+++ b/src/repositories/environment.repository.ts
@@ -1,0 +1,59 @@
+import { Environment, DeploymentStatus } from "@prisma/client";
+import prisma from "../prisma/client";
+
+const DEFAULT_ENV_NAME = "production";
+
+export const DEFAULT_ENVIRONMENT_NAME = DEFAULT_ENV_NAME;
+
+export class EnvironmentRepository {
+  async findById(id: string): Promise<Environment | null> {
+    return prisma.environment.findUnique({ where: { id } });
+  }
+
+  async findDefaultForProject(projectId: string): Promise<Environment | null> {
+    return prisma.environment.findFirst({
+      where: { projectId, name: DEFAULT_ENV_NAME },
+    });
+  }
+
+  async findByProjectAndName(projectId: string, name: string): Promise<Environment | null> {
+    return prisma.environment.findUnique({
+      where: { projectId_name: { projectId, name } },
+    });
+  }
+
+  async findAllForProject(projectId: string): Promise<Environment[]> {
+    return prisma.environment.findMany({
+      where: { projectId },
+      orderBy: { createdAt: "asc" },
+    });
+  }
+
+  async acquireDeployLock(id: string): Promise<boolean> {
+    const { count } = await prisma.environment.updateMany({
+      where: { id, lockedAt: null },
+      data: { lockedAt: new Date() },
+    });
+    return count === 1;
+  }
+
+  async releaseDeployLock(id: string): Promise<void> {
+    await prisma.environment.updateMany({
+      where: { id },
+      data: { lockedAt: null },
+    });
+  }
+
+  async clearStaleDeployLocks(): Promise<number> {
+    const { count } = await prisma.environment.updateMany({
+      where: {
+        lockedAt: { not: null },
+        deployments: {
+          none: { status: DeploymentStatus.DEPLOYING },
+        },
+      },
+      data: { lockedAt: null },
+    });
+    return count;
+  }
+}

--- a/src/repositories/project.repository.ts
+++ b/src/repositories/project.repository.ts
@@ -1,11 +1,25 @@
-import { DeploymentStatus, Project, Prisma } from "@prisma/client";
+import { Project, Prisma } from "@prisma/client";
 import prisma from "../prisma/client";
 import { encrypt } from "../utils/crypto";
 import { decryptProjectEnv, parseProjectEnv } from "../utils/env";
+import { DEFAULT_ENVIRONMENT_NAME } from "./environment.repository";
 
 export class ProjectRepository {
   async create(data: Prisma.ProjectCreateInput): Promise<Project> {
-    const project = await prisma.project.create({ data: this.prepareCreateData(data) });
+    const project = await prisma.$transaction(async (tx) => {
+      const created = await tx.project.create({ data: this.prepareCreateData(data) });
+      await tx.environment.create({
+        data: {
+          name: DEFAULT_ENVIRONMENT_NAME,
+          projectId: created.id,
+          branch: created.branch,
+          serverHost: "localhost",
+          basePort: created.basePort,
+          appPort: created.appPort,
+        },
+      });
+      return created;
+    });
     return this.hydrateProject(project);
   }
 
@@ -52,40 +66,8 @@ export class ProjectRepository {
   }
 
   async delete(id: string): Promise<Project> {
-    await prisma.job.deleteMany({ where: { projectId: id } });
-    await prisma.deployment.deleteMany({ where: { projectId: id } });
     const project = await prisma.project.delete({ where: { id } });
     return this.hydrateProject(project);
-  }
-
-  async acquireDeployLock(id: string): Promise<boolean> {
-    const { count } = await prisma.project.updateMany({
-      where: { id, lockedAt: null } as Prisma.ProjectWhereInput,
-      data: { lockedAt: new Date() } as Prisma.ProjectUpdateManyMutationInput,
-    });
-
-    return count === 1;
-  }
-
-  async releaseDeployLock(id: string): Promise<void> {
-    await prisma.project.updateMany({
-      where: { id },
-      data: { lockedAt: null } as Prisma.ProjectUpdateManyMutationInput,
-    });
-  }
-
-  async clearStaleDeployLocks(): Promise<number> {
-    const { count } = await prisma.project.updateMany({
-      where: {
-        lockedAt: { not: null },
-        deployments: {
-          none: { status: DeploymentStatus.DEPLOYING },
-        },
-      } as Prisma.ProjectWhereInput,
-      data: { lockedAt: null } as Prisma.ProjectUpdateManyMutationInput,
-    });
-
-    return count;
   }
 
   private prepareCreateData(data: Prisma.ProjectCreateInput): Prisma.ProjectCreateInput {

--- a/src/routes/deployment.routes.ts
+++ b/src/routes/deployment.routes.ts
@@ -11,6 +11,7 @@ const deployBodySchema = {
   required: ["projectId"],
   properties: {
     projectId: { type: "string", minLength: 1 },
+    environmentId: { type: "string", minLength: 1 },
   },
   additionalProperties: false,
 };
@@ -25,7 +26,7 @@ const deploymentSchema = {
     port: { type: "number" },
     color: { type: "string" },
     status: { type: "string" },
-    projectId: { type: "string" },
+    environmentId: { type: "string" },
     createdAt: { type: "string" },
     updatedAt: { type: "string" },
   },
@@ -41,6 +42,7 @@ export async function deploymentRoutes(app: FastifyInstance): Promise<void> {
           properties: {
             jobId: { type: "string" },
             status: { type: "string" },
+            environmentId: { type: "string" },
           },
         },
       },

--- a/src/routes/project.routes.ts
+++ b/src/routes/project.routes.ts
@@ -9,6 +9,7 @@ import {
   updateProjectEnvHandler,
   generatePipelineHandler,
 } from "../controllers/project.controller";
+import { listEnvironmentsHandler } from "../controllers/environment.controller";
 
 const envSchema = {
   type: "object",
@@ -82,6 +83,36 @@ export async function projectRoutes(app: FastifyInstance): Promise<void> {
       },
     },
     handler: listProjectsHandler,
+  });
+
+  const environmentSchema = {
+    type: "object",
+    properties: {
+      id: { type: "string" },
+      name: { type: "string" },
+      projectId: { type: "string" },
+      branch: { type: "string" },
+      serverHost: { type: "string" },
+      basePort: { type: "number" },
+      appPort: { type: "number" },
+      lockedAt: { type: "string", nullable: true },
+      createdAt: { type: "string" },
+      updatedAt: { type: "string" },
+    },
+  };
+
+  app.get("/projects/:id/environments", {
+    schema: {
+      response: {
+        200: {
+          type: "object",
+          properties: {
+            environments: { type: "array", items: environmentSchema },
+          },
+        },
+      },
+    },
+    handler: listEnvironmentsHandler,
   });
 
   app.get("/projects/:id", {
@@ -158,6 +189,7 @@ export async function projectRoutes(app: FastifyInstance): Promise<void> {
           properties: {
             jobId: { type: "string" },
             status: { type: "string" },
+            environmentId: { type: "string" },
           },
         },
       },

--- a/src/services/deployment.service.ts
+++ b/src/services/deployment.service.ts
@@ -3,6 +3,7 @@ import { config } from "../config/env";
 import { parseProjectEnv } from "../utils/env";
 import { DeploymentRepository } from "../repositories/deployment.repository";
 import { ProjectRepository } from "../repositories/project.repository";
+import { EnvironmentRepository } from "../repositories/environment.repository";
 import { buildImage, runContainer, stopContainer, removeContainer, freeHostPort } from "../utils/docker";
 import { ensureDockerfile } from "../utils/dockerfile";
 import { logger } from "../utils/logger";
@@ -12,6 +13,7 @@ import { GitService } from "./git.service";
 
 export interface DeployOptions {
   projectId: string;
+  environmentId: string;
 }
 
 export interface DeployResult {
@@ -20,79 +22,69 @@ export interface DeployResult {
 }
 
 export class DeploymentService {
-  // Projects for which a cancel has been requested mid-deploy
   private static readonly cancelRequests = new Set<string>();
 
   private readonly repo: DeploymentRepository;
   private readonly projectRepo: ProjectRepository;
+  private readonly envRepo: EnvironmentRepository;
   private readonly traffic: TrafficService;
   private readonly git: GitService;
 
   constructor() {
     this.repo = new DeploymentRepository();
     this.projectRepo = new ProjectRepository();
+    this.envRepo = new EnvironmentRepository();
     this.traffic = new TrafficService();
     this.git = new GitService();
   }
 
-  /**
-   * Full blue-green deployment pipeline:
-   * 1. Acquire per-project lock
-   * 2. Fetch project config
-   * 3. Clone/pull source via Git
-   * 4. Build Docker image from source
-   * 5. Determine color (BLUE/GREEN) and port
-   * 6. Start new container
-   * 7. Switch Nginx traffic
-   * 8. Mark new ACTIVE, retire old
-   * 9. Release lock (always — via finally)
-   */
   async deploy(opts: DeployOptions): Promise<DeployResult> {
-    const { projectId } = opts;
+    const { projectId, environmentId } = opts;
 
     const project = await this.projectRepo.findById(projectId);
     if (!project) {
       throw new NotFoundError(`Project ${projectId}`);
     }
 
-    if (!(await this.acquireLock(projectId))) {
-      throw new ConflictError(`Deployment already in progress for project ${projectId}`);
+    const envRow = await this.envRepo.findById(environmentId);
+    if (!envRow || envRow.projectId !== projectId) {
+      throw new NotFoundError(`Environment ${environmentId}`);
+    }
+
+    if (!(await this.acquireLock(environmentId))) {
+      throw new ConflictError(`Deployment already in progress for environment ${environmentId}`);
     }
 
     let deploymentId: string | undefined;
 
     try {
-      logger.info({ projectId, name: project.name }, "Starting deployment pipeline");
+      logger.info({ projectId, environmentId, name: project.name }, "Starting deployment pipeline");
 
-      // ── Step 1: Prepare source ─────────────────────────────────────────────
-      logger.info({ projectId, step: 1 }, "Preparing source code");
+      logger.info({ projectId, environmentId, step: 1 }, "Preparing source code");
       await this.git.prepareSource(project);
-      this.checkCancelled(projectId);
+      this.checkCancelled(environmentId);
       const repoRoot = this.git.projectPath(project);
       const buildContextPath = await ensureDockerfile(
         this.git.buildContextPath(project),
-        project.appPort,
+        envRow.appPort,
         repoRoot
       );
 
-      // ── Step 2: Determine color and port ───────────────────────────────────
-      const activeDeployment = await this.repo.findActiveForProject(projectId);
+      const activeDeployment = await this.repo.findActiveForEnvironment(environmentId);
       const newColor =
         activeDeployment?.color === DeploymentColor.BLUE
           ? DeploymentColor.GREEN
           : DeploymentColor.BLUE;
-      const hostPort =
-        newColor === DeploymentColor.BLUE ? project.basePort : project.basePort + 1;
-      const containerName = `${project.name}-${newColor.toLowerCase()}`;
+      const hostPort = newColor === DeploymentColor.BLUE ? envRow.basePort : envRow.basePort + 1;
+      const containerName = `${project.name}-${envRow.name}-${newColor.toLowerCase()}`;
       const imageTag = `versiongate-${project.name}:${Date.now()}`;
-      const version = await this.repo.getNextVersionForProject(projectId);
+      const version = await this.repo.getNextVersionForEnvironment(environmentId);
 
       logger.info(
-        { projectId, step: 2, newColor, hostPort, containerName, imageTag },
+        { projectId, environmentId, step: 2, newColor, hostPort, containerName, imageTag },
         "Determined deployment target"
       );
 
-      // ── Step 3: Create DEPLOYING record ───────────────────────────────────
       const deployment = await this.repo.create({
         version,
         imageTag,
@@ -100,19 +92,15 @@ export class DeploymentService {
         port: hostPort,
         color: newColor,
         status: DeploymentStatus.DEPLOYING,
-        project: { connect: { id: projectId } },
+        environment: { connect: { id: environmentId } },
       });
       deploymentId = deployment.id;
 
-      // ── Step 4: Build image ────────────────────────────────────────────────
-      logger.info({ projectId, step: 4, imageTag, buildContextPath }, "Building Docker image");
+      logger.info({ projectId, environmentId, step: 4, imageTag, buildContextPath }, "Building Docker image");
       await buildImage(imageTag, buildContextPath);
-      this.checkCancelled(projectId);
+      this.checkCancelled(environmentId);
 
-      // ── Step 5: Start container ────────────────────────────────────────────
-      logger.info({ projectId, step: 5, containerName, hostPort }, "Starting container");
-      // Pre-cleanup: remove any stale container with the same name AND free the
-      // target port so we never hit "port already allocated".
+      logger.info({ projectId, environmentId, step: 5, containerName, hostPort }, "Starting container");
       await stopContainer(containerName).catch(() => null);
       await removeContainer(containerName).catch(() => null);
       await freeHostPort(hostPort);
@@ -125,22 +113,20 @@ export class DeploymentService {
         containerName,
         imageTag,
         hostPort,
-        project.appPort,
+        envRow.appPort,
         config.dockerNetwork,
         projectEnv
       );
-      this.checkCancelled(projectId);
+      this.checkCancelled(environmentId);
 
-      // ── Step 6: Switch traffic ─────────────────────────────────────────────
-      logger.info({ projectId, step: 6, hostPort }, "Switching traffic");
+      logger.info({ projectId, environmentId, step: 6, hostPort }, "Switching traffic");
       await this.traffic.switchTrafficTo(hostPort);
 
-      // ── Step 7: Activate new, retire old ──────────────────────────────────
       await this.repo.updateStatus(deployment.id, DeploymentStatus.ACTIVE);
 
       if (activeDeployment) {
         logger.info(
-          { projectId, step: 7, oldContainer: activeDeployment.containerName },
+          { projectId, environmentId, step: 7, oldContainer: activeDeployment.containerName },
           "Stopping old container"
         );
         await stopContainer(activeDeployment.containerName).catch((err) => {
@@ -153,7 +139,7 @@ export class DeploymentService {
       }
 
       logger.info(
-        { projectId, deploymentId: deployment.id, containerName },
+        { projectId, environmentId, deploymentId: deployment.id, containerName },
         "Deployment successful"
       );
 
@@ -162,7 +148,6 @@ export class DeploymentService {
         message: `Deployment successful — ${containerName} is live on port ${hostPort}`,
       };
     } catch (err) {
-      // Mark FAILED with the error message so the dashboard can display it
       if (deploymentId) {
         const errMsg = err instanceof Error ? err.message : String(err);
         await this.repo
@@ -171,46 +156,44 @@ export class DeploymentService {
       }
       throw err;
     } finally {
-      DeploymentService.cancelRequests.delete(projectId);
-      await this.releaseLock(projectId);
+      DeploymentService.cancelRequests.delete(environmentId);
+      await this.releaseLock(environmentId);
     }
   }
 
-  /**
-   * Requests cancellation of the in-progress deployment for a project.
-   * Marks the flag (so the pipeline throws on the next checkpoint) and
-   * stops the container immediately so health-check retries exit fast.
-   */
   async cancelDeploy(projectId: string): Promise<{ cancelled: boolean }> {
-    const deploying = await this.repo.findDeployingForProject(projectId);
+    const defaultEnv = await this.envRepo.findDefaultForProject(projectId);
+    if (!defaultEnv) {
+      throw new NotFoundError(`No default environment for project ${projectId}`);
+    }
+
+    const deploying = await this.repo.findDeployingForEnvironment(defaultEnv.id);
 
     if (!deploying) {
       throw new NotFoundError(`No in-progress deployment found for project ${projectId}`);
     }
 
-    // Signal the running pipeline to stop if this process is handling it.
-    DeploymentService.cancelRequests.add(projectId);
+    DeploymentService.cancelRequests.add(defaultEnv.id);
 
-    // Stop + remove the container regardless (handles stale DEPLOYING records too)
     if (deploying.containerName) {
       await stopContainer(deploying.containerName).catch(() => null);
       await removeContainer(deploying.containerName).catch(() => null);
     }
 
-    // Mark the deployment as FAILED so the UI unblocks
     await this.repo.updateStatus(deploying.id, DeploymentStatus.FAILED, "Cancelled by user").catch(() => null);
 
-    // Release the persisted lock so a fresh deploy can start.
-    await this.releaseLock(projectId);
-    DeploymentService.cancelRequests.delete(projectId);
+    await this.releaseLock(defaultEnv.id);
+    DeploymentService.cancelRequests.delete(defaultEnv.id);
 
-    logger.info({ projectId, deploymentId: deploying.id }, "Deployment cancelled");
+    logger.info({ projectId, environmentId: defaultEnv.id, deploymentId: deploying.id }, "Deployment cancelled");
     return { cancelled: true };
   }
 
   async getActiveDeployment(projectId?: string): Promise<Deployment | null> {
     if (projectId) {
-      return this.repo.findActiveForProject(projectId);
+      const env = await this.envRepo.findDefaultForProject(projectId);
+      if (!env) return null;
+      return this.repo.findActiveForEnvironment(env.id);
     }
     return this.repo.findAll().then((all) => all.find((d) => d.status === DeploymentStatus.ACTIVE) ?? null);
   }
@@ -222,26 +205,26 @@ export class DeploymentService {
     return this.repo.findAll();
   }
 
-  private checkCancelled(projectId: string): void {
-    if (DeploymentService.cancelRequests.has(projectId)) {
+  private checkCancelled(environmentId: string): void {
+    if (DeploymentService.cancelRequests.has(environmentId)) {
       throw new DeploymentError("Cancelled by user");
     }
   }
 
-  private async acquireLock(projectId: string): Promise<boolean> {
-    const acquired = await this.projectRepo.acquireDeployLock(projectId);
+  private async acquireLock(environmentId: string): Promise<boolean> {
+    const acquired = await this.envRepo.acquireDeployLock(environmentId);
 
     if (!acquired) {
-      logger.warn({ projectId }, "Deploy lock already held — rejecting concurrent deploy");
+      logger.warn({ environmentId }, "Deploy lock already held — rejecting concurrent deploy");
       return false;
     }
 
-    logger.info({ projectId }, "Deploy lock acquired");
+    logger.info({ environmentId }, "Deploy lock acquired");
     return true;
   }
 
-  private async releaseLock(projectId: string): Promise<void> {
-    await this.projectRepo.releaseDeployLock(projectId);
-    logger.info({ projectId }, "Deploy lock released");
+  private async releaseLock(environmentId: string): Promise<void> {
+    await this.envRepo.releaseDeployLock(environmentId);
+    logger.info({ environmentId }, "Deploy lock released");
   }
 }

--- a/src/services/job-queue.ts
+++ b/src/services/job-queue.ts
@@ -1,7 +1,9 @@
 import { Job, Prisma } from "@prisma/client";
 import prisma from "../prisma/client";
 
-export async function claimNextJob(): Promise<(Job & { project: import("@prisma/client").Project }) | null> {
+export async function claimNextJob(): Promise<
+  (Job & { project: import("@prisma/client").Project; environment: import("@prisma/client").Environment | null }) | null
+> {
   return prisma.$transaction(async (tx) => {
     const next = await tx.job.findFirst({
       where: { status: "PENDING" },
@@ -17,7 +19,7 @@ export async function claimNextJob(): Promise<(Job & { project: import("@prisma/
 
     const job = await tx.job.findUnique({
       where: { id: next.id },
-      include: { project: true },
+      include: { project: true, environment: true },
     });
     return job;
   });
@@ -62,12 +64,14 @@ export async function appendLog(jobId: string, line: string): Promise<void> {
 export async function enqueueJob(
   type: string,
   projectId: string,
-  payload: Record<string, unknown>
+  payload: Record<string, unknown>,
+  environmentId?: string
 ): Promise<string> {
   const job = await prisma.job.create({
     data: {
       type,
       projectId,
+      ...(environmentId ? { environmentId } : {}),
       payload: payload as Prisma.InputJsonValue,
     },
   });

--- a/src/services/reconciliation.service.ts
+++ b/src/services/reconciliation.service.ts
@@ -1,5 +1,5 @@
 import { DeploymentRepository } from "../repositories/deployment.repository";
-import { ProjectRepository } from "../repositories/project.repository";
+import { EnvironmentRepository } from "../repositories/environment.repository";
 import { stopContainer, removeContainer, inspectContainer } from "../utils/docker";
 import { DeploymentStatus } from "@prisma/client";
 import { logger } from "../utils/logger";
@@ -11,11 +11,11 @@ export interface ReconciliationReport {
 
 export class ReconciliationService {
   private readonly repo: DeploymentRepository;
-  private readonly projectRepo: ProjectRepository;
+  private readonly envRepo: EnvironmentRepository;
 
   constructor() {
     this.repo = new DeploymentRepository();
-    this.projectRepo = new ProjectRepository();
+    this.envRepo = new EnvironmentRepository();
   }
 
   /**
@@ -34,7 +34,7 @@ export class ReconciliationService {
     logger.info("Starting startup reconciliation");
 
     const deployingFixed = await this.fixDeployingDeployments();
-    const staleLocksCleared = await this.projectRepo.clearStaleDeployLocks();
+    const staleLocksCleared = await this.envRepo.clearStaleDeployLocks();
     const activeInvalidated = await this.auditActiveDeployments();
 
     logger.info(
@@ -52,7 +52,7 @@ export class ReconciliationService {
 
     for (const d of deploying) {
       logger.warn(
-        { deploymentId: d.id, containerName: d.containerName, projectId: d.projectId },
+        { deploymentId: d.id, containerName: d.containerName, environmentId: d.environmentId },
         "Recovering crashed deployment"
       );
       await stopContainer(d.containerName).catch(() => null);
@@ -77,14 +77,14 @@ export class ReconciliationService {
         running = await inspectContainer(d.containerName);
       } catch (err) {
         logger.warn(
-          { err, deploymentId: d.id, containerName: d.containerName, projectId: d.projectId },
+          { err, deploymentId: d.id, containerName: d.containerName, environmentId: d.environmentId },
           "Reconciliation: docker inspect failed — skipping this deployment (will retry on next startup)"
         );
         continue;
       }
       if (!running) {
         logger.warn(
-          { deploymentId: d.id, containerName: d.containerName, projectId: d.projectId },
+          { deploymentId: d.id, containerName: d.containerName, environmentId: d.environmentId },
           "ACTIVE deployment container is not running — marking FAILED"
         );
         await this.repo

--- a/src/services/rollback.service.ts
+++ b/src/services/rollback.service.ts
@@ -2,6 +2,7 @@ import { Deployment, DeploymentStatus } from "@prisma/client";
 import { parseProjectEnv } from "../utils/env";
 import { DeploymentRepository } from "../repositories/deployment.repository";
 import { ProjectRepository } from "../repositories/project.repository";
+import { EnvironmentRepository } from "../repositories/environment.repository";
 import { TrafficService } from "./traffic.service";
 import { ValidationService } from "./validation.service";
 import { runContainer, stopContainer, removeContainer } from "../utils/docker";
@@ -18,40 +19,37 @@ export interface RollbackResult {
 export class RollbackService {
   private readonly repo: DeploymentRepository;
   private readonly projectRepo: ProjectRepository;
+  private readonly envRepo: EnvironmentRepository;
   private readonly traffic: TrafficService;
   private readonly validation: ValidationService;
 
   constructor() {
     this.repo = new DeploymentRepository();
     this.projectRepo = new ProjectRepository();
+    this.envRepo = new EnvironmentRepository();
     this.traffic = new TrafficService();
     this.validation = new ValidationService();
   }
 
-  /**
-   * Rolls back a project to its previous deployment:
-   * 1. Find the current ACTIVE deployment for the project.
-   * 2. Find the most recent ROLLED_BACK deployment with a lower version.
-   * 3. Restart the old container (it was stopped when superseded).
-   * 4. Validate the restarted container.
-   * 5. Switch traffic back to the old port.
-   * 6. Stop and remove the current container.
-   * 7. Update DB statuses.
-   */
-  async rollback(projectId: string): Promise<RollbackResult> {
-    logger.info({ projectId }, "Initiating rollback");
+  async rollback(projectId: string, environmentId: string): Promise<RollbackResult> {
+    logger.info({ projectId, environmentId }, "Initiating rollback");
 
     const project = await this.projectRepo.findById(projectId);
     if (!project) {
       throw new NotFoundError(`Project ${projectId}`);
     }
 
-    const current = await this.repo.findActiveForProject(projectId);
+    const envRow = await this.envRepo.findById(environmentId);
+    if (!envRow || envRow.projectId !== projectId) {
+      throw new NotFoundError(`Environment ${environmentId}`);
+    }
+
+    const current = await this.repo.findActiveForEnvironment(environmentId);
     if (!current) {
       throw new BadRequestError("No active deployment to roll back from");
     }
 
-    const previous = await this.repo.findPreviousForProject(projectId, current.version);
+    const previous = await this.repo.findPreviousForEnvironment(environmentId, current.version);
     if (!previous) {
       throw new BadRequestError("No previous deployment available for rollback");
     }
@@ -61,11 +59,10 @@ export class RollbackService {
     }
 
     logger.info(
-      { projectId, from: current.containerName, to: previous.containerName },
+      { projectId, environmentId, from: current.containerName, to: previous.containerName },
       "Rolling back"
     );
 
-    // Restart the old container using stored imageTag and port
     logger.info({ containerName: previous.containerName }, "Restarting previous container");
     const projectEnv = parseProjectEnv(project.env);
     const envKeys = Object.keys(projectEnv);
@@ -76,12 +73,11 @@ export class RollbackService {
       previous.containerName,
       previous.imageTag,
       previous.port,
-      project.appPort,
+      envRow.appPort,
       config.dockerNetwork,
       projectEnv
     );
 
-    // Validate the restarted container before switching traffic
     const result = await this.validation.validate(
       `http://localhost:${previous.port}`,
       project.healthPath,
@@ -89,7 +85,6 @@ export class RollbackService {
     );
 
     if (!result.success) {
-      // Clean up the restarted container — rollback itself failed
       await stopContainer(previous.containerName).catch(() => null);
       await removeContainer(previous.containerName).catch(() => null);
       throw new DeploymentError(
@@ -97,10 +92,8 @@ export class RollbackService {
       );
     }
 
-    // Switch traffic to old container
     await this.traffic.switchTrafficTo(previous.port);
 
-    // Stop and remove the current (now-replaced) container
     await stopContainer(current.containerName).catch((err) => {
       logger.warn({ err, containerName: current.containerName }, "Failed to stop current container during rollback");
     });
@@ -108,12 +101,11 @@ export class RollbackService {
       logger.warn({ err, containerName: current.containerName }, "Failed to remove current container during rollback");
     });
 
-    // Update DB
     await this.repo.updateStatus(current.id, DeploymentStatus.ROLLED_BACK);
     await this.repo.updateStatus(previous.id, DeploymentStatus.ACTIVE);
 
     logger.info(
-      { projectId, from: current.containerName, to: previous.containerName },
+      { projectId, environmentId, from: current.containerName, to: previous.containerName },
       "Rollback completed"
     );
 

--- a/src/worker/handlers/deploy.handler.ts
+++ b/src/worker/handlers/deploy.handler.ts
@@ -1,8 +1,8 @@
-import { DeploymentColor, DeploymentStatus, Job, Project } from "@prisma/client";
+import { DeploymentColor, DeploymentStatus, Environment, Job, Project } from "@prisma/client";
 import { config } from "../../config/env";
 import { parseProjectEnv } from "../../utils/env";
 import { DeploymentRepository } from "../../repositories/deployment.repository";
-import { ProjectRepository } from "../../repositories/project.repository";
+import { EnvironmentRepository } from "../../repositories/environment.repository";
 import { buildImage, runContainer, stopContainer, removeContainer, freeHostPort } from "../../utils/docker";
 import { ensureDockerfile } from "../../utils/dockerfile";
 import { DeploymentError } from "../../utils/errors";
@@ -15,7 +15,7 @@ import { logEmitter } from "../../events/log-emitter";
 import prisma from "../../prisma/client";
 
 const repo = new DeploymentRepository();
-const projectRepo = new ProjectRepository();
+const envRepo = new EnvironmentRepository();
 const traffic = new TrafficService();
 const git = new GitService();
 const validation = new ValidationService();
@@ -38,13 +38,28 @@ async function updateJobDeploymentId(jobId: string, deploymentId: string): Promi
   });
 }
 
-export async function runDeployJob(job: Job & { project: Project }, log: LogFn): Promise<void> {
+export async function runDeployJob(
+  job: Job & { project: Project; environment: Environment | null },
+  log: LogFn
+): Promise<void> {
   const { projectId, id: jobId } = job;
   const project = job.project;
 
-  const acquired = await projectRepo.acquireDeployLock(projectId);
+  const environment =
+    job.environment ??
+    (await envRepo.findDefaultForProject(projectId));
+  if (!environment) {
+    await failJob(jobId, `No environment for project ${projectId}`);
+    await log(`No default environment — cannot deploy`);
+    logEmitter.emitStatus(jobId, "FAILED");
+    return;
+  }
+
+  const environmentId = environment.id;
+
+  const acquired = await envRepo.acquireDeployLock(environmentId);
   if (!acquired) {
-    await failJob(jobId, `Deployment already in progress for project ${projectId}`);
+    await failJob(jobId, `Deployment already in progress for environment ${environmentId}`);
     await log(`Deploy lock already held — rejecting job`);
     logEmitter.emitStatus(jobId, "FAILED");
     return;
@@ -53,23 +68,23 @@ export async function runDeployJob(job: Job & { project: Project }, log: LogFn):
   let deploymentId: string | undefined;
 
   try {
-    await log(`Starting deployment pipeline for project ${project.name} (${projectId})`);
+    await log(`Starting deployment pipeline for project ${project.name} (${projectId}), env ${environment.name} (${environmentId})`);
 
     await log(`Step 1: Preparing source code`);
     await git.prepareSource(project);
     await checkCancelled(undefined, log);
 
     const repoRoot = git.projectPath(project);
-    const buildContextPath = await ensureDockerfile(git.buildContextPath(project), project.appPort, repoRoot);
+    const buildContextPath = await ensureDockerfile(git.buildContextPath(project), environment.appPort, repoRoot);
 
     await log(`Step 2: Determining blue/green target`);
-    const activeDeployment = await repo.findActiveForProject(projectId);
+    const activeDeployment = await repo.findActiveForEnvironment(environmentId);
     const newColor =
       activeDeployment?.color === DeploymentColor.BLUE ? DeploymentColor.GREEN : DeploymentColor.BLUE;
-    const hostPort = newColor === DeploymentColor.BLUE ? project.basePort : project.basePort + 1;
-    const containerName = `${project.name}-${newColor.toLowerCase()}`;
+    const hostPort = newColor === DeploymentColor.BLUE ? environment.basePort : environment.basePort + 1;
+    const containerName = `${project.name}-${environment.name}-${newColor.toLowerCase()}`;
     const imageTag = `versiongate-${project.name}:${Date.now()}`;
-    const version = await repo.getNextVersionForProject(projectId);
+    const version = await repo.getNextVersionForEnvironment(environmentId);
 
     await log(
       `Target: color=${newColor}, hostPort=${hostPort}, container=${containerName}, image=${imageTag}, version=${version}`
@@ -83,7 +98,7 @@ export async function runDeployJob(job: Job & { project: Project }, log: LogFn):
       port: hostPort,
       color: newColor,
       status: DeploymentStatus.DEPLOYING,
-      project: { connect: { id: projectId } },
+      environment: { connect: { id: environmentId } },
     });
     deploymentId = deployment.id;
 
@@ -106,7 +121,7 @@ export async function runDeployJob(job: Job & { project: Project }, log: LogFn):
       containerName,
       imageTag,
       hostPort,
-      project.appPort,
+      environment.appPort,
       config.dockerNetwork,
       projectEnv
     );
@@ -157,7 +172,7 @@ export async function runDeployJob(job: Job & { project: Project }, log: LogFn):
     await log(`FAILED: ${friendly}`);
     logEmitter.emitStatus(jobId, "FAILED");
   } finally {
-    await projectRepo.releaseDeployLock(projectId);
+    await envRepo.releaseDeployLock(environmentId);
     await log(`Deploy lock released`);
   }
 }

--- a/src/worker/handlers/rollback.handler.ts
+++ b/src/worker/handlers/rollback.handler.ts
@@ -1,7 +1,7 @@
-import { DeploymentStatus, Job, Project } from "@prisma/client";
+import { DeploymentStatus, Environment, Job, Project } from "@prisma/client";
 import { parseProjectEnv } from "../../utils/env";
 import { DeploymentRepository } from "../../repositories/deployment.repository";
-import { ProjectRepository } from "../../repositories/project.repository";
+import { EnvironmentRepository } from "../../repositories/environment.repository";
 import { TrafficService } from "../../services/traffic.service";
 import { ValidationService } from "../../services/validation.service";
 import { runContainer, stopContainer, removeContainer } from "../../utils/docker";
@@ -12,33 +12,48 @@ import { humanizeDeployFailure } from "../../utils/deploy-errors";
 import { logEmitter } from "../../events/log-emitter";
 
 const repo = new DeploymentRepository();
-const projectRepo = new ProjectRepository();
+const envRepo = new EnvironmentRepository();
 const traffic = new TrafficService();
 const validation = new ValidationService();
 
 export type LogFn = (line: string) => void | Promise<void>;
 
-export async function runRollbackJob(job: Job & { project: Project }, log: LogFn): Promise<void> {
+export async function runRollbackJob(
+  job: Job & { project: Project; environment: Environment | null },
+  log: LogFn
+): Promise<void> {
   const { projectId, id: jobId } = job;
   const project = job.project;
 
-  const acquired = await projectRepo.acquireDeployLock(projectId);
+  const environment =
+    job.environment ??
+    (await envRepo.findDefaultForProject(projectId));
+  if (!environment) {
+    await failJob(jobId, `No environment for project ${projectId}`);
+    await log(`No default environment — cannot rollback`);
+    logEmitter.emitStatus(jobId, "FAILED");
+    return;
+  }
+
+  const environmentId = environment.id;
+
+  const acquired = await envRepo.acquireDeployLock(environmentId);
   if (!acquired) {
-    await failJob(jobId, `Deployment already in progress for project ${projectId}`);
+    await failJob(jobId, `Deployment already in progress for environment ${environmentId}`);
     await log(`Deploy lock already held — cannot rollback`);
     logEmitter.emitStatus(jobId, "FAILED");
     return;
   }
 
   try {
-    await log(`Initiating rollback for project ${project.name} (${projectId})`);
+    await log(`Initiating rollback for project ${project.name} (${projectId}), env ${environment.name} (${environmentId})`);
 
-    const current = await repo.findActiveForProject(projectId);
+    const current = await repo.findActiveForEnvironment(environmentId);
     if (!current) {
       throw new BadRequestError("No active deployment to roll back from");
     }
 
-    const previous = await repo.findPreviousForProject(projectId, current.version);
+    const previous = await repo.findPreviousForEnvironment(environmentId, current.version);
     if (!previous) {
       throw new BadRequestError("No previous deployment available for rollback");
     }
@@ -59,7 +74,7 @@ export async function runRollbackJob(job: Job & { project: Project }, log: LogFn
       previous.containerName,
       previous.imageTag,
       previous.port,
-      project.appPort,
+      environment.appPort,
       config.dockerNetwork,
       projectEnv
     );
@@ -109,7 +124,7 @@ export async function runRollbackJob(job: Job & { project: Project }, log: LogFn
     await log(`FAILED: ${friendly}`);
     logEmitter.emitStatus(jobId, "FAILED");
   } finally {
-    await projectRepo.releaseDeployLock(projectId);
+    await envRepo.releaseDeployLock(environmentId);
     await log(`Deploy lock released`);
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This PR implements **Sprint 2 issue #16 (Environment model)** as the foundation for multi-environment promotion and gates.

### Data model

- New `Environment` table: `name`, `projectId`, `branch`, `serverHost`, `basePort`, `appPort`, `lockedAt` (deploy lock moved from `Project`).
- `Deployment` now references `environmentId` (required); existing rows migrate to a default **`production`** environment per project with the same `basePort` / `appPort` / `branch` as before.
- `Job` optionally stores `environmentId` for deploy/rollback jobs.

### API behavior

- `POST /api/v1/deploy` accepts optional `environmentId`; if omitted, resolves the default **`production`** environment.
- `POST /api/v1/projects/:id/rollback` targets the default environment and returns `environmentId` in the response.
- **`GET /api/v1/projects/:id/environments`** lists environments (for the upcoming environment chain UI).
- Deployment list payloads include **`projectId`** (derived via the environment) so the dashboard can keep filtering by project.

### Runtime

- Worker deploy/rollback handlers use the job’s environment (or default).
- Webhooks compare the pushed branch to the **default environment’s** `branch` and enqueue deploy with that environment id.
- Container names are now `{project}-{env}-{color}` to avoid collisions when multiple environments exist later.

### Migration

- Run `prisma migrate deploy` (or your usual deploy path). The SQL migration creates environments, backfills, and drops `Project.lockedAt`.

## Follow-ups (separate PRs)

- Promote without rebuild, per-environment env vars, gates, audit log, notifications, GitHub App — as in the Sprint 2 milestone.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a93afe41-ffe1-43ee-9533-0ffc6d4073a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a93afe41-ffe1-43ee-9533-0ffc6d4073a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

