### PR TITLE
security: session gate for API, harden setup and buildContext

### DIFF
--- a/src/controllers/setup.controller.ts
+++ b/src/controllers/setup.controller.ts
@@ -174,14 +174,12 @@ export async function applySetupHandler(
   }
 
   const existingDatabaseUrl = readDatabaseUrl();
-  if (existingDatabaseUrl) {
-    const existingDbConnected = await canConnectToDatabase(existingDatabaseUrl);
-    if (existingDbConnected) {
-      return reply.code(409).send({
-        error: "SetupError",
-        message: "Setup is already complete. Update configuration manually if needed.",
-      });
-    }
+  if (existingDatabaseUrl?.trim()) {
+    return reply.code(409).send({
+      error: "SetupError",
+      message:
+        "Setup already has DATABASE_URL in .env. Edit or remove DATABASE_URL manually and restart before re-running the wizard.",
+    });
   }
 
   // 1. Validate database connection

--- a/src/middleware/require-api-auth.ts
+++ b/src/middleware/require-api-auth.ts
@@ -1,5 +1,4 @@
 import type { FastifyReply, FastifyRequest } from "fastify";
-import prisma from "../prisma/client";
 import { getUserFromSessionToken } from "../services/auth.service";
 import { getSessionTokenFromRequest } from "../utils/cookie";
 
@@ -27,8 +26,9 @@ export type AuthedRequest = FastifyRequest & {
 };
 
 /**
- * Requires a valid session cookie once at least one dashboard user exists.
- * Before the first user is registered, all API routes stay open (bootstrap window).
+ * Session cookie gate for `/api/v1/*` when the database URL is configured.
+ * Public paths remain open (setup wizard, login/register, webhooks, CI self-update).
+ * Settings are blocked until DATABASE_URL is set so `.env` cannot be edited anonymously.
  */
 export async function requireApiAuth(req: AuthedRequest, reply: FastifyReply): Promise<void> {
   const path = pathOnly(req.url);
@@ -36,14 +36,21 @@ export async function requireApiAuth(req: AuthedRequest, reply: FastifyReply): P
   if (isPublicApiPath(path)) return;
 
   if (!process.env.DATABASE_URL?.trim()) {
+    if (path.startsWith("/api/v1/settings/")) {
+      await reply.code(503).send({
+        error: "ServiceUnavailable",
+        message: "Database is not configured. Open /setup to finish installation, or set DATABASE_URL and restart.",
+        code: "SETUP_REQUIRED",
+      });
+      return;
+    }
     return;
   }
 
+  let user: { id: string; email: string } | null;
   try {
-    const userCount = await prisma.user.count();
-    if (userCount === 0) {
-      return;
-    }
+    const raw = getSessionTokenFromRequest(req.headers.cookie);
+    user = await getUserFromSessionToken(raw);
   } catch {
     await reply.code(503).send({
       error: "ServiceUnavailable",
@@ -52,8 +59,6 @@ export async function requireApiAuth(req: AuthedRequest, reply: FastifyReply): P
     return;
   }
 
-  const raw = getSessionTokenFromRequest(req.headers.cookie);
-  const user = await getUserFromSessionToken(raw);
   if (!user) {
     await reply.code(401).send({
       error: "Unauthorized",

--- a/src/services/git.service.ts
+++ b/src/services/git.service.ts
@@ -15,11 +15,24 @@ export class GitService {
   }
 
   /**
-   * Returns the Docker build context path — the repo root joined with
-   * buildContext (e.g. "." keeps it at root, "server" points to a subdir).
+   * Returns the Docker build context path — resolved under the project repo dir only
+   * (rejects ../ and absolute segments).
    */
   buildContextPath(project: Pick<Project, "id" | "buildContext">): string {
-    return path.join(config.projectsRootPath, project.id, project.buildContext ?? ".");
+    const repoRoot = path.resolve(path.join(config.projectsRootPath, project.id));
+    const raw = (project.buildContext ?? ".").trim() || ".";
+
+    if (path.isAbsolute(raw)) {
+      throw new DeploymentError("buildContext must be a relative path (e.g. . or apps/api).");
+    }
+
+    const resolved = path.resolve(repoRoot, raw);
+    const relativeToRepo = path.relative(repoRoot, resolved);
+    if (relativeToRepo.startsWith("..") || path.isAbsolute(relativeToRepo)) {
+      throw new DeploymentError("buildContext must stay inside the project repository directory.");
+    }
+
+    return resolved;
   }
 
   /**


### PR DESCRIPTION
## Summary

This PR tightens authentication and path handling around the API, setup flow, and Docker build context resolution. It removes the "anonymous API" bootstrap window once `DATABASE_URL` is configured, blocks unauthenticated access to server settings before the database is wired, prevents re-running setup when `.env` already declares a database URL, and closes a path-traversal class of issue in `buildContext`.

## Motivation

1. **Session gate after DB config**: Previously, `requireApiAuth` skipped enforcement while `prisma.user.count() === 0`, leaving all non-public `/api/v1/*` routes callable without a session until the first user existed. That widened the attack surface for anyone who could reach the API between DB availability and admin registration (or in misconfigured deployments).

2. **Settings without `DATABASE_URL`**: When the process had no `DATABASE_URL` in the environment, most `/api/v1/*` routes remained open. If any `/api/v1/settings/*` endpoints could mutate `.env` or similar, that would be reachable without authentication during that window. Settings calls now return **503** with `SETUP_REQUIRED` until `DATABASE_URL` is set.

3. **Setup idempotency**: Re-applying setup when `.env` already contained `DATABASE_URL` used to allow another run if the stored URL could not be connected to from the server. That could allow overwriting configuration in edge cases while the DB was unreachable. Setup apply now **rejects with 409** whenever a non-empty `DATABASE_URL` is already present in `.env`, forcing explicit manual edits and restart.

4. **`buildContext` traversal**: `buildContext` was joined blindly with the project directory, so values like `../` or absolute paths could point Docker build context outside the intended repo directory. Resolution is now constrained to stay under the project repo root with clear `DeploymentError` messages.

## Changes (by area)

### `src/middleware/require-api-auth.ts`

- Removed dependency on `prisma.user.count()` for deciding whether auth is required.
- Whenever `DATABASE_URL` is set, **every** non-public `/api/v1/*` request must present a valid session (same as before for "logged-in" flows, but **no** longer bypassed for zero users).
- When `DATABASE_URL` is **not** set: non-settings routes behave as before (open for bootstrap); **`/api/v1/settings/*`** returns **503** with JSON `code: "SETUP_REQUIRED"` and a message pointing operators to `/setup` or env configuration.
- Session resolution (`getUserFromSessionToken`) is wrapped in the same try/catch as before for DB outages (**503** "Database unavailable for authentication").

**Public paths unchanged**: `/api/v1/setup/*`, `/api/v1/auth/*`, `/api/v1/webhooks/*`, and the CI self-update endpoints remain exempt.

### `src/controllers/setup.controller.ts`

- `applySetupHandler`: if `readDatabaseUrl()` returns a **trimmed non-empty** value, respond **409** immediately with a clear message to edit or remove `DATABASE_URL` in `.env` and restart—**no** longer conditioned on a live DB connection test for that decision.

### `src/services/git.service.ts`

- `buildContextPath`: resolve `repoRoot` with `path.resolve`, reject **absolute** `buildContext`, resolve user path under repo root, and reject if `path.relative(repoRoot, resolved)` escapes (starts with `..` or is absolute). Returns the **resolved** path under the repo.

## Behavioral notes / upgrade impact

- **First-time setup UX**: Operators **must** complete admin creation through the normal setup/login flow; there is no longer an API-wide anonymous period after the database is configured but before a user row exists. If automation relied on unauthenticated API calls in that window, it must use setup/auth/public routes or authenticate.
- **Broken `DATABASE_URL` in `.env`**: Apply-setup will **not** auto-recover by re-posting the wizard; fix or clear the line in `.env` and restart, then run setup again if appropriate.
- **Invalid `buildContext`**: Projects with absolute or parent-relative `buildContext` will throw `DeploymentError` at deploy time until the field is corrected in the UI/DB.

## Suggested verification

1. With a fresh install: complete `/setup`, confirm dashboard API calls return **401** when logged out and **200** when logged in.
2. Temporarily unset `DATABASE_URL` in the process env while `.env` on disk still has it: hit `GET /api/v1/settings/...` and confirm **503** + `SETUP_REQUIRED`.
3. Set a project `buildContext` to `../` or an absolute path; confirm deploy fails with the new error messages; confirm `.` and `apps/api`-style paths still work.

## Security review (high level)

- **Session requirement** after DB configuration reduces unauthorized access to privileged APIs.
- **Settings lock** before DB configuration closes anonymous mutation of settings during the pre-bootstrap phase (defense in depth assuming settings touch sensitive config).
- **Setup 409** avoids ambiguous re-application when `.env` already declares a DSN.
- **`buildContext` containment** mitigates path traversal / arbitrary filesystem exposure for Docker builds.
