### PR TITLE
Run bun install in dashboard before build so root install and self-update resolve lucide-react

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev:api": "bun --watch src/server.ts",
     "dev:worker": "bun --watch src/worker/index.ts",
     "dev:dashboard": "cd dashboard && bun run dev",
-    "build:dashboard": "cd dashboard && bun run build",
+    "build:dashboard": "cd dashboard && bun install && bun run build",
     "build": "bun run build:dashboard",
     "start": "pm2 start ecosystem.config.cjs",
     "migrate": "bunx prisma migrate deploy",


### PR DESCRIPTION
This pull request makes a small but important update to the `build:dashboard` script in the `package.json` file. Now, running the dashboard build will also ensure dependencies are installed first, which helps prevent build failures due to missing packages.

* Updated the `build:dashboard` script to run `bun install` before `bun run build`, ensuring all dependencies are installed prior to building the dashboard.