### PR TITLE
fix(self-update): return 200 with outcome body and surface apply errors

### DIFF
--- a/dashboard/src/components/UpdateAvailableBanner.tsx
+++ b/dashboard/src/components/UpdateAvailableBanner.tsx
@@ -85,6 +85,10 @@ export function UpdateAvailableBanner() {
         dismissedRef.current = false;
         sessionStorage.removeItem(DISMISS_KEY);
         await poll();
+      } else {
+        toast.error(r.error ?? "Update failed", {
+          description: r.steps?.length ? r.steps.slice(-3).join(" → ") : undefined,
+        });
       }
     } catch (e) {
       toast.error(e instanceof Error ? e.message : "Update failed");

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -40,10 +40,12 @@ async function request<T>(method: string, path: string, body?: unknown): Promise
         window.location.assign("/login");
       }
     }
-    const msg =
-      typeof data === "object" && data !== null && "message" in data
-        ? String((data as { message?: unknown }).message)
-        : `HTTP ${res.status}`;
+    let msg = `HTTP ${res.status}`;
+    if (typeof data === "object" && data !== null) {
+      const o = data as { message?: unknown; error?: unknown };
+      if (o.message != null && String(o.message)) msg = String(o.message);
+      else if (o.error != null && String(o.error)) msg = String(o.error);
+    }
     throw new ApiError(msg, res.status, data);
   }
 

--- a/dashboard/src/pages/Settings.tsx
+++ b/dashboard/src/pages/Settings.tsx
@@ -164,6 +164,10 @@ export function Settings() {
       if (r.ok) {
         toast.success("Update applied — PM2 reload scheduled. Refresh this page in a few seconds.");
         await refreshSelfUpdate();
+      } else {
+        toast.error(r.error ?? "Update failed", {
+          description: r.steps?.length ? r.steps.slice(-3).join(" → ") : undefined,
+        });
       }
     } catch (e) {
       toast.error(e instanceof Error ? e.message : "Update failed");

--- a/src/controllers/self-update.controller.ts
+++ b/src/controllers/self-update.controller.ts
@@ -49,10 +49,6 @@ export async function selfUpdateApplyHandler(req: FastifyRequest, reply: Fastify
     return;
   }
   const result = await applySelfUpdate(selfUpdateBranchLive());
-  if (!result.ok) {
-    reply.code(500).send(result);
-    return;
-  }
   reply.code(200).send(result);
 }
 

--- a/src/controllers/settings.controller.ts
+++ b/src/controllers/settings.controller.ts
@@ -289,9 +289,6 @@ export async function postSelfUpdateApplyHandler(_req: FastifyRequest, reply: Fa
     });
   }
   const result = await applySelfUpdate(selfUpdateBranchLive());
-  if (!result.ok) {
-    reply.code(500).send(result);
-    return;
-  }
+  /** Always 200: outcome is in `result.ok` / `result.error` (avoids generic client treating merge/build failure as an HTTP exception). */
   reply.code(200).send(result);
 }


### PR DESCRIPTION
Apply failures (merge/build/etc.) were sent as HTTP 500; the dashboard request helper only read message, not error, so users saw generic failures. Always return 200 with { ok, steps, error }; toast r.error when ok is false. Improve ApiError to fall back to body.error. Align bearer apply endpoint.

Made-with: Cursor