### PR TITLE
GitHub App: install flow, installation token, repos API, and webhooks

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,15 @@ PROJECTS_ROOT_PATH="/var/versiongate/projects"
 # Personal access token for private repositories (optional)
 GIT_TOKEN=""
 
+# ── GitHub App (VersionGate-App) ───────────────────────────────────────────────
+# From GitHub → App settings: App ID, Client ID, Private key, Webhook secret.
+GITHUB_APP_ID="3587447"
+GITHUB_APP_CLIENT_ID="Iv23liAp0wg0PPIDLvZ0"
+# PEM for signing JWTs (single line with \n escapes, or multiline in quoted string)
+GITHUB_APP_PRIVATE_KEY=""
+# Used to verify POST /api/webhooks/github (X-Hub-Signature-256) and to sign install redirect state
+GITHUB_WEBHOOK_SECRET=""
+
 # ── Security ───────────────────────────────────────────────────────────────────
 # 32-byte hex string used to encrypt stored project env vars at rest
 ENCRYPTION_KEY=""

--- a/bun.lock
+++ b/bun.lock
@@ -8,6 +8,8 @@
         "@fastify/sensible": "^5.5.0",
         "@fastify/static": "^6.12.0",
         "@fastify/websocket": "10.0.1",
+        "@octokit/auth-app": "^8.2.0",
+        "@octokit/rest": "^22.0.1",
         "@prisma/client": "^5.10.0",
         "axios": "^1.6.7",
         "dotenv": "^16.4.5",
@@ -43,6 +45,42 @@
     "@fastify/websocket": ["@fastify/websocket@10.0.1", "", { "dependencies": { "duplexify": "^4.1.2", "fastify-plugin": "^4.0.0", "ws": "^8.0.0" } }, "sha512-8/pQIxTPRD8U94aILTeJ+2O3el/r19+Ej5z1O1mXlqplsUH7KzCjAI0sgd5DM/NoPjAi5qLFNIjgM5+9/rGSNw=="],
 
     "@lukeed/ms": ["@lukeed/ms@2.0.2", "", {}, "sha512-9I2Zn6+NJLfaGoz9jN3lpwDgAYvfGeNYdbAIjJOqzs4Tpc+VU3Jqq4IofSUBKajiDS8k9fZIg18/z13mpk1bsA=="],
+
+    "@octokit/auth-app": ["@octokit/auth-app@8.2.0", "", { "dependencies": { "@octokit/auth-oauth-app": "^9.0.3", "@octokit/auth-oauth-user": "^6.0.2", "@octokit/request": "^10.0.6", "@octokit/request-error": "^7.0.2", "@octokit/types": "^16.0.0", "toad-cache": "^3.7.0", "universal-github-app-jwt": "^2.2.0", "universal-user-agent": "^7.0.0" } }, "sha512-vVjdtQQwomrZ4V46B9LaCsxsySxGoHsyw6IYBov/TqJVROrlYdyNgw5q6tQbB7KZt53v1l1W53RiqTvpzL907g=="],
+
+    "@octokit/auth-oauth-app": ["@octokit/auth-oauth-app@9.0.3", "", { "dependencies": { "@octokit/auth-oauth-device": "^8.0.3", "@octokit/auth-oauth-user": "^6.0.2", "@octokit/request": "^10.0.6", "@octokit/types": "^16.0.0", "universal-user-agent": "^7.0.0" } }, "sha512-+yoFQquaF8OxJSxTb7rnytBIC2ZLbLqA/yb71I4ZXT9+Slw4TziV9j/kyGhUFRRTF2+7WlnIWsePZCWHs+OGjg=="],
+
+    "@octokit/auth-oauth-device": ["@octokit/auth-oauth-device@8.0.3", "", { "dependencies": { "@octokit/oauth-methods": "^6.0.2", "@octokit/request": "^10.0.6", "@octokit/types": "^16.0.0", "universal-user-agent": "^7.0.0" } }, "sha512-zh2W0mKKMh/VWZhSqlaCzY7qFyrgd9oTWmTmHaXnHNeQRCZr/CXy2jCgHo4e4dJVTiuxP5dLa0YM5p5QVhJHbw=="],
+
+    "@octokit/auth-oauth-user": ["@octokit/auth-oauth-user@6.0.2", "", { "dependencies": { "@octokit/auth-oauth-device": "^8.0.3", "@octokit/oauth-methods": "^6.0.2", "@octokit/request": "^10.0.6", "@octokit/types": "^16.0.0", "universal-user-agent": "^7.0.0" } }, "sha512-qLoPPc6E6GJoz3XeDG/pnDhJpTkODTGG4kY0/Py154i/I003O9NazkrwJwRuzgCalhzyIeWQ+6MDvkUmKXjg/A=="],
+
+    "@octokit/auth-token": ["@octokit/auth-token@6.0.0", "", {}, "sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w=="],
+
+    "@octokit/core": ["@octokit/core@7.0.6", "", { "dependencies": { "@octokit/auth-token": "^6.0.0", "@octokit/graphql": "^9.0.3", "@octokit/request": "^10.0.6", "@octokit/request-error": "^7.0.2", "@octokit/types": "^16.0.0", "before-after-hook": "^4.0.0", "universal-user-agent": "^7.0.0" } }, "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q=="],
+
+    "@octokit/endpoint": ["@octokit/endpoint@11.0.3", "", { "dependencies": { "@octokit/types": "^16.0.0", "universal-user-agent": "^7.0.2" } }, "sha512-FWFlNxghg4HrXkD3ifYbS/IdL/mDHjh9QcsNyhQjN8dplUoZbejsdpmuqdA76nxj2xoWPs7p8uX2SNr9rYu0Ag=="],
+
+    "@octokit/graphql": ["@octokit/graphql@9.0.3", "", { "dependencies": { "@octokit/request": "^10.0.6", "@octokit/types": "^16.0.0", "universal-user-agent": "^7.0.0" } }, "sha512-grAEuupr/C1rALFnXTv6ZQhFuL1D8G5y8CN04RgrO4FIPMrtm+mcZzFG7dcBm+nq+1ppNixu+Jd78aeJOYxlGA=="],
+
+    "@octokit/oauth-authorization-url": ["@octokit/oauth-authorization-url@8.0.0", "", {}, "sha512-7QoLPRh/ssEA/HuHBHdVdSgF8xNLz/Bc5m9fZkArJE5bb6NmVkDm3anKxXPmN1zh6b5WKZPRr3697xKT/yM3qQ=="],
+
+    "@octokit/oauth-methods": ["@octokit/oauth-methods@6.0.2", "", { "dependencies": { "@octokit/oauth-authorization-url": "^8.0.0", "@octokit/request": "^10.0.6", "@octokit/request-error": "^7.0.2", "@octokit/types": "^16.0.0" } }, "sha512-HiNOO3MqLxlt5Da5bZbLV8Zarnphi4y9XehrbaFMkcoJ+FL7sMxH/UlUsCVxpddVu4qvNDrBdaTVE2o4ITK8ng=="],
+
+    "@octokit/openapi-types": ["@octokit/openapi-types@27.0.0", "", {}, "sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA=="],
+
+    "@octokit/plugin-paginate-rest": ["@octokit/plugin-paginate-rest@14.0.0", "", { "dependencies": { "@octokit/types": "^16.0.0" }, "peerDependencies": { "@octokit/core": ">=6" } }, "sha512-fNVRE7ufJiAA3XUrha2omTA39M6IXIc6GIZLvlbsm8QOQCYvpq/LkMNGyFlB1d8hTDzsAXa3OKtybdMAYsV/fw=="],
+
+    "@octokit/plugin-request-log": ["@octokit/plugin-request-log@6.0.0", "", { "peerDependencies": { "@octokit/core": ">=6" } }, "sha512-UkOzeEN3W91/eBq9sPZNQ7sUBvYCqYbrrD8gTbBuGtHEuycE4/awMXcYvx6sVYo7LypPhmQwwpUe4Yyu4QZN5Q=="],
+
+    "@octokit/plugin-rest-endpoint-methods": ["@octokit/plugin-rest-endpoint-methods@17.0.0", "", { "dependencies": { "@octokit/types": "^16.0.0" }, "peerDependencies": { "@octokit/core": ">=6" } }, "sha512-B5yCyIlOJFPqUUeiD0cnBJwWJO8lkJs5d8+ze9QDP6SvfiXSz1BF+91+0MeI1d2yxgOhU/O+CvtiZ9jSkHhFAw=="],
+
+    "@octokit/request": ["@octokit/request@10.0.8", "", { "dependencies": { "@octokit/endpoint": "^11.0.3", "@octokit/request-error": "^7.0.2", "@octokit/types": "^16.0.0", "fast-content-type-parse": "^3.0.0", "json-with-bigint": "^3.5.3", "universal-user-agent": "^7.0.2" } }, "sha512-SJZNwY9pur9Agf7l87ywFi14W+Hd9Jg6Ifivsd33+/bGUQIjNujdFiXII2/qSlN2ybqUHfp5xpekMEjIBTjlSw=="],
+
+    "@octokit/request-error": ["@octokit/request-error@7.1.0", "", { "dependencies": { "@octokit/types": "^16.0.0" } }, "sha512-KMQIfq5sOPpkQYajXHwnhjCC0slzCNScLHs9JafXc4RAJI+9f+jNDlBNaIMTvazOPLgb4BnlhGJOTbnN0wIjPw=="],
+
+    "@octokit/rest": ["@octokit/rest@22.0.1", "", { "dependencies": { "@octokit/core": "^7.0.6", "@octokit/plugin-paginate-rest": "^14.0.0", "@octokit/plugin-request-log": "^6.0.0", "@octokit/plugin-rest-endpoint-methods": "^17.0.0" } }, "sha512-Jzbhzl3CEexhnivb1iQ0KJ7s5vvjMWcmRtq5aUsKmKDrRW6z3r84ngmiFKFvpZjpiU/9/S6ITPFRpn5s/3uQJw=="],
+
+    "@octokit/types": ["@octokit/types@16.0.0", "", { "dependencies": { "@octokit/openapi-types": "^27.0.0" } }, "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg=="],
 
     "@pinojs/redact": ["@pinojs/redact@0.4.0", "", {}, "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg=="],
 
@@ -81,6 +119,8 @@
     "balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
     "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
+
+    "before-after-hook": ["before-after-hook@4.0.0", "", {}, "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ=="],
 
     "brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
 
@@ -196,6 +236,8 @@
 
     "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
+    "json-with-bigint": ["json-with-bigint@3.5.8", "", {}, "sha512-eq/4KP6K34kwa7TcFdtvnftvHCD9KvHOGGICWwMFc4dOOKF5t4iYqnfLK8otCRCRv06FXOzGGyqE8h8ElMvvdw=="],
+
     "light-my-request": ["light-my-request@5.14.0", "", { "dependencies": { "cookie": "^0.7.0", "process-warning": "^3.0.0", "set-cookie-parser": "^2.4.1" } }, "sha512-aORPWntbpH5esaYpGOOmri0OHDOe3wC5M2MQxZ9dvMLZm6DnaAn0kJlcbU9hwsQgLzmZyReKwFwwPkR+nHu5kA=="],
 
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
@@ -290,6 +332,10 @@
 
     "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
+    "universal-github-app-jwt": ["universal-github-app-jwt@2.2.2", "", {}, "sha512-dcmbeSrOdTnsjGjUfAlqNDJrhxXizjAz94ija9Qw8YkZ1uu0d+GoZzyH+Jb9tIIqvGsadUfwg+22k5aDqqwzbw=="],
+
+    "universal-user-agent": ["universal-user-agent@7.0.3", "", {}, "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A=="],
+
     "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
 
     "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
@@ -301,6 +347,8 @@
     "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
 
     "@fastify/send/http-errors": ["http-errors@2.0.0", "", { "dependencies": { "depd": "2.0.0", "inherits": "2.0.4", "setprototypeof": "1.2.0", "statuses": "2.0.1", "toidentifier": "1.0.1" } }, "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ=="],
+
+    "@octokit/request/fast-content-type-parse": ["fast-content-type-parse@3.0.0", "", {}, "sha512-ZvLdcY8P+N8mGQJahJV5G4U88CSvT1rP8ApL6uETe88MBXrBHAkZlSEySdUlyztF7ccb+Znos3TFqaepHxdhBg=="],
 
     "ajv/fast-uri": ["fast-uri@3.1.0", "", {}, "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="],
 

--- a/package.json
+++ b/package.json
@@ -27,6 +27,8 @@
     "@fastify/sensible": "^5.5.0",
     "@fastify/static": "^6.12.0",
     "@fastify/websocket": "10.0.1",
+    "@octokit/auth-app": "^8.2.0",
+    "@octokit/rest": "^22.0.1",
     "@prisma/client": "^5.10.0",
     "axios": "^1.6.7",
     "dotenv": "^16.4.5",

--- a/prisma/migrations/20260503120000_github_installation/migration.sql
+++ b/prisma/migrations/20260503120000_github_installation/migration.sql
@@ -1,0 +1,20 @@
+-- CreateTable
+CREATE TABLE "GitHubInstallation" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "installationId" BIGINT NOT NULL,
+    "githubAccountLogin" TEXT NOT NULL,
+    "githubAccountType" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "GitHubInstallation_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "GitHubInstallation_installationId_key" ON "GitHubInstallation"("installationId");
+
+-- CreateIndex
+CREATE INDEX "GitHubInstallation_userId_idx" ON "GitHubInstallation"("userId");
+
+-- AddForeignKey
+ALTER TABLE "GitHubInstallation" ADD CONSTRAINT "GitHubInstallation_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -21,12 +21,26 @@ enum DeploymentColor {
 }
 
 model User {
-  id           String    @id @default(cuid())
-  email        String    @unique
-  passwordHash String
-  createdAt    DateTime  @default(now())
-  updatedAt    DateTime  @updatedAt
-  sessions     Session[]
+  id                  String                @id @default(cuid())
+  email               String                @unique
+  passwordHash        String
+  createdAt           DateTime              @default(now())
+  updatedAt           DateTime              @updatedAt
+  sessions            Session[]
+  githubInstallations GitHubInstallation[]
+}
+
+/// GitHub App installation linked to a VersionGate user (for API + repo listing).
+model GitHubInstallation {
+  id                   String   @id @default(cuid())
+  userId               String
+  user                 User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  installationId       BigInt   @unique
+  githubAccountLogin   String
+  githubAccountType    String
+  createdAt            DateTime @default(now())
+
+  @@index([userId])
 }
 
 model Session {

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,4 +1,4 @@
-import Fastify, { FastifyInstance } from "fastify";
+import Fastify, { FastifyInstance, FastifyRequest } from "fastify";
 import { existsSync } from "fs";
 import { join } from "path";
 import { config } from "./config/env";
@@ -17,6 +17,7 @@ import { jobRoutes } from "./routes/job.routes";
 import { requireDatabaseConfigured } from "./middleware/require-database";
 import { requireApiAuth } from "./middleware/require-api-auth";
 import { authRoutes } from "./routes/auth.routes";
+import { githubAppRoutes } from "./routes/github-app.routes";
 
 export async function buildApp(): Promise<FastifyInstance> {
   const app = Fastify({
@@ -26,6 +27,22 @@ export async function buildApp(): Promise<FastifyInstance> {
     disableRequestLogging: true, // manual logging below — API only
     /** Default 10s is too tight when cold-starting many plugins (e.g. websocket) on slow disks. */
     pluginTimeout: 120_000,
+  });
+
+  // Raw body for GitHub App webhooks (signature verification must use unparsed bytes).
+  app.addHook("preParsing", async (request, _reply, payload) => {
+    const pathOnly = request.url.split("?")[0];
+    if (pathOnly !== "/api/webhooks/github" || request.method !== "POST") {
+      return payload;
+    }
+    const chunks: Buffer[] = [];
+    for await (const chunk of payload) {
+      chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+    }
+    const raw = Buffer.concat(chunks);
+    (request as FastifyRequest & { rawBody?: Buffer }).rawBody = raw;
+    const { Readable } = await import("node:stream");
+    return Readable.from(raw);
   });
 
   // ── API access log: skip noisy dashboard polling (successful GETs only) ─────
@@ -113,6 +130,7 @@ export async function buildApp(): Promise<FastifyInstance> {
 
   // ── API Routes (registered before static — order matters) ──────────────────
   await app.register(authRoutes, { prefix: "/api/v1" });
+  await app.register(githubAppRoutes, { prefix: "/api" });
 
   const dbRoutes = async (instance: FastifyInstance): Promise<void> => {
     instance.addHook("preHandler", requireDatabaseConfigured);

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -68,6 +68,13 @@ export const config = {
     optionalEnv("SKIP_MIGRATE_ON_BOOT", "") === "1",
   /** Session cookie `Secure` flag — enable when the UI is HTTPS-only. */
   cookieSecure: optionalEnv("COOKIE_SECURE", "").toLowerCase() === "true",
+
+  /** GitHub App (REST + webhooks). PEM may use `\n` escapes in `.env`. */
+  githubAppId: optionalEnv("GITHUB_APP_ID", "").trim(),
+  githubAppClientId: optionalEnv("GITHUB_APP_CLIENT_ID", "").trim(),
+  githubAppPrivateKey: optionalEnv("GITHUB_APP_PRIVATE_KEY", "").replace(/\\n/g, "\n"),
+  /** Verifies GitHub App webhook signatures & signs GitHub App install `state` (recommended). */
+  githubWebhookSecret: optionalEnv("GITHUB_WEBHOOK_SECRET", "").trim(),
 } as const;
 
 /** Live values (updated when .env is patched at runtime). */

--- a/src/controllers/github-app.controller.ts
+++ b/src/controllers/github-app.controller.ts
@@ -1,0 +1,291 @@
+import type { FastifyReply, FastifyRequest } from "fastify";
+import type { GitHubInstallation } from "@prisma/client";
+import { Octokit } from "@octokit/rest";
+import { createAppAuth } from "@octokit/auth-app";
+import { config } from "../config/env";
+import prisma from "../prisma/client";
+import { EnvironmentRepository } from "../repositories/environment.repository";
+import { ProjectRepository } from "../repositories/project.repository";
+import { enqueueJob } from "../services/job-queue";
+import { getUserFromSessionToken } from "../services/auth.service";
+import { getSessionTokenFromRequest } from "../utils/cookie";
+import { logger } from "../utils/logger";
+import { createInstallState, parseInstallState } from "../utils/github-install-state";
+import { getInstallationAccessToken } from "../utils/github-installation-token";
+import { normalizeGithubRepoUrl } from "../utils/github-repo-url";
+import { verifyGithubWebhookSignature } from "../utils/github-webhook-signature";
+
+const projectRepo = new ProjectRepository();
+const envRepo = new EnvironmentRepository();
+
+const INSTALL_APP_URL = "https://github.com/apps/VersionGate-App/installations/new";
+
+function githubAppReady(): boolean {
+  const appId = Number(config.githubAppId);
+  return Number.isFinite(appId) && appId > 0 && !!config.githubAppPrivateKey?.trim();
+}
+
+interface GitHubPushPayload {
+  ref?: string;
+  repository?: { clone_url?: string; html_url?: string };
+}
+
+type ReqWithRaw = FastifyRequest & { rawBody?: Buffer };
+
+export async function githubInstallHandler(req: FastifyRequest, reply: FastifyReply): Promise<void> {
+  if (!githubAppReady()) {
+    reply.code(503).send({
+      error: "ServiceUnavailable",
+      message: "GitHub App is not configured. Set GITHUB_APP_ID and GITHUB_APP_PRIVATE_KEY.",
+    });
+    return;
+  }
+
+  const raw = getSessionTokenFromRequest(req.headers.cookie);
+  const user = await getUserFromSessionToken(raw);
+  if (!user) {
+    reply.code(401).send({ error: "Unauthorized", message: "Sign in required", code: "AUTH_REQUIRED" });
+    return;
+  }
+
+  const url = new URL(INSTALL_APP_URL);
+  const secret = config.githubWebhookSecret;
+  if (secret) {
+    url.searchParams.set("state", createInstallState(user.id, secret));
+  }
+
+  reply.redirect(302, url.toString());
+}
+
+export async function githubCallbackHandler(
+  req: FastifyRequest<{ Querystring: Record<string, string | undefined> }>,
+  reply: FastifyReply
+): Promise<void> {
+  if (!githubAppReady()) {
+    reply.redirect(302, "/?github=config");
+    return;
+  }
+
+  const installationIdStr = req.query.installation_id ?? "";
+  const setupAction = req.query.setup_action ?? "";
+
+  if (!installationIdStr || !/^\d+$/.test(installationIdStr)) {
+    reply.redirect(302, "/?github=missing_installation");
+    return;
+  }
+
+  const secret = config.githubWebhookSecret;
+  let userId = secret ? parseInstallState(req.query.state, secret) : null;
+  if (!userId) {
+    const raw = getSessionTokenFromRequest(req.headers.cookie);
+    const user = await getUserFromSessionToken(raw);
+    userId = user?.id ?? null;
+  }
+  if (!userId) {
+    reply.redirect(302, "/?github=auth_required");
+    return;
+  }
+
+  if (setupAction === "request") {
+    reply.redirect(302, "/");
+    return;
+  }
+
+  const auth = createAppAuth({
+    appId: Number(config.githubAppId),
+    privateKey: config.githubAppPrivateKey,
+  });
+  const { token } = await auth({ type: "app" });
+  const octokit = new Octokit({ auth: token });
+  const { data: installation } = await octokit.rest.apps.getInstallation({
+    installation_id: Number(installationIdStr),
+  });
+
+  const account = installation.account;
+  if (!account || typeof account !== "object") {
+    reply.redirect(302, "/?github=bad_installation");
+    return;
+  }
+  const login = "login" in account ? account.login : "";
+  const accountType = "type" in account ? String(account.type) : "unknown";
+  const installationId = BigInt(installationIdStr);
+
+  await prisma.gitHubInstallation.upsert({
+    where: { installationId },
+    create: {
+      userId,
+      installationId,
+      githubAccountLogin: login,
+      githubAccountType: accountType,
+    },
+    update: {
+      userId,
+      githubAccountLogin: login,
+      githubAccountType: accountType,
+    },
+  });
+
+  reply.redirect(302, "/");
+}
+
+export async function githubReposHandler(req: FastifyRequest, reply: FastifyReply): Promise<void> {
+  if (!githubAppReady()) {
+    reply.code(503).send({
+      error: "ServiceUnavailable",
+      message: "GitHub App is not configured. Set GITHUB_APP_ID and GITHUB_APP_PRIVATE_KEY.",
+    });
+    return;
+  }
+
+  const raw = getSessionTokenFromRequest(req.headers.cookie);
+  const user = await getUserFromSessionToken(raw);
+  if (!user) {
+    reply.code(401).send({ error: "Unauthorized", message: "Sign in required", code: "AUTH_REQUIRED" });
+    return;
+  }
+
+  const q = req.query as { installationId?: string };
+  let row: GitHubInstallation | null;
+  if (q.installationId && /^\d+$/.test(q.installationId)) {
+    row = await prisma.gitHubInstallation.findFirst({
+      where: { userId: user.id, installationId: BigInt(q.installationId) },
+    });
+  } else {
+    row = await prisma.gitHubInstallation.findFirst({
+      where: { userId: user.id },
+      orderBy: { createdAt: "desc" },
+    });
+  }
+
+  if (!row) {
+    reply.code(400).send({
+      error: "BadRequest",
+      message: "No GitHub App installation for this user. Open /api/auth/github/install first.",
+    });
+    return;
+  }
+
+  const { token } = await getInstallationAccessToken(row.installationId);
+  const octokit = new Octokit({ auth: token });
+
+  const repositories: Awaited<
+    ReturnType<Octokit["rest"]["apps"]["listReposAccessibleToInstallation"]>
+  >["data"]["repositories"] = [];
+
+  let page = 1;
+  for (;;) {
+    const { data } = await octokit.rest.apps.listReposAccessibleToInstallation({
+      per_page: 100,
+      page,
+    });
+    repositories.push(...data.repositories);
+    if (data.repositories.length < 100) break;
+    page += 1;
+  }
+
+  reply.code(200).send({
+    installationId: row.installationId.toString(),
+    totalCount: repositories.length,
+    repositories: repositories.map((r) => ({
+      id: r.id,
+      name: r.name,
+      fullName: r.full_name,
+      private: r.private,
+      defaultBranch: r.default_branch,
+      cloneUrl: r.clone_url,
+      htmlUrl: r.html_url,
+    })),
+  });
+}
+
+export async function githubAppWebhookHandler(req: ReqWithRaw, reply: FastifyReply): Promise<void> {
+  const secret = config.githubWebhookSecret;
+  if (!secret) {
+    reply.code(503).send({
+      error: "ServiceUnavailable",
+      message: "GITHUB_WEBHOOK_SECRET is not configured.",
+    });
+    return;
+  }
+
+  const rawBody = req.rawBody;
+  if (!rawBody?.length) {
+    reply.code(400).send({ error: "BadRequest", message: "Missing raw body for signature verification" });
+    return;
+  }
+
+  const sig = req.headers["x-hub-signature-256"];
+  const sigStr = Array.isArray(sig) ? sig[0] : sig;
+  if (!verifyGithubWebhookSignature(rawBody, sigStr, secret)) {
+    reply.code(401).send({ error: "Unauthorized", message: "Invalid webhook signature" });
+    return;
+  }
+
+  let body: unknown;
+  try {
+    body = JSON.parse(rawBody.toString("utf8"));
+  } catch {
+    reply.code(400).send({ error: "BadRequest", message: "Invalid JSON body" });
+    return;
+  }
+
+  const event = req.headers["x-github-event"];
+  const eventStr = (Array.isArray(event) ? event[0] : event)?.toLowerCase() ?? "";
+
+  if (eventStr === "ping") {
+    reply.code(200).send({ ok: true, ping: true });
+    return;
+  }
+
+  if (eventStr !== "push") {
+    reply.code(200).send({ skipped: true, reason: `Ignoring event: ${eventStr || "unknown"}` });
+    return;
+  }
+
+  const payload = body as GitHubPushPayload;
+  const ref = payload.ref ?? "";
+  const pushedBranch = ref.replace("refs/heads/", "");
+  const cloneUrl = payload.repository?.clone_url ?? "";
+  const htmlUrl = payload.repository?.html_url ?? "";
+  const normalized = normalizeGithubRepoUrl(cloneUrl || htmlUrl);
+
+  if (!normalized) {
+    reply.code(200).send({ skipped: true, reason: "Could not determine repository URL" });
+    return;
+  }
+
+  const projects = await projectRepo.findAll();
+  const matches = projects.filter((p) => normalizeGithubRepoUrl(p.repoUrl) === normalized);
+
+  if (matches.length === 0) {
+    logger.info({ normalized }, "GitHub App webhook: no VersionGate project matches repository");
+    reply.code(200).send({ skipped: true, reason: "No matching project for repository" });
+    return;
+  }
+
+  const triggered: string[] = [];
+  for (const project of matches) {
+    const defaultEnv = await envRepo.findDefaultForProject(project.id);
+    if (!defaultEnv) {
+      logger.error({ projectId: project.id }, "GitHub App webhook: no default environment — skipping deploy");
+      continue;
+    }
+    if (pushedBranch && pushedBranch !== defaultEnv.branch) {
+      logger.info(
+        { projectId: project.id, pushedBranch, configuredBranch: defaultEnv.branch },
+        "GitHub App webhook: branch mismatch — skipping"
+      );
+      continue;
+    }
+
+    logger.info(
+      { projectId: project.id, projectName: project.name, environmentId: defaultEnv.id, ref },
+      "GitHub App webhook: triggering auto-deploy"
+    );
+
+    await enqueueJob("DEPLOY", project.id, {}, defaultEnv.id);
+    triggered.push(project.name);
+  }
+
+  reply.code(200).send({ triggered: triggered.length > 0, projects: triggered });
+}

--- a/src/routes/github-app.routes.ts
+++ b/src/routes/github-app.routes.ts
@@ -1,0 +1,16 @@
+import type { FastifyInstance } from "fastify";
+import { requireDatabaseConfigured } from "../middleware/require-database";
+import {
+  githubAppWebhookHandler,
+  githubCallbackHandler,
+  githubInstallHandler,
+  githubReposHandler,
+} from "../controllers/github-app.controller";
+
+export async function githubAppRoutes(app: FastifyInstance): Promise<void> {
+  app.addHook("preHandler", requireDatabaseConfigured);
+  app.get("/auth/github/install", githubInstallHandler);
+  app.get("/auth/github/callback", githubCallbackHandler);
+  app.get("/github/repos", githubReposHandler);
+  app.post("/webhooks/github", githubAppWebhookHandler);
+}

--- a/src/utils/github-install-state.ts
+++ b/src/utils/github-install-state.ts
@@ -1,0 +1,33 @@
+import { createHmac, timingSafeEqual } from "crypto";
+
+const INSTALL_STATE_MAX_AGE_MS = 60 * 60 * 1000;
+
+export function createInstallState(userId: string, secret: string): string {
+  const ts = Date.now();
+  const payload = `${userId}.${ts}`;
+  const sig = createHmac("sha256", secret).update(payload).digest("hex");
+  return Buffer.from(`${payload}.${sig}`, "utf8").toString("base64url");
+}
+
+export function parseInstallState(state: string | undefined, secret: string): string | null {
+  if (!state || !secret) return null;
+  try {
+    const raw = Buffer.from(state, "base64url").toString("utf8");
+    const lastDot = raw.lastIndexOf(".");
+    const secondLast = raw.lastIndexOf(".", lastDot - 1);
+    if (secondLast <= 0 || lastDot <= secondLast) return null;
+    const userId = raw.slice(0, secondLast);
+    const tsStr = raw.slice(secondLast + 1, lastDot);
+    const sig = raw.slice(lastDot + 1);
+    const payload = `${userId}.${tsStr}`;
+    const expected = createHmac("sha256", secret).update(payload).digest("hex");
+    const a = Buffer.from(sig, "hex");
+    const b = Buffer.from(expected, "hex");
+    if (a.length !== b.length || !timingSafeEqual(a, b)) return null;
+    const ts = parseInt(tsStr, 10);
+    if (!Number.isFinite(ts) || Date.now() - ts > INSTALL_STATE_MAX_AGE_MS) return null;
+    return userId;
+  } catch {
+    return null;
+  }
+}

--- a/src/utils/github-installation-token.ts
+++ b/src/utils/github-installation-token.ts
@@ -1,0 +1,45 @@
+import { createAppAuth } from "@octokit/auth-app";
+import { config } from "../config/env";
+
+export interface InstallationAccessToken {
+  token: string;
+  /** GitHub installation token TTL (~1h); ISO string when provided by auth-app. */
+  expiresAt?: string;
+}
+
+function appAuthOptions() {
+  const appId = Number(config.githubAppId);
+  if (!Number.isFinite(appId) || appId <= 0) {
+    throw new Error("Invalid GITHUB_APP_ID");
+  }
+  if (!config.githubAppPrivateKey?.trim()) {
+    throw new Error("GITHUB_APP_PRIVATE_KEY is not set");
+  }
+  return {
+    appId,
+    privateKey: config.githubAppPrivateKey,
+  };
+}
+
+/**
+ * Creates a GitHub App JWT, exchanges it for a short-lived installation access token (~1 hour).
+ */
+export async function getInstallationAccessToken(
+  installationId: bigint | number | string
+): Promise<InstallationAccessToken> {
+  const auth = createAppAuth(appAuthOptions());
+  const id =
+    typeof installationId === "bigint"
+      ? Number(installationId)
+      : typeof installationId === "string"
+        ? Number(installationId)
+        : installationId;
+  if (!Number.isFinite(id) || id <= 0) {
+    throw new Error("Invalid installation id");
+  }
+  const result = await auth({ type: "installation", installationId: id });
+  return {
+    token: result.token,
+    expiresAt: "expiresAt" in result && typeof result.expiresAt === "string" ? result.expiresAt : undefined,
+  };
+}

--- a/src/utils/github-repo-url.ts
+++ b/src/utils/github-repo-url.ts
@@ -1,0 +1,26 @@
+/**
+ * Normalize GitHub repository URLs for comparison (HTTPS, SSH, optional .git).
+ */
+export function normalizeGithubRepoUrl(url: string): string {
+  const trimmed = url.trim();
+  if (!trimmed) return "";
+
+  const noGit = trimmed.replace(/\.git$/i, "");
+  const ssh = /^git@github\.com:([^/]+)\/([^/]+)$/i.exec(noGit);
+  if (ssh) {
+    return `https://github.com/${ssh[1]}/${ssh[2]}`.toLowerCase();
+  }
+
+  try {
+    const withProto = /^https?:\/\//i.test(noGit) ? noGit : `https://${noGit}`;
+    const parsed = new URL(withProto);
+    const host = parsed.hostname.replace(/^www\./i, "");
+    if (host !== "github.com") {
+      return noGit.toLowerCase();
+    }
+    const path = parsed.pathname.replace(/^\/+|\/+$/g, "");
+    return `https://github.com/${path}`.toLowerCase();
+  } catch {
+    return noGit.toLowerCase();
+  }
+}

--- a/src/utils/github-webhook-signature.ts
+++ b/src/utils/github-webhook-signature.ts
@@ -1,0 +1,22 @@
+import { createHmac, timingSafeEqual } from "crypto";
+
+/**
+ * Verifies GitHub `X-Hub-Signature-256` (HMAC SHA256 of raw body).
+ */
+export function verifyGithubWebhookSignature(
+  rawBody: Buffer,
+  signatureHeader: string | undefined,
+  secret: string
+): boolean {
+  if (!signatureHeader?.startsWith("sha256=")) return false;
+  const receivedHex = signatureHeader.slice("sha256=".length);
+  const expectedHex = createHmac("sha256", secret).update(rawBody).digest("hex");
+  try {
+    const a = Buffer.from(receivedHex, "hex");
+    const b = Buffer.from(expectedHex, "hex");
+    if (a.length !== b.length) return false;
+    return timingSafeEqual(a, b);
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary

Integrates the **VersionGate-App** GitHub App (App ID 3587447) for org/user installs, installation-scoped API access, and app-level webhooks that trigger the existing deploy job queue when a push matches a VersionGate project\u2019s `repoUrl`.

## What changed

### Database (Prisma)
- New model `GitHubInstallation`: `id`, `userId`, `installationId` (unique `BigInt`), `githubAccountLogin`, `githubAccountType`, `createdAt`, with relation from `User`.
- Migration: `prisma/migrations/20260503120000_github_installation/migration.sql`.

### API routes (prefix `/api`, not `/api/v1`)
| Method | Path | Auth | Purpose |
|--------|------|------|--------|
| `GET` | `/api/auth/github/install` | Session | Redirects to `https://github.com/apps/VersionGate-App/installations/new` (optional HMAC `state` when `GITHUB_WEBHOOK_SECRET` is set). |
| `GET` | `/api/auth/github/callback` | `state` or session | Persists install after GitHub redirect; fetches account via app JWT; upsert `GitHubInstallation`; redirect to `/`. |
| `GET` | `/api/github/repos` | Session | Lists repos via installation token; `GET /installation/repositories` (Octokit `listReposAccessibleToInstallation`); optional `?installationId=`. |
| `POST` | `/api/webhooks/github` | `X-Hub-Signature-256` | Verifies `GITHUB_WEBHOOK_SECRET`; on `push`, normalizes repo URL, matches `Project.repoUrl`, enqueues `DEPLOY` (same branch rules as existing per-project webhook). |

### Server
- `preParsing` hook for `POST /api/webhooks/github` to retain **raw body** for signature verification.
- `@octokit/auth-app` + `@octokit/rest`.
- `getInstallationAccessToken(installationId)` in `src/utils/github-installation-token.ts` (JWT + installation token, ~1h).

### Configuration
- `.env.example`: `GITHUB_APP_ID`, `GITHUB_APP_CLIENT_ID`, `GITHUB_APP_PRIVATE_KEY`, `GITHUB_WEBHOOK_SECRET` (webhook HMAC + optional install `state` signing).
- `src/config/env.ts` reads the same.

## GitHub App settings (ops)
- **Callback URL:** `{PUBLIC_ORIGIN}/api/auth/github/callback`
- **Webhook URL:** `{PUBLIC_ORIGIN}/api/webhooks/github`
- **Webhook secret:** must match `GITHUB_WEBHOOK_SECRET`
- **Private key:** PEM in `GITHUB_APP_PRIVATE_KEY` (single line with `\n` escapes supported)

## How to test
1. `bunx prisma migrate deploy` (or your usual sync) so `GitHubInstallation` exists.
2. Set env vars; restart API.
3. Sign in, open `GET /api/auth/github/install` (or follow link in UI when wired), complete install on GitHub.
4. Callback should create a row; `GET /api/github/repos` should return repositories.
5. Send a test `push` webhook (or real push) and confirm a `DEPLOY` job when `Project.repoUrl` matches and branch matches default environment.

## Security notes
- Webhook requests are rejected if HMAC does not match (`timingSafeEqual`).
- Install redirect `state` is HMAC-signed when `GITHUB_WEBHOOK_SECRET` is set; callback also accepts session cookie as fallback for the linking user.

## Related
- Existing per-project webhook remains at `/api/v1/webhooks/:secret`; this PR adds the GitHub App global webhook path.

Made with [Cursor](https://cursor.com)