### PR TITLE
fix(prisma): skip db push fallback on P3005/P3009 baseline errors

### DIFF
--- a/dashboard/src/components/EnvironmentChain.tsx
+++ b/dashboard/src/components/EnvironmentChain.tsx
@@ -31,14 +31,15 @@ export interface EnvironmentChainProps {
   projectId: string;
   environments: EnvironmentSummary[];
   onRefresh: () => Promise<void>;
-  onDeployToDev: () => Promise<void>;
+  /** Deploy/build for the leftmost environment in the chain (not always named “development”). */
+  onDeployToEnvironment: (environmentId: string) => Promise<void>;
 }
 
 export function EnvironmentChain({
   projectId,
   environments,
   onRefresh,
-  onDeployToDev,
+  onDeployToEnvironment,
 }: EnvironmentChainProps) {
   const navigate = useNavigate();
   const [promotingId, setPromotingId] = useState<string | null>(null);
@@ -64,86 +65,85 @@ export function EnvironmentChain({
   }
 
   return (
-    <Card className="border-border/50 bg-card/60 ring-1 ring-border/25">
-      <CardHeader>
-        <CardTitle className="text-base">Environment chain</CardTitle>
-        <CardDescription>
-          Dev → staging → production. Promote reuses the upstream Docker image without rebuilding (
-          <span className="font-mono text-xs">POST /environments/:id/promote</span>).
-        </CardDescription>
-      </CardHeader>
-      <CardContent>
-        <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-stretch">
-          {sorted.map((env, index) => {
-            const upstream = index > 0 ? sorted[index - 1] : null;
-            const upstreamActive = upstream?.activeDeployment?.status === "ACTIVE";
-            const active = env.activeDeployment;
-            const showPromote = index > 0;
-            const promoteDisabled = !upstreamActive || promotingId !== null;
+    <div className="space-y-3">
+      <p className="text-xs text-muted-foreground">
+        <strong className="text-foreground/80">Promote</strong> reuses the upstream Docker image (no rebuild).{" "}
+        <span className="font-mono text-[0.7rem] opacity-80">POST /projects/…/environments/:id/promote</span>
+      </p>
+      <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-stretch">
+        {sorted.map((env, index) => {
+          const upstream = index > 0 ? sorted[index - 1] : null;
+          const upstreamActive = upstream?.activeDeployment?.status === "ACTIVE";
+          const active = env.activeDeployment;
+          const showPromote = index > 0;
+          const promoteDisabled = !upstreamActive || promotingId !== null;
 
-            return (
-              <div key={env.id} className="flex flex-1 min-w-[200px] flex-col gap-3 sm:flex-row sm:items-stretch">
-                {index > 0 ? <ChainArrow /> : null}
-                <Card className="flex-1 border-border/40 bg-background/40">
-                  <CardHeader className="pb-2">
-                    <div className="flex flex-wrap items-center justify-between gap-2">
-                      <CardTitle className="text-sm font-medium">{env.name}</CardTitle>
-                      {active ? <StatusBadge status={active.status} /> : <StatusBadge status="PENDING" />}
+          return (
+            <div key={env.id} className="flex flex-1 min-w-[200px] flex-col gap-3 sm:flex-row sm:items-stretch">
+              {index > 0 ? <ChainArrow /> : null}
+              <Card className="flex-1 border-border/40 bg-background/40">
+                <CardHeader className="pb-2">
+                  <div className="flex flex-wrap items-center justify-between gap-2">
+                    <CardTitle className="text-sm font-medium">{env.name}</CardTitle>
+                    {active ? <StatusBadge status={active.status} /> : <StatusBadge status="PENDING" />}
+                  </div>
+                  <CardDescription className="font-mono text-xs">
+                    Branch {env.branch} · host ports {env.basePort}–{env.basePort + 1}
+                  </CardDescription>
+                </CardHeader>
+                <CardContent className="space-y-3 pt-0">
+                  {active ? (
+                    <div className="space-y-1 text-xs text-muted-foreground">
+                      <p>
+                        <span className="text-foreground/80">Version</span>{" "}
+                        <span className="font-mono tabular-nums">v{active.version}</span>
+                      </p>
+                      <p className="truncate font-mono" title={active.imageTag}>
+                        {active.imageTag}
+                      </p>
                     </div>
-                    <CardDescription className="font-mono text-xs">
-                      Branch {env.branch} · host ports {env.basePort}–{env.basePort + 1}
-                    </CardDescription>
-                  </CardHeader>
-                  <CardContent className="space-y-3 pt-0">
-                    {active ? (
-                      <div className="space-y-1 text-xs text-muted-foreground">
-                        <p>
-                          <span className="text-foreground/80">Version</span>{" "}
-                          <span className="font-mono tabular-nums">v{active.version}</span>
-                        </p>
-                        <p className="truncate font-mono" title={active.imageTag}>
-                          {active.imageTag}
-                        </p>
-                      </div>
-                    ) : (
-                      <p className="text-xs text-muted-foreground">No deployment yet.</p>
-                    )}
+                  ) : (
+                    <p className="text-xs text-muted-foreground">No deployment yet.</p>
+                  )}
 
-                    <div className="flex flex-wrap gap-2">
-                      {index === 0 ? (
-                        <Button size="sm" variant="secondary" onClick={() => void onDeployToDev()}>
-                          Deploy to dev
-                        </Button>
-                      ) : null}
-                      {showPromote ? (
-                        <Button
-                          size="sm"
-                          disabled={promoteDisabled}
-                          onClick={() => upstream && void onPromote(env.id, upstream.id)}
-                          title={
-                            !upstreamActive
-                              ? `Wait until ${upstream?.name ?? "upstream"} has an ACTIVE deployment`
-                              : undefined
-                          }
-                        >
-                          {promotingId === env.id ? (
-                            <>
-                              <span className="mr-2 inline-block h-4 w-4 animate-spin rounded-full border-2 border-muted-foreground border-t-primary" />
-                              Promoting…
-                            </>
-                          ) : (
-                            "Promote"
-                          )}
-                        </Button>
-                      ) : null}
-                    </div>
-                  </CardContent>
-                </Card>
-              </div>
-            );
-          })}
-        </div>
-      </CardContent>
-    </Card>
+                  <div className="flex flex-wrap gap-2">
+                    {index === 0 ? (
+                      <Button
+                        size="sm"
+                        variant="secondary"
+                        onClick={() => void onDeployToEnvironment(env.id)}
+                      >
+                        Deploy to {env.name}
+                      </Button>
+                    ) : null}
+                    {showPromote ? (
+                      <Button
+                        size="sm"
+                        disabled={promoteDisabled}
+                        onClick={() => upstream && void onPromote(env.id, upstream.id)}
+                        title={
+                          !upstreamActive
+                            ? `Wait until ${upstream?.name ?? "upstream"} has an ACTIVE deployment`
+                            : undefined
+                        }
+                      >
+                        {promotingId === env.id ? (
+                          <>
+                            <span className="mr-2 inline-block h-4 w-4 animate-spin rounded-full border-2 border-muted-foreground border-t-primary" />
+                            Promoting…
+                          </>
+                        ) : (
+                          "Promote"
+                        )}
+                      </Button>
+                    ) : null}
+                  </div>
+                </CardContent>
+              </Card>
+            </div>
+          );
+        })}
+      </div>
+    </div>
   );
 }

--- a/dashboard/src/pages/ProjectDetail.tsx
+++ b/dashboard/src/pages/ProjectDetail.tsx
@@ -51,6 +51,7 @@ export function ProjectDetail() {
   const [project, setProject] = useState<Project | null>(null);
   const [deployments, setDeployments] = useState<Deployment[]>([]);
   const [environments, setEnvironments] = useState<EnvironmentSummary[]>([]);
+  const [environmentsError, setEnvironmentsError] = useState<string | null>(null);
   const [jobs, setJobs] = useState<JobRecord[]>([]);
   const [loading, setLoading] = useState(true);
   const [deleteOpen, setDeleteOpen] = useState(false);
@@ -62,22 +63,31 @@ export function ProjectDetail() {
       return;
     }
     setLoading(true);
+    setEnvironmentsError(null);
     try {
       const [p, d, j] = await Promise.all([
         getProject(id),
         getDeployments(id),
         listProjectJobs(id, { limit: 25 }),
       ]);
-      const envData = await getProjectEnvironments(id).catch(() => ({ environments: [] as EnvironmentSummary[] }));
       setProject(p.project ?? null);
       setDeployments(d.deployments);
-      setEnvironments(envData.environments ?? []);
       setJobs(j.jobs);
+
+      try {
+        const envData = await getProjectEnvironments(id);
+        setEnvironments(envData.environments ?? []);
+        setEnvironmentsError(null);
+      } catch (envEx) {
+        setEnvironments([]);
+        setEnvironmentsError(envEx instanceof Error ? envEx.message : "Failed to load environments");
+      }
     } catch (e) {
       toast.error(e instanceof Error ? e.message : "Failed to load project");
       setProject(null);
       setDeployments([]);
       setEnvironments([]);
+      setEnvironmentsError(null);
       setJobs([]);
     } finally {
       setLoading(false);
@@ -132,7 +142,7 @@ export function ProjectDetail() {
     if (!id) return;
     try {
       const r = await triggerDeploy(id);
-      toast.success(`Deploy queued — job ${r.jobId.slice(0, 8)}…`);
+      toast.success(`Deploy queued (production) — job ${r.jobId.slice(0, 8)}…`);
       navigate(`/projects/${id}/deploy/${r.jobId}`);
     } catch (e) {
       toast.error(e instanceof Error ? e.message : "Deploy failed");
@@ -150,16 +160,13 @@ export function ProjectDetail() {
     }
   };
 
-  const onDeployToDev = async () => {
+  const onDeployToEnvironment = async (environmentId: string) => {
     if (!id) return;
-    const dev = [...environments].sort((a, b) => a.chainOrder - b.chainOrder)[0];
-    if (!dev) {
-      toast.error("No development environment configured");
-      return;
-    }
+    const label =
+      environments.find((e) => e.id === environmentId)?.name ?? environmentId.slice(0, 8);
     try {
-      const r = await triggerDeploy(id, dev.id);
-      toast.success(`Dev deploy queued — job ${r.jobId.slice(0, 8)}…`);
+      const r = await triggerDeploy(id, environmentId);
+      toast.success(`Deploy queued — ${label} — job ${r.jobId.slice(0, 8)}…`);
       navigate(`/projects/${id}/deploy/${r.jobId}`);
     } catch (e) {
       toast.error(e instanceof Error ? e.message : "Deploy failed");
@@ -238,7 +245,9 @@ export function ProjectDetail() {
           </div>
         </div>
         <div className="flex flex-wrap gap-2">
-          <Button onClick={() => void onDeploy()}>Deploy</Button>
+          <Button onClick={() => void onDeploy()} title="Deploys the default production environment">
+            Deploy
+          </Button>
           <Button variant="secondary" onClick={() => void onRollback()}>
             Rollback
           </Button>
@@ -284,6 +293,55 @@ export function ProjectDetail() {
         </Card>
       </div>
 
+      <Card className="border-border/50 bg-card/60 ring-1 ring-border/25">
+        <CardHeader>
+          <CardTitle className="text-base">Environments &amp; promotion</CardTitle>
+          <CardDescription>
+            Stages run on different host port ranges. Use <strong>Deploy to …</strong> on the first stage for a fresh build, then{" "}
+            <strong>Promote</strong> to reuse the upstream image on the next stage. The top <strong>Deploy</strong> button targets{" "}
+            <strong>production</strong> only.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {environmentsError ? (
+            <div className="rounded-lg border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm">
+              <p className="font-medium text-destructive">Could not list environments</p>
+              <p className="mt-1 text-muted-foreground">{environmentsError}</p>
+              <Button className="mt-3" variant="outline" size="sm" type="button" onClick={() => void load()}>
+                Retry
+              </Button>
+            </div>
+          ) : null}
+          {!environmentsError && environments.length === 0 ? (
+            <div className="space-y-2 text-sm text-muted-foreground">
+              <p>No environments were returned for this project.</p>
+              <p>
+                New projects get <span className="font-medium text-foreground">development</span>,{" "}
+                <span className="font-medium text-foreground">staging</span>, and{" "}
+                <span className="font-medium text-foreground">production</span>. If this project was created on an older release, upgrade the
+                engine and apply migrations, or create a new project to get the full chain.
+              </p>
+            </div>
+          ) : null}
+          {!environmentsError && environments.length === 1 && environments[0]?.name === "production" ? (
+            <p className="text-xs text-amber-700 dark:text-amber-400/95">
+              Only <strong className="font-medium">production</strong> is present. The dev → staging → production chain appears when all three
+              environment rows exist.
+            </p>
+          ) : null}
+          {!environmentsError && environments.length > 0 ? (
+            <EnvironmentChain
+              projectId={project.id}
+              environments={environments}
+              onRefresh={async () => {
+                await load();
+              }}
+              onDeployToEnvironment={onDeployToEnvironment}
+            />
+          ) : null}
+        </CardContent>
+      </Card>
+
       {deployments.length > 0 || jobs.length > 0 ? (
         <div className="grid gap-4 md:grid-cols-2">
           <Card className="border-border/50 bg-card/50 ring-1 ring-border/25">
@@ -311,19 +369,6 @@ export function ProjectDetail() {
             </CardContent>
           </Card>
         </div>
-      ) : null}
-
-      {environments.length > 0 ? (
-        <EnvironmentChain
-          projectId={project.id}
-          environments={environments}
-          onRefresh={async () => {
-            await load();
-          }}
-          onDeployToDev={async () => {
-            await onDeployToDev();
-          }}
-        />
       ) : null}
 
       <BlueGreenTrafficCard

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -81,7 +81,7 @@ After success, open the dashboard from `/`. The wizard is intended for initial b
 | `GEMINI_API_KEY` | No | — | Google AI Studio key for CI pipeline generation |
 | `GEMINI_MODEL` | No | `gemini-2.5-pro` | Gemini model ID |
 | `LOG_LEVEL` | No | `info` | Pino log level (`trace` `debug` `info` `warn` `error`) |
-| `PRISMA_SCHEMA_SYNC` | No | `migrate` | `migrate` = `prisma migrate deploy` (with `db push` fallback on failure); `push` = `db push` only (legacy / dev) |
+| `PRISMA_SCHEMA_SYNC` | No | `migrate` | `migrate` = `prisma migrate deploy` (optional `db push` fallback except P3005/P3009/baseline); `push` = `db push` only (legacy / dev) |
 
 ---
 

--- a/docs/database-migrations.md
+++ b/docs/database-migrations.md
@@ -8,7 +8,7 @@ On startup (when `DATABASE_URL` is set), the engine runs schema sync from [`src/
 
 | `PRISMA_SCHEMA_SYNC` | Behavior |
 |----------------------|----------|
-| `migrate` (default) | Runs `bunx prisma migrate deploy`. On failure, falls back to `bunx prisma db push --accept-data-loss` (legacy / drifted DBs). |
+| `migrate` (default) | Runs `bunx prisma migrate deploy`. On some failures it falls back to `bunx prisma db push --accept-data-loss` (legacy / drifted DBs). **No fallback** on P3005 / P3009 / baseline errors — `db push` cannot replay multi-step migrations (e.g. data backfills). |
 | `push` | Runs **only** `bunx prisma db push --accept-data-loss` — no migration history required. Use only when you accept push-only discipline for that install. |
 
 Set in `.env`:
@@ -67,6 +67,8 @@ If logs show **`migrate deploy failed — falling back to prisma db push`**:
 
 1. Prefer **baselining** (above) so `migrate deploy` succeeds.
 2. Or set **`PRISMA_SCHEMA_SYNC=push`** explicitly if this install is intentionally push-only — then startup logs reflect policy instead of a failed migrate attempt.
+
+If you see **`Not using db push fallback`** with **P3005**, you must baseline (or use an empty database) — do not expect `db push` to fix it after a failed self-update.
 
 ## References
 

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -4,6 +4,16 @@ import { envFilePath } from "../utils/paths";
 
 dotenv.config({ path: envFilePath });
 
+/** Default and normalize so startup, self-update, and spawned CLIs all see an explicit value. */
+(() => {
+  const t = process.env.PRISMA_SCHEMA_SYNC?.trim().toLowerCase();
+  if (!t || (t !== "push" && t !== "migrate")) {
+    process.env.PRISMA_SCHEMA_SYNC = "migrate";
+    return;
+  }
+  process.env.PRISMA_SCHEMA_SYNC = t;
+})();
+
 /** Docker CLI path: explicit `DOCKER_BIN`, else first existing common path, else `docker` (relies on PATH). */
 function resolveDockerBin(): string {
   const fromEnv = process.env.DOCKER_BIN?.trim();
@@ -18,7 +28,7 @@ function optionalEnv(key: string, fallback: string): string {
   return process.env[key] ?? fallback;
 }
 
-const prismaSchemaSyncRaw = optionalEnv("PRISMA_SCHEMA_SYNC", "migrate").toLowerCase();
+const prismaSchemaSyncRaw = optionalEnv("PRISMA_SCHEMA_SYNC", "migrate").trim().toLowerCase();
 const prismaSchemaSync: "migrate" | "push" =
   prismaSchemaSyncRaw === "push" ? "push" : "migrate";
 
@@ -26,7 +36,7 @@ export const config = {
   port: parseInt(optionalEnv("PORT", "9090"), 10) || 9090,
   logLevel: optionalEnv("LOG_LEVEL", "info"),
   databaseUrl: optionalEnv("DATABASE_URL", ""),
-  /** migrate: `prisma migrate deploy` (with db push fallback); push: `prisma db push` only */
+  /** migrate: `prisma migrate deploy` (optional db push fallback); push: `prisma db push` only */
   prismaSchemaSync,
   dockerBin: resolveDockerBin(),
   dockerNetwork: optionalEnv("DOCKER_NETWORK", "versiongate-net"),

--- a/src/utils/prisma-schema-sync.ts
+++ b/src/utils/prisma-schema-sync.ts
@@ -48,6 +48,19 @@ export function runPrismaSchemaSync(options: {
     if (strict) {
       throw firstErr;
     }
+    // P3005 = DB never baselined for Migrate; push would emit wrong one-shot DDL (e.g. NOT NULL
+    // without the backfill steps in versioned migrations). Do not fall back to db push.
+    const noPushFallback =
+      /\bP3005\b/i.test(msg) ||
+      /\bP3009\b/i.test(msg) ||
+      /baseline an existing production database/i.test(msg);
+    if (noPushFallback) {
+      logger.error(
+        { err: msg },
+        "prisma migrate deploy failed (baseline / migration history). Not using db push fallback — baseline this database then run migrate deploy (see docs/database-migrations.md)."
+      );
+      throw firstErr;
+    }
     logger.warn(
       { err: msg },
       "prisma migrate deploy failed — falling back to prisma db push (legacy or drifted database)"


### PR DESCRIPTION
migrate deploy failed with P3005 then db push tried to add NOT NULL environmentId without migration backfill SQL. Refuse push fallback for baseline/history errors; document behavior.

Made-with: Cursor