### PR TITLE
fix(prisma): Neon migrate via DIRECT_DATABASE_URL; no push on P1002

### DIFF
--- a/dashboard/src/pages/Settings.tsx
+++ b/dashboard/src/pages/Settings.tsx
@@ -504,6 +504,24 @@ export function Settings() {
                 autoComplete="off"
               />
             </div>
+            <div className="space-y-2">
+              <label className="text-xs font-medium text-muted-foreground" htmlFor="env-direct-database-url">
+                DIRECT_DATABASE_URL{" "}
+                <span className="font-normal text-muted-foreground/80">(optional, Neon unpooled)</span>
+              </label>
+              <textarea
+                id="env-direct-database-url"
+                value={envDraft.DIRECT_DATABASE_URL ?? ""}
+                onChange={(e) => setEnvField("DIRECT_DATABASE_URL", e.target.value)}
+                className={textareaClass}
+                placeholder="postgresql://…-direct… or non-pooler host — used only for prisma migrate deploy on startup/self-update"
+                autoComplete="off"
+              />
+              <p className="text-xs text-muted-foreground">
+                When set, migrate runs against this URL so advisory locks work. Keep <code className="rounded bg-muted px-1 font-mono text-[0.7rem]">DATABASE_URL</code> as the
+                pooler for the app.
+              </p>
+            </div>
             <div className="grid gap-4 sm:grid-cols-2">
               <div className="space-y-2">
                 <label className="text-xs font-medium text-muted-foreground" htmlFor="env-enc">

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -72,6 +72,7 @@ After success, open the dashboard from `/`. The wizard is intended for initial b
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
 | `DATABASE_URL` | Yes | — | PostgreSQL connection string |
+| `DIRECT_DATABASE_URL` | No | — | Unpooled URL (e.g. Neon direct) used **only** for `prisma migrate deploy` during startup/self-update — avoids P1002 advisory-lock timeouts on poolers |
 | `PORT` | No | `9090` | API + dashboard server port |
 | `DOCKER_NETWORK` | No | `versiongate-net` | Docker network for containers |
 | `NGINX_CONFIG_PATH` | No | `/etc/nginx/conf.d/upstream.conf` | Nginx upstream file path |
@@ -81,7 +82,7 @@ After success, open the dashboard from `/`. The wizard is intended for initial b
 | `GEMINI_API_KEY` | No | — | Google AI Studio key for CI pipeline generation |
 | `GEMINI_MODEL` | No | `gemini-2.5-pro` | Gemini model ID |
 | `LOG_LEVEL` | No | `info` | Pino log level (`trace` `debug` `info` `warn` `error`) |
-| `PRISMA_SCHEMA_SYNC` | No | `migrate` | `migrate` = `prisma migrate deploy` (optional `db push` fallback except P3005/P3009/baseline); `push` = `db push` only (legacy / dev) |
+| `PRISMA_SCHEMA_SYNC` | No | `migrate` | `migrate` = `prisma migrate deploy` (optional `db push` fallback except baseline / P1001 / P1002 / advisory lock); `push` = `db push` only (legacy / dev) |
 
 ---
 

--- a/docs/database-migrations.md
+++ b/docs/database-migrations.md
@@ -8,7 +8,7 @@ On startup (when `DATABASE_URL` is set), the engine runs schema sync from [`src/
 
 | `PRISMA_SCHEMA_SYNC` | Behavior |
 |----------------------|----------|
-| `migrate` (default) | Runs `bunx prisma migrate deploy`. On some failures it falls back to `bunx prisma db push --accept-data-loss` (legacy / drifted DBs). **No fallback** on P3005 / P3009 / baseline errors — `db push` cannot replay multi-step migrations (e.g. data backfills). |
+| `migrate` (default) | Runs `bunx prisma migrate deploy` (uses **`DIRECT_DATABASE_URL`** as `DATABASE_URL` for that subprocess when set — see Neon below). On some failures it falls back to `db push`. **No fallback** on P3005 / P3009 / P1001 / P1002 / baseline / advisory-lock errors. |
 | `push` | Runs **only** `bunx prisma db push --accept-data-loss` — no migration history required. Use only when you accept push-only discipline for that install. |
 
 Set in `.env`:
@@ -37,6 +37,10 @@ After baselining, keep using **versioned migrations** for all future schema chan
 If you intentionally do not use migration history (e.g. ephemeral dev), set `PRISMA_SCHEMA_SYNC=push`. Startup will skip `migrate deploy` and use **`db push`** only. This is weaker for multi-environment discipline and is **not** recommended for regulated production unless you accept that tradeoff.
 
 ## Neon: pooler timeouts and advisory locks
+
+VersionGate reads optional **`DIRECT_DATABASE_URL`** from `.env`. When present, **`prisma migrate deploy`** (startup and self-update) runs with `DATABASE_URL` temporarily set to that value so Prisma can acquire **PostgreSQL advisory locks** reliably. The running API and Prisma client continue to use the normal pooled **`DATABASE_URL`**.
+
+Add the direct connection string from the Neon console (non-pooler / `-direct` host). You can edit it in **Settings → Update server environment** on the dashboard.
 
 Neon (and similar poolers) often expose:
 

--- a/src/controllers/settings.controller.ts
+++ b/src/controllers/settings.controller.ts
@@ -92,6 +92,7 @@ export async function getInstanceSettingsHandler(
 /** Keys permitted to merge into the server `.env` file from the dashboard. */
 const PATCHABLE_ENV_KEYS = new Set([
   "DATABASE_URL",
+  "DIRECT_DATABASE_URL",
   "ENCRYPTION_KEY",
   "GEMINI_API_KEY",
   "GEMINI_MODEL",

--- a/src/server.ts
+++ b/src/server.ts
@@ -72,6 +72,12 @@ async function start(): Promise<void> {
     }
 
     await app.listen({ port: PORT, host: "0.0.0.0" });
+    try {
+      const srv = app.server as import("node:net").Server & { setMaxListeners?: (n: number) => void };
+      srv.setMaxListeners?.(48);
+    } catch {
+      /* ignore */
+    }
     logger.info(
       {
         port: PORT,

--- a/src/utils/prisma-schema-sync.ts
+++ b/src/utils/prisma-schema-sync.ts
@@ -6,6 +6,13 @@ export type PrismaSchemaSyncMode = "migrate" | "push";
 
 const DEFAULT_TIMEOUT_MS = 120_000;
 
+/** Prisma Migrate needs a real DB session for advisory locks — Neon pooler URLs often hit P1002. */
+function envForMigrateDeploy(base: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  const direct = base.DIRECT_DATABASE_URL?.trim();
+  if (!direct) return base;
+  return { ...base, DATABASE_URL: direct };
+}
+
 /**
  * Applies Prisma schema changes: prefer `migrate deploy` (versioned migrations in repo),
  * with optional fallback to `db push` for databases that predate migration history.
@@ -35,10 +42,15 @@ export function runPrismaSchemaSync(options: {
     return;
   }
 
+  const migrateEnv = envForMigrateDeploy(env);
+  if (env.DIRECT_DATABASE_URL?.trim()) {
+    logger.info("prisma migrate deploy: using DIRECT_DATABASE_URL as DATABASE_URL (avoids pooler advisory-lock timeouts)");
+  }
+
   try {
     execSync("bunx prisma migrate deploy", {
       cwd,
-      env,
+      env: migrateEnv,
       stdio: "pipe",
       timeout,
     });
@@ -50,14 +62,18 @@ export function runPrismaSchemaSync(options: {
     }
     // P3005 = DB never baselined for Migrate; push would emit wrong one-shot DDL (e.g. NOT NULL
     // without the backfill steps in versioned migrations). Do not fall back to db push.
+    // P1001/P1002 = connectivity / advisory lock (Neon pooler) — push is the wrong recovery; use DIRECT_DATABASE_URL.
     const noPushFallback =
       /\bP3005\b/i.test(msg) ||
       /\bP3009\b/i.test(msg) ||
-      /baseline an existing production database/i.test(msg);
+      /\bP1001\b/i.test(msg) ||
+      /\bP1002\b/i.test(msg) ||
+      /baseline an existing production database/i.test(msg) ||
+      /advisory lock/i.test(msg);
     if (noPushFallback) {
       logger.error(
         { err: msg },
-        "prisma migrate deploy failed (baseline / migration history). Not using db push fallback — baseline this database then run migrate deploy (see docs/database-migrations.md)."
+        "prisma migrate deploy failed (baseline / migration history / DB reachability / advisory lock). Not using db push fallback — fix DATABASE_URL connectivity, set DIRECT_DATABASE_URL (Neon unpooled) for migrate, or baseline the DB (see docs/database-migrations.md)."
       );
       throw firstErr;
     }


### PR DESCRIPTION
- Run migrate deploy with DATABASE_URL swapped to DIRECT_DATABASE_URL when set
- Refuse db push fallback on P1001/P1002/advisory lock (pooler noise), not only P3005
- Patchable env + Settings UI field for DIRECT_DATABASE_URL
- Raise HTTP server maxListeners after listen to reduce PM2 reload ws warnings
- Docs: Neon direct URL for VersionGate migrate

Made-with: Cursor