### PR TITLE
Dashboard: GitHub integrations UI, repo picker, and extended /api/github endpoints

### DIFF
--- a/dashboard/src/components/CreateProjectModal.tsx
+++ b/dashboard/src/components/CreateProjectModal.tsx
@@ -1,7 +1,14 @@
-import { useState, type FormEvent } from "react";
-import { useNavigate } from "react-router-dom";
+import { useEffect, useState, type FormEvent } from "react";
+import { Link, useNavigate } from "react-router-dom";
 import { Info } from "lucide-react";
-import { createProject } from "@/lib/api";
+import {
+  ApiError,
+  createProject,
+  getGithubIntegrationStatus,
+  getGithubRepoBranches,
+  type GithubInstallationSummary,
+  type GithubRepoRow,
+} from "@/lib/api";
 import {
   Dialog,
   DialogContent,
@@ -13,6 +20,10 @@ import {
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { toast } from "sonner";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { GithubRepoPicker } from "@/components/GithubRepoPicker";
+import { cn } from "@/lib/utils";
 
 const NAME_PATTERN = /^[a-z0-9-]+$/;
 
@@ -22,6 +33,12 @@ const ROOT_PRESETS = [
   { label: "frontend", value: "frontend" },
   { label: "packages/app", value: "packages/app" },
 ] as const;
+
+const selectClass = cn(
+  "h-8 w-full min-w-0 rounded-lg border border-input bg-transparent px-2.5 py-1 text-sm outline-none",
+  "focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50",
+  "disabled:cursor-not-allowed disabled:opacity-50 dark:bg-input/30"
+);
 
 export function CreateProjectModal({
   open,
@@ -41,6 +58,15 @@ export function CreateProjectModal({
   const [appPort, setAppPort] = useState("3000");
   const [healthPath, setHealthPath] = useState("/health");
 
+  const [ghLoading, setGhLoading] = useState(false);
+  const [ghConnected, setGhConnected] = useState(false);
+  const [ghInstallations, setGhInstallations] = useState<GithubInstallationSummary[]>([]);
+  const [selectedInstallationId, setSelectedInstallationId] = useState<string | null>(null);
+  const [ghSource, setGhSource] = useState<"github" | "manual">("manual");
+  const [selectedGithubRepo, setSelectedGithubRepo] = useState<GithubRepoRow | null>(null);
+  const [branchNames, setBranchNames] = useState<string[]>([]);
+  const [branchesLoading, setBranchesLoading] = useState(false);
+
   const reset = () => {
     setName("");
     setRepoUrl("");
@@ -48,6 +74,14 @@ export function CreateProjectModal({
     setBuildContext(".");
     setAppPort("3000");
     setHealthPath("/health");
+    setGhLoading(false);
+    setGhConnected(false);
+    setGhInstallations([]);
+    setSelectedInstallationId(null);
+    setGhSource("manual");
+    setSelectedGithubRepo(null);
+    setBranchNames([]);
+    setBranchesLoading(false);
   };
 
   const handleOpenChange = (next: boolean) => {
@@ -55,11 +89,83 @@ export function CreateProjectModal({
     onOpenChange(next);
   };
 
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    setGhLoading(true);
+    void getGithubIntegrationStatus()
+      .then((s) => {
+        if (cancelled) return;
+        setGhConnected(s.connected);
+        setGhInstallations(s.installations);
+        const id =
+          s.installation?.installationId ?? s.installations[0]?.installationId ?? null;
+        setSelectedInstallationId(id);
+        setGhSource(s.connected ? "github" : "manual");
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setGhConnected(false);
+          setGhInstallations([]);
+          setGhSource("manual");
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setGhLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [open]);
+
+  const handleRepoPick = (r: GithubRepoRow) => {
+    setSelectedGithubRepo(r);
+    setRepoUrl(r.cloneUrl);
+    const defaultB = r.defaultBranch?.trim() || "main";
+    setBranch(defaultB);
+    setBranchNames([]);
+  };
+
+  useEffect(() => {
+    if (!selectedGithubRepo || !selectedInstallationId) return;
+    const slash = selectedGithubRepo.fullName.indexOf("/");
+    const owner = slash >= 0 ? selectedGithubRepo.fullName.slice(0, slash) : "";
+    const repoName = slash >= 0 ? selectedGithubRepo.fullName.slice(slash + 1) : "";
+    if (!owner || !repoName) return;
+
+    setBranchesLoading(true);
+    void getGithubRepoBranches(owner, repoName, selectedInstallationId)
+      .then((res) => {
+        const names = res.branches.map((b) => b.name);
+        setBranchNames(names);
+        const preferred = selectedGithubRepo.defaultBranch?.trim() || "main";
+        if (names.includes(preferred)) {
+          setBranch(preferred);
+        } else if (names[0]) {
+          setBranch(names[0]);
+        }
+      })
+      .catch((e: unknown) => {
+        setBranchNames([]);
+        const msg = e instanceof ApiError ? e.message : "Could not list branches.";
+        toast.error(msg);
+      })
+      .finally(() => setBranchesLoading(false));
+  }, [selectedInstallationId, selectedGithubRepo]);
+
   const onSubmit = async (e: FormEvent) => {
     e.preventDefault();
     const trimmed = name.trim().toLowerCase();
     if (!NAME_PATTERN.test(trimmed)) {
       toast.error("Name must be lowercase letters, numbers, and hyphens only (e.g. my-app).");
+      return;
+    }
+    if (ghSource === "github" && ghConnected && !repoUrl.trim()) {
+      toast.error("Select a GitHub repository or switch to manual URL.");
+      return;
+    }
+    if (ghSource === "manual" && !repoUrl.trim()) {
+      toast.error("Enter a Git repository URL.");
       return;
     }
     const port = Number.parseInt(appPort, 10);
@@ -88,6 +194,35 @@ export function CreateProjectModal({
     }
   };
 
+  const manualRepoFields = (
+    <>
+      <div className="grid gap-1.5">
+        <label htmlFor="cp-repo" className="text-sm font-medium">
+          Git repository URL
+        </label>
+        <Input
+          id="cp-repo"
+          value={repoUrl}
+          onChange={(e) => setRepoUrl(e.target.value)}
+          placeholder="https://github.com/org/repo.git"
+          autoComplete="off"
+          required={ghSource === "manual"}
+        />
+      </div>
+      <div className="grid gap-1.5">
+        <label htmlFor="cp-branch-manual" className="text-sm font-medium">
+          Default branch
+        </label>
+        <Input
+          id="cp-branch-manual"
+          value={branch}
+          onChange={(e) => setBranch(e.target.value)}
+          placeholder="main"
+        />
+      </div>
+    </>
+  );
+
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-lg">
@@ -109,6 +244,7 @@ export function CreateProjectModal({
               traffic can switch with no downtime.
             </p>
           </div>
+
           <div className="grid gap-1.5">
             <label htmlFor="cp-name" className="text-sm font-medium">
               Project name (slug)
@@ -123,25 +259,112 @@ export function CreateProjectModal({
             />
             <p className="text-xs text-muted-foreground">Lowercase letters, numbers, hyphens only.</p>
           </div>
-          <div className="grid gap-1.5">
-            <label htmlFor="cp-repo" className="text-sm font-medium">
-              Git repository URL
-            </label>
-            <Input
-              id="cp-repo"
-              value={repoUrl}
-              onChange={(e) => setRepoUrl(e.target.value)}
-              placeholder="https://github.com/org/repo.git"
-              autoComplete="off"
-              required
-            />
-          </div>
-          <div className="grid gap-1.5">
-            <label htmlFor="cp-branch" className="text-sm font-medium">
-              Default branch
-            </label>
-            <Input id="cp-branch" value={branch} onChange={(e) => setBranch(e.target.value)} placeholder="main" />
-          </div>
+
+          {ghLoading ? (
+            <div className="rounded-lg border border-border bg-muted/30 px-3 py-6 text-center text-sm text-muted-foreground">
+              Checking GitHub connection…
+            </div>
+          ) : ghConnected ? (
+            <Tabs
+              value={ghSource}
+              onValueChange={(v) => {
+                setGhSource(v as "github" | "manual");
+                if (v === "manual") {
+                  setSelectedGithubRepo(null);
+                  setBranchNames([]);
+                }
+              }}
+            >
+              <TabsList variant="line" className="w-full justify-start">
+                <TabsTrigger value="github">From GitHub</TabsTrigger>
+                <TabsTrigger value="manual">Manual URL</TabsTrigger>
+              </TabsList>
+              <TabsContent value="github" className="mt-4 grid gap-4">
+                {ghInstallations.length > 1 ? (
+                  <div className="grid gap-1.5">
+                    <label htmlFor="cp-gh-install" className="text-sm font-medium">
+                      GitHub installation
+                    </label>
+                    <select
+                      id="cp-gh-install"
+                      className={selectClass}
+                      value={selectedInstallationId ?? ""}
+                      onChange={(e) => {
+                        setSelectedInstallationId(e.target.value || null);
+                        setSelectedGithubRepo(null);
+                        setRepoUrl("");
+                        setBranchNames([]);
+                      }}
+                    >
+                      {ghInstallations.map((i) => (
+                        <option key={i.installationId} value={i.installationId}>
+                          {i.githubAccountLogin} ({i.githubAccountType})
+                        </option>
+                      ))}
+                    </select>
+                    <p className="text-xs text-muted-foreground">Organization or account this project&apos;s repos belong to.</p>
+                  </div>
+                ) : null}
+                <div className="grid gap-1.5">
+                  <span className="text-sm font-medium">Repository</span>
+                  <GithubRepoPicker
+                    installationId={selectedInstallationId}
+                    selectedFullName={selectedGithubRepo?.fullName ?? null}
+                    onRepoSelect={handleRepoPick}
+                  />
+                </div>
+                <div className="grid gap-1.5">
+                  <label htmlFor="cp-branch-gh" className="text-sm font-medium">
+                    Branch
+                  </label>
+                  {branchesLoading ? (
+                    <p className="text-sm text-muted-foreground">Loading branches…</p>
+                  ) : branchNames.length > 0 ? (
+                    <select
+                      id="cp-branch-gh"
+                      className={selectClass}
+                      value={branchNames.includes(branch) ? branch : branchNames[0]}
+                      onChange={(e) => setBranch(e.target.value)}
+                    >
+                      {branchNames.map((b) => (
+                        <option key={b} value={b}>
+                          {b}
+                        </option>
+                      ))}
+                    </select>
+                  ) : (
+                    <Input
+                      id="cp-branch-gh"
+                      value={branch}
+                      onChange={(e) => setBranch(e.target.value)}
+                      placeholder={selectedGithubRepo ? "main" : "Select a repository first"}
+                      disabled={!selectedGithubRepo}
+                    />
+                  )}
+                  <p className="text-xs text-muted-foreground">
+                    Production environment tracks this branch for deploys and webhooks.
+                  </p>
+                </div>
+              </TabsContent>
+              <TabsContent value="manual" className="mt-4 grid gap-4">
+                {manualRepoFields}
+              </TabsContent>
+            </Tabs>
+          ) : (
+            <>
+              <Alert>
+                <AlertTitle>Connect GitHub</AlertTitle>
+                <AlertDescription>
+                  Install the VersionGate GitHub App to browse repositories here. You can still paste a repository URL
+                  below.&nbsp;
+                  <Link to="/dashboard/integrations" className="font-medium text-foreground underline-offset-2 hover:underline">
+                    Open Integrations
+                  </Link>
+                </AlertDescription>
+              </Alert>
+              {manualRepoFields}
+            </>
+          )}
 
           <div className="grid gap-2">
             <label htmlFor="cp-ctx" className="text-sm font-medium">
@@ -189,7 +412,12 @@ export function CreateProjectModal({
               <label htmlFor="cp-health" className="text-sm font-medium">
                 Health check path
               </label>
-              <Input id="cp-health" value={healthPath} onChange={(e) => setHealthPath(e.target.value)} placeholder="/healthz" />
+              <Input
+                id="cp-health"
+                value={healthPath}
+                onChange={(e) => setHealthPath(e.target.value)}
+                placeholder="/healthz"
+              />
             </div>
           </div>
           <DialogFooter className="gap-2 pt-2 sm:justify-end">

--- a/dashboard/src/components/GithubRepoPicker.tsx
+++ b/dashboard/src/components/GithubRepoPicker.tsx
@@ -1,0 +1,181 @@
+import { useEffect, useMemo, useState } from "react";
+import { Link } from "react-router-dom";
+import { ExternalLink, GitBranch, Lock, Search } from "lucide-react";
+import { ApiError, getGithubRepos, type GithubRepoRow } from "@/lib/api";
+import { Input } from "@/components/ui/input";
+import { buttonVariants } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import { cn } from "@/lib/utils";
+
+function formatUpdated(iso: string | null): string {
+  if (!iso) return "—";
+  try {
+    const d = new Date(iso);
+    return d.toLocaleDateString(undefined, { month: "short", day: "numeric", year: "numeric" });
+  } catch {
+    return "—";
+  }
+}
+
+export function GithubRepoPicker({
+  installationId,
+  selectedFullName,
+  onRepoSelect,
+}: {
+  installationId: string | null;
+  selectedFullName: string | null;
+  onRepoSelect: (repo: GithubRepoRow) => void;
+}) {
+  const [filter, setFilter] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [repos, setRepos] = useState<GithubRepoRow[]>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!installationId) {
+      setRepos([]);
+      setError(null);
+      return;
+    }
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    void getGithubRepos(installationId)
+      .then((r) => {
+        if (!cancelled) setRepos(r.repositories);
+      })
+      .catch((e: unknown) => {
+        if (cancelled) return;
+        const msg =
+          e instanceof ApiError
+            ? e.status === 400 || e.status === 401
+              ? "GitHub is not connected or the installation is invalid. Reconnect on Integrations."
+              : e.message
+            : "Could not load repositories.";
+        setError(msg);
+        setRepos([]);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [installationId]);
+
+  const filtered = useMemo(() => {
+    const q = filter.trim().toLowerCase();
+    if (!q) return repos;
+    return repos.filter(
+      (r) =>
+        r.fullName.toLowerCase().includes(q) ||
+        r.name.toLowerCase().includes(q) ||
+        r.owner.toLowerCase().includes(q)
+    );
+  }, [repos, filter]);
+
+  if (!installationId) {
+    return (
+      <div className="rounded-lg border border-dashed border-border bg-muted/30 px-4 py-8 text-center text-sm text-muted-foreground">
+        Choose a GitHub installation above (Integrations) or connect GitHub first.
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid gap-3">
+      <div className="relative">
+        <Search className="pointer-events-none absolute left-2.5 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+        <Input
+          value={filter}
+          onChange={(e) => setFilter(e.target.value)}
+          placeholder="Search by repository name…"
+          className="pl-9"
+          disabled={loading}
+          aria-label="Filter repositories"
+        />
+      </div>
+
+      {loading ? (
+        <div className="grid gap-2 rounded-lg border border-border bg-card p-2">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <Skeleton key={i} className="h-14 w-full rounded-md" />
+          ))}
+        </div>
+      ) : error ? (
+        <div
+          className="rounded-lg border border-amber-200/90 bg-amber-50/90 px-3 py-3 text-sm text-amber-950"
+          role="alert"
+        >
+          <p className="font-medium">Could not load repositories</p>
+          <p className="mt-1 text-amber-900/90">{error}</p>
+          <Link
+            to="/dashboard/integrations"
+            className={cn(buttonVariants({ variant: "outline", size: "sm" }), "mt-3 inline-flex")}
+          >
+            Open Integrations
+          </Link>
+        </div>
+      ) : filtered.length === 0 ? (
+        <div className="rounded-lg border border-dashed border-border px-4 py-8 text-center text-sm text-muted-foreground">
+          {repos.length === 0 ? "No repositories returned for this installation." : "No matches for your search."}
+        </div>
+      ) : (
+        <ul className="max-h-72 space-y-1 overflow-y-auto rounded-lg border border-border bg-card p-1.5">
+          {filtered.map((r) => {
+            const active = selectedFullName === r.fullName;
+            return (
+              <li key={r.id}>
+                <button
+                  type="button"
+                  onClick={() => onRepoSelect(r)}
+                  className={cn(
+                    "flex w-full flex-col gap-1 rounded-md px-2.5 py-2 text-left text-sm transition-colors",
+                    active
+                      ? "bg-primary/10 ring-1 ring-primary/30"
+                      : "hover:bg-muted/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                  )}
+                >
+                  <div className="flex min-w-0 items-center justify-between gap-2">
+                    <span className="truncate font-medium text-foreground">{r.fullName}</span>
+                    <div className="flex shrink-0 items-center gap-1">
+                      <Badge variant={r.private ? "secondary" : "outline"} className="text-[10px] font-normal">
+                        {r.private ? (
+                          <>
+                            <Lock className="mr-0.5 size-3" aria-hidden />
+                            Private
+                          </>
+                        ) : (
+                          "Public"
+                        )}
+                      </Badge>
+                      <a
+                        href={r.htmlUrl}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="rounded p-0.5 text-muted-foreground hover:text-foreground"
+                        title="Open on GitHub"
+                        onClick={(e) => e.stopPropagation()}
+                      >
+                        <ExternalLink className="size-3.5" aria-hidden />
+                      </a>
+                    </div>
+                  </div>
+                  <div className="flex flex-wrap items-center gap-x-3 gap-y-0.5 text-xs text-muted-foreground">
+                    {r.language ? <span>{r.language}</span> : null}
+                    <span className="inline-flex items-center gap-1">
+                      <GitBranch className="size-3 opacity-70" aria-hidden />
+                      {r.defaultBranch ?? "—"}
+                    </span>
+                    <span>Updated {formatUpdated(r.updatedAt ?? r.pushedAt)}</span>
+                  </div>
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/dashboard/src/components/Layout.tsx
+++ b/dashboard/src/components/Layout.tsx
@@ -2,6 +2,7 @@ import { NavLink, Outlet, useNavigate } from "react-router-dom";
 import {
   Activity,
   Bell,
+  Cable,
   CircleHelp,
   FolderKanban,
   HeartPulse,
@@ -54,6 +55,7 @@ const nav = [
   { to: "/", label: "Overview", end: true, icon: LayoutGrid },
   { to: "/projects", label: "Projects", end: true, icon: FolderKanban },
   { to: "/activity", label: "Activity", end: false, icon: Activity },
+  { to: "/dashboard/integrations", label: "Integrations", end: false, icon: Cable },
   { to: "/system", label: "System health", end: false, icon: HeartPulse },
   { to: "/settings", label: "Settings", end: false, icon: Settings },
 ] as const;

--- a/dashboard/src/components/SidebarBreadcrumbs.tsx
+++ b/dashboard/src/components/SidebarBreadcrumbs.tsx
@@ -12,6 +12,8 @@ function crumbsForPath(pathname: string, projectName: string | null): Crumb[] {
   if (pathname === "/projects") return [{ label: "Overview", to: "/" }, { label: "Projects" }];
   if (pathname === "/system") return [{ label: "Overview", to: "/" }, { label: "System health" }];
   if (pathname === "/settings") return [{ label: "Overview", to: "/" }, { label: "Settings" }];
+  if (pathname === "/dashboard/integrations")
+    return [{ label: "Overview", to: "/" }, { label: "Integrations" }];
 
   const deployM = pathname.match(/^\/projects\/([^/]+)\/deploy\/([^/]+)$/);
   if (deployM) {

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -1,5 +1,12 @@
 const API_BASE = (import.meta.env.VITE_API_URL as string | undefined)?.replace(/\/$/, "") ?? "/api/v1";
 
+/** Routes mounted at `/api` (GitHub App) — not under `/api/v1`. */
+function githubApiBase(): string {
+  const v = (import.meta.env.VITE_API_URL as string | undefined)?.trim().replace(/\/$/, "");
+  if (!v) return "/api";
+  return v.replace(/\/api\/v1$/i, "/api");
+}
+
 export class ApiError extends Error {
   readonly status: number;
   readonly body?: unknown;
@@ -22,8 +29,8 @@ async function parseJsonSafe(res: Response): Promise<unknown> {
   }
 }
 
-async function request<T>(method: string, path: string, body?: unknown): Promise<T> {
-  const url = path.startsWith("http") ? path : `${API_BASE}${path.startsWith("/") ? path : `/${path}`}`;
+async function request<T>(method: string, path: string, body?: unknown, baseUrl: string = API_BASE): Promise<T> {
+  const url = path.startsWith("http") ? path : `${baseUrl}${path.startsWith("/") ? path : `/${path}`}`;
   const res = await fetch(url, {
     method,
     headers: body !== undefined ? { "Content-Type": "application/json" } : undefined,
@@ -415,6 +422,78 @@ export function listAllJobs(opts?: { limit?: number; offset?: number }): Promise
   if (opts?.offset != null) q.set("offset", String(opts.offset));
   const qs = q.toString();
   return request("GET", `/jobs${qs ? `?${qs}` : ""}`);
+}
+
+export interface GithubInstallationSummary {
+  installationId: string;
+  githubAccountLogin: string;
+  githubAccountType: string;
+  createdAt: string;
+}
+
+export interface GithubIntegrationStatus {
+  connected: boolean;
+  installations: GithubInstallationSummary[];
+  installation?: {
+    installationId: string;
+    githubAccountLogin: string;
+    githubAccountType: string;
+    avatarUrl: string | null;
+    createdAt: string;
+  };
+}
+
+export interface GithubRepoRow {
+  id: number;
+  name: string;
+  fullName: string;
+  owner: string;
+  private: boolean;
+  defaultBranch: string | null;
+  cloneUrl: string;
+  htmlUrl: string;
+  language: string | null;
+  updatedAt: string | null;
+  pushedAt: string | null;
+}
+
+export interface GithubReposResponse {
+  installationId: string;
+  totalCount: number;
+  repositories: GithubRepoRow[];
+}
+
+export interface GithubBranchRow {
+  name: string;
+  sha?: string;
+}
+
+export interface GithubBranchesResponse {
+  installationId: string;
+  branches: GithubBranchRow[];
+}
+
+export function getGithubIntegrationStatus(): Promise<GithubIntegrationStatus> {
+  return request("GET", "/github/status", undefined, githubApiBase());
+}
+
+export function getGithubRepos(installationId?: string): Promise<GithubReposResponse> {
+  const q = installationId ? `?installationId=${encodeURIComponent(installationId)}` : "";
+  return request("GET", `/github/repos${q}`, undefined, githubApiBase());
+}
+
+export function getGithubRepoBranches(
+  owner: string,
+  repo: string,
+  installationId?: string
+): Promise<GithubBranchesResponse> {
+  const q = installationId ? `?installationId=${encodeURIComponent(installationId)}` : "";
+  return request(
+    "GET",
+    `/github/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/branches${q}`,
+    undefined,
+    githubApiBase()
+  );
 }
 
 export function createWebSocket(jobId: string): WebSocket {

--- a/dashboard/src/main.tsx
+++ b/dashboard/src/main.tsx
@@ -8,7 +8,7 @@ import { ProjectDetail } from "@/pages/ProjectDetail";
 import { DeployLog } from "@/pages/DeployLog";
 import { SystemHealth } from "@/pages/SystemHealth";
 import { Projects } from "@/pages/Projects";
-import { Settings } from "@/pages/Settings";
+import { Integrations } from "@/pages/Integrations";
 import { Setup } from "@/pages/Setup";
 import { Activity } from "@/pages/Activity";
 import { Login } from "@/pages/Login";
@@ -27,7 +27,7 @@ createRoot(document.getElementById("root")!).render(
           <Route path="/projects/:id/deploy/:jobId" element={<DeployLog />} />
           <Route path="/system" element={<SystemHealth />} />
           <Route path="/server" element={<Navigate to="/system" replace />} />
-          <Route path="/settings" element={<Settings />} />
+          <Route path="/dashboard/integrations" element={<Integrations />} />
           <Route path="*" element={<Navigate to="/" replace />} />
         </Route>
       </Routes>

--- a/dashboard/src/pages/Integrations.tsx
+++ b/dashboard/src/pages/Integrations.tsx
@@ -1,0 +1,208 @@
+import { useEffect, useMemo, useState } from "react";
+import { Link, useSearchParams } from "react-router-dom";
+import { Cable, ExternalLink } from "lucide-react";
+import { toast } from "sonner";
+import { PageHeader } from "@/components/PageHeader";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { ApiError, getGithubIntegrationStatus, type GithubIntegrationStatus } from "@/lib/api";
+import { Separator } from "@/components/ui/separator";
+import { buttonVariants } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+const MANAGE_APP_HREF = "https://github.com/apps/VersionGate-App/installations";
+const INSTALL_HREF = "/api/auth/github/install";
+
+export function Integrations() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [loading, setLoading] = useState(true);
+  const [status, setStatus] = useState<GithubIntegrationStatus | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const s = await getGithubIntegrationStatus();
+        if (!cancelled) setStatus(s);
+      } catch (e) {
+        if (!cancelled) {
+          if (e instanceof ApiError && e.status === 503) {
+            setError(
+              "GitHub App is not configured on this server. Set GITHUB_APP_ID and GITHUB_APP_PRIVATE_KEY on the engine."
+            );
+          } else {
+            setError(e instanceof ApiError ? e.message : "Failed to load GitHub status");
+          }
+          setStatus(null);
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const githubQuery = useMemo(() => {
+    const g = searchParams.get("github");
+    return g ? g.trim().toLowerCase() : null;
+  }, [searchParams]);
+
+  useEffect(() => {
+    if (!githubQuery) return;
+    const messages: Record<string, { type: "success" | "error"; text: string }> = {
+      connected: { type: "success", text: "GitHub App connected successfully." },
+      auth_required: {
+        type: "error",
+        text: "Could not link the installation — sign in to VersionGate and try again.",
+      },
+      config: { type: "error", text: "GitHub App is not configured on this server." },
+      missing_installation: { type: "error", text: "Missing installation from GitHub redirect." },
+      bad_installation: { type: "error", text: "Could not read installation details from GitHub." },
+    };
+    const m = messages[githubQuery];
+    if (m) {
+      if (m.type === "success") toast.success(m.text);
+      else toast.error(m.text);
+    }
+    setSearchParams({}, { replace: true });
+  }, [githubQuery, setSearchParams]);
+
+  const connected = status?.connected && status.installation;
+
+  return (
+    <div className="mx-auto flex w-full max-w-3xl flex-col gap-8">
+      <PageHeader
+        title="Integrations"
+        description="Connect external services to streamline project setup and automation."
+      />
+
+      <Card>
+        <CardHeader>
+          <div className="flex items-start justify-between gap-4">
+            <div className="space-y-1">
+              <CardTitle className="flex items-center gap-2 text-lg">
+                <Cable className="size-5 opacity-80" aria-hidden />
+                GitHub
+              </CardTitle>
+              <CardDescription>
+                Install the VersionGate GitHub App to list repositories and deploy on push.
+              </CardDescription>
+            </div>
+          </div>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          {loading ? (
+            <div className="flex items-center gap-4">
+              <Skeleton className="size-14 rounded-full" />
+              <div className="grid flex-1 gap-2">
+                <Skeleton className="h-5 w-48" />
+                <Skeleton className="h-4 w-72" />
+              </div>
+            </div>
+          ) : error ? (
+            <div className="rounded-lg border border-destructive/25 bg-destructive/5 px-4 py-3 text-sm text-destructive">
+              {error}
+              {error.toLowerCase().includes("not configured") ? (
+                <p className="mt-2 text-muted-foreground">
+                  Ask your operator to set <code className="rounded bg-muted px-1 font-mono text-xs">GITHUB_APP_ID</code>{" "}
+                  and <code className="rounded bg-muted px-1 font-mono text-xs">GITHUB_APP_PRIVATE_KEY</code>.
+                </p>
+              ) : null}
+            </div>
+          ) : connected && status.installation ? (
+            <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+              <div className="flex items-start gap-4">
+                <Avatar size="lg" className="size-14 border border-border">
+                  {status.installation.avatarUrl ? (
+                    <AvatarImage src={status.installation.avatarUrl} alt="" />
+                  ) : null}
+                  <AvatarFallback className="bg-muted text-lg font-semibold">
+                    {status.installation.githubAccountLogin.slice(0, 2).toUpperCase()}
+                  </AvatarFallback>
+                </Avatar>
+                <div className="min-w-0 space-y-1">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <p className="truncate font-mono text-base font-semibold text-foreground">
+                      {status.installation.githubAccountLogin}
+                    </p>
+                    <Badge className="font-normal">Connected</Badge>
+                    <Badge variant="outline" className="font-normal capitalize">
+                      {status.installation.githubAccountType}
+                    </Badge>
+                  </div>
+                  <p className="text-xs text-muted-foreground">
+                    Installation ID <span className="font-mono">{status.installation.installationId}</span>
+                  </p>
+                  {status.installations.length > 1 ? (
+                    <p className="text-xs text-muted-foreground">
+                      + {status.installations.length - 1} other installation
+                      {status.installations.length > 2 ? "s" : ""} linked to your account
+                    </p>
+                  ) : null}
+                </div>
+              </div>
+              <div className="flex shrink-0 flex-wrap gap-2">
+                <a
+                  href={MANAGE_APP_HREF}
+                  target="_blank"
+                  rel="noreferrer"
+                  className={cn(buttonVariants({ variant: "outline", size: "sm" }), "inline-flex gap-1.5")}
+                >
+                  <ExternalLink className="size-3.5" />
+                  Manage on GitHub
+                </a>
+                <a href={INSTALL_HREF} className={cn(buttonVariants({ variant: "secondary", size: "sm" }))}>
+                  Add another org
+                </a>
+              </div>
+            </div>
+          ) : (
+            <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+              <p className="text-sm text-muted-foreground">
+                Connect your GitHub account or organization so VersionGate can read repositories you grant access to.
+              </p>
+              <a href={INSTALL_HREF} className={cn(buttonVariants())}>
+                Connect GitHub
+              </a>
+            </div>
+          )}
+
+          {!loading && !error && status?.connected && status.installations.length > 1 ? (
+            <>
+              <Separator />
+              <div>
+                <p className="mb-2 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                  All installations
+                </p>
+                <ul className="grid gap-2 text-sm">
+                  {status.installations.map((i) => (
+                    <li
+                      key={i.installationId}
+                      className="flex flex-wrap items-center justify-between gap-2 rounded-md border border-border bg-muted/30 px-3 py-2"
+                    >
+                      <span className="font-mono font-medium">{i.githubAccountLogin}</span>
+                      <span className="text-xs capitalize text-muted-foreground">{i.githubAccountType}</span>
+                      <span className="font-mono text-xs text-muted-foreground">{i.installationId}</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            </>
+          ) : null}
+        </CardContent>
+      </Card>
+
+      <p className="text-center text-xs text-muted-foreground">
+        After connecting, use <Link className="text-primary underline-offset-2 hover:underline" to="/projects">New project</Link>{" "}
+        to pick a repository and branch.
+      </p>
+    </div>
+  );
+}

--- a/src/controllers/github-app.controller.ts
+++ b/src/controllers/github-app.controller.ts
@@ -19,6 +19,8 @@ const projectRepo = new ProjectRepository();
 const envRepo = new EnvironmentRepository();
 
 const INSTALL_APP_URL = "https://github.com/apps/VersionGate-App/installations/new";
+/** Dashboard Integrations page (SPA). */
+const INTEGRATIONS_PATH = "/dashboard/integrations";
 
 function githubAppReady(): boolean {
   const appId = Number(config.githubAppId);
@@ -62,7 +64,7 @@ export async function githubCallbackHandler(
   reply: FastifyReply
 ): Promise<void> {
   if (!githubAppReady()) {
-    reply.redirect(302, "/?github=config");
+    reply.redirect(302, `${INTEGRATIONS_PATH}?github=config`);
     return;
   }
 
@@ -70,7 +72,7 @@ export async function githubCallbackHandler(
   const setupAction = req.query.setup_action ?? "";
 
   if (!installationIdStr || !/^\d+$/.test(installationIdStr)) {
-    reply.redirect(302, "/?github=missing_installation");
+    reply.redirect(302, `${INTEGRATIONS_PATH}?github=missing_installation`);
     return;
   }
 
@@ -82,12 +84,12 @@ export async function githubCallbackHandler(
     userId = user?.id ?? null;
   }
   if (!userId) {
-    reply.redirect(302, "/?github=auth_required");
+    reply.redirect(302, `${INTEGRATIONS_PATH}?github=auth_required`);
     return;
   }
 
   if (setupAction === "request") {
-    reply.redirect(302, "/");
+    reply.redirect(302, INTEGRATIONS_PATH);
     return;
   }
 
@@ -103,7 +105,7 @@ export async function githubCallbackHandler(
 
   const account = installation.account;
   if (!account || typeof account !== "object") {
-    reply.redirect(302, "/?github=bad_installation");
+    reply.redirect(302, `${INTEGRATIONS_PATH}?github=bad_installation`);
     return;
   }
   const login = "login" in account ? account.login : "";
@@ -125,7 +127,149 @@ export async function githubCallbackHandler(
     },
   });
 
-  reply.redirect(302, "/");
+  reply.redirect(302, `${INTEGRATIONS_PATH}?github=connected`);
+}
+
+async function resolveInstallationForUser(
+  userId: string,
+  installationIdQuery?: string
+): Promise<GitHubInstallation | null> {
+  if (installationIdQuery && /^\d+$/.test(installationIdQuery)) {
+    return prisma.gitHubInstallation.findFirst({
+      where: { userId, installationId: BigInt(installationIdQuery) },
+    });
+  }
+  return prisma.gitHubInstallation.findFirst({
+    where: { userId },
+    orderBy: { createdAt: "desc" },
+  });
+}
+
+async function avatarForInstallation(row: GitHubInstallation, octokit: Octokit): Promise<string | null> {
+  const login = row.githubAccountLogin;
+  const kind = row.githubAccountType.toLowerCase();
+  try {
+    if (kind === "organization") {
+      const { data } = await octokit.rest.orgs.get({ org: login });
+      return data.avatar_url;
+    }
+    const { data } = await octokit.rest.users.getByUsername({ username: login });
+    return data.avatar_url;
+  } catch {
+    return null;
+  }
+}
+
+/** GET /api/github/status — session; connected GitHub App installs + avatar for primary. */
+export async function githubIntegrationStatusHandler(req: FastifyRequest, reply: FastifyReply): Promise<void> {
+  if (!githubAppReady()) {
+    reply.code(503).send({
+      error: "ServiceUnavailable",
+      message: "GitHub App is not configured. Set GITHUB_APP_ID and GITHUB_APP_PRIVATE_KEY.",
+    });
+    return;
+  }
+
+  const raw = getSessionTokenFromRequest(req.headers.cookie);
+  const user = await getUserFromSessionToken(raw);
+  if (!user) {
+    reply.code(401).send({ error: "Unauthorized", message: "Sign in required", code: "AUTH_REQUIRED" });
+    return;
+  }
+
+  const rows = await prisma.gitHubInstallation.findMany({
+    where: { userId: user.id },
+    orderBy: { createdAt: "desc" },
+  });
+
+  if (rows.length === 0) {
+    reply.code(200).send({ connected: false, installations: [] });
+    return;
+  }
+
+  const primary = rows[0];
+  const { token } = await getInstallationAccessToken(primary.installationId);
+  const octokit = new Octokit({ auth: token });
+  const avatarUrl = await avatarForInstallation(primary, octokit);
+
+  reply.code(200).send({
+    connected: true,
+    installations: rows.map((r) => ({
+      installationId: r.installationId.toString(),
+      githubAccountLogin: r.githubAccountLogin,
+      githubAccountType: r.githubAccountType,
+      createdAt: r.createdAt.toISOString(),
+    })),
+    installation: {
+      installationId: primary.installationId.toString(),
+      githubAccountLogin: primary.githubAccountLogin,
+      githubAccountType: primary.githubAccountType,
+      avatarUrl,
+      createdAt: primary.createdAt.toISOString(),
+    },
+  });
+}
+
+/** GET /api/github/repos/:owner/:repo/branches — installation token; lists branch names for picker. */
+export async function githubRepoBranchesHandler(
+  req: FastifyRequest<{ Params: { owner: string; repo: string }; Querystring: { installationId?: string } }>,
+  reply: FastifyReply
+): Promise<void> {
+  if (!githubAppReady()) {
+    reply.code(503).send({
+      error: "ServiceUnavailable",
+      message: "GitHub App is not configured. Set GITHUB_APP_ID and GITHUB_APP_PRIVATE_KEY.",
+    });
+    return;
+  }
+
+  const raw = getSessionTokenFromRequest(req.headers.cookie);
+  const user = await getUserFromSessionToken(raw);
+  if (!user) {
+    reply.code(401).send({ error: "Unauthorized", message: "Sign in required", code: "AUTH_REQUIRED" });
+    return;
+  }
+
+  const owner = decodeURIComponent(req.params.owner ?? "").trim();
+  const repo = decodeURIComponent(req.params.repo ?? "").trim();
+  if (!owner || !repo || owner.includes("/") || repo.includes("/")) {
+    reply.code(400).send({ error: "BadRequest", message: "Invalid owner or repo" });
+    return;
+  }
+
+  const q = req.query as { installationId?: string };
+  const row = await resolveInstallationForUser(user.id, q.installationId);
+  if (!row) {
+    reply.code(400).send({
+      error: "BadRequest",
+      message: "No GitHub App installation for this user.",
+    });
+    return;
+  }
+
+  const { token } = await getInstallationAccessToken(row.installationId);
+  const octokit = new Octokit({ auth: token });
+
+  const names: { name: string; sha: string | undefined }[] = [];
+  let page = 1;
+  for (;;) {
+    const { data } = await octokit.rest.repos.listBranches({
+      owner,
+      repo,
+      per_page: 100,
+      page,
+    });
+    for (const b of data) {
+      names.push({ name: b.name, sha: b.commit?.sha });
+    }
+    if (data.length < 100) break;
+    page += 1;
+  }
+
+  reply.code(200).send({
+    installationId: row.installationId.toString(),
+    branches: names,
+  });
 }
 
 export async function githubReposHandler(req: FastifyRequest, reply: FastifyReply): Promise<void> {
@@ -145,17 +289,7 @@ export async function githubReposHandler(req: FastifyRequest, reply: FastifyRepl
   }
 
   const q = req.query as { installationId?: string };
-  let row: GitHubInstallation | null;
-  if (q.installationId && /^\d+$/.test(q.installationId)) {
-    row = await prisma.gitHubInstallation.findFirst({
-      where: { userId: user.id, installationId: BigInt(q.installationId) },
-    });
-  } else {
-    row = await prisma.gitHubInstallation.findFirst({
-      where: { userId: user.id },
-      orderBy: { createdAt: "desc" },
-    });
-  }
+  const row = await resolveInstallationForUser(user.id, q.installationId);
 
   if (!row) {
     reply.code(400).send({
@@ -190,10 +324,14 @@ export async function githubReposHandler(req: FastifyRequest, reply: FastifyRepl
       id: r.id,
       name: r.name,
       fullName: r.full_name,
+      owner: r.owner?.login ?? r.full_name.split("/")[0] ?? "",
       private: r.private,
       defaultBranch: r.default_branch,
       cloneUrl: r.clone_url,
       htmlUrl: r.html_url,
+      language: r.language ?? null,
+      updatedAt: r.updated_at ?? null,
+      pushedAt: r.pushed_at ?? null,
     })),
   });
 }

--- a/src/routes/github-app.routes.ts
+++ b/src/routes/github-app.routes.ts
@@ -3,7 +3,9 @@ import { requireDatabaseConfigured } from "../middleware/require-database";
 import {
   githubAppWebhookHandler,
   githubCallbackHandler,
+  githubIntegrationStatusHandler,
   githubInstallHandler,
+  githubRepoBranchesHandler,
   githubReposHandler,
 } from "../controllers/github-app.controller";
 
@@ -11,6 +13,8 @@ export async function githubAppRoutes(app: FastifyInstance): Promise<void> {
   app.addHook("preHandler", requireDatabaseConfigured);
   app.get("/auth/github/install", githubInstallHandler);
   app.get("/auth/github/callback", githubCallbackHandler);
+  app.get("/github/status", githubIntegrationStatusHandler);
+  app.get("/github/repos/:owner/:repo/branches", githubRepoBranchesHandler);
   app.get("/github/repos", githubReposHandler);
   app.post("/webhooks/github", githubAppWebhookHandler);
 }


### PR DESCRIPTION
## Summary

Adds a first-class **GitHub integration experience** in the VersionGate dashboard: an **Integrations** page to connect the GitHub App and inspect linked accounts, a **searchable repo picker** with loading/empty/error states, and **project creation** that prefers GitHub repo + branch selection while retaining the existing manual URL flow.

Extends the backend with **integration status**, **branch listing**, richer **repo list payloads**, and redirects the GitHub App **OAuth callback** to the new dashboard route.

---

## Backend (`/api`, not `/api/v1`)

### New endpoints
| Method | Path | Auth | Description |
|--------|------|------|-------------|
| `GET` | `/api/github/status` | Session cookie | Returns whether the user has any `GitHubInstallation` rows, lists all installs, and includes a **primary** install with **avatar URL** (resolved via installation token + `orgs.get` / `users.getByUsername`). |
| `GET` | `/api/github/repos/:owner/:repo/branches` | Session cookie | Paginates `repos.listBranches` using the installation access token; optional `?installationId=` when the user has multiple installs. |

### Changes to existing handlers
- **`GET /api/github/repos`** — Response repositories now include `owner`, `language`, `updatedAt`, `pushedAt` (for UI: visibility, language, last updated).
- **`GET /api/auth/github/callback`** — Redirect target is **`/dashboard/integrations`** with query flags (`github=connected`, `github=config`, `github=auth_required`, etc.) instead of `/`.
- **Shared helper** — `resolveInstallationForUser()` used by repos + branches handlers to pick the install row (latest by default or explicit `installationId`).

### Files
- `src/controllers/github-app.controller.ts`
- `src/routes/github-app.routes.ts` (register `/github/status` and `/github/repos/:owner/:repo/branches` **before** `/github/repos` to avoid route shadowing)

---

## Dashboard

### Routing & chrome
- **Route:** `/dashboard/integrations` → `Integrations` page.
- **Sidebar:** \Integrations\ nav item (Cable icon — `lucide-react` has no GitHub brand icon in this version).
- **Breadcrumbs:** Overview → Integrations.

### Integrations page (`dashboard/src/pages/Integrations.tsx`)
- Loads **`GET /api/github/status`** with skeleton loading and clear **503 / misconfiguration** messaging for operators.
- **Not connected:** primary CTA **Connect GitHub** → `/api/auth/github/install` (full-page redirect to GitHub App install URL).
- **Connected:** avatar (or initials fallback), login, **Connected** + account-type badges, installation id, **Manage on GitHub** (`https://github.com/apps/VersionGate-App/installations`), **Add another org** (same install URL).
- **Multiple installations:** secondary list of all linked installs.
- **Callback UX:** reads `?github=` from the URL, shows **toast** (success/error), then **clears query string** with `replace`.

### API client (`dashboard/src/lib/api.ts`)
- `request()` accepts optional **base URL** (default remains `/api/v1`).
- **`githubApiBase()`** resolves `/api` for dev proxy; when `VITE_API_URL` points at `…/api/v1`, it maps to `…/api` so GitHub routes hit the correct prefix.
- New exports: `getGithubIntegrationStatus`, `getGithubRepos`, `getGithubRepoBranches`, plus TypeScript types for responses.

### Repo picker (`dashboard/src/components/GithubRepoPicker.tsx`)
- Fetches **`GET /api/github/repos`** for the chosen installation id.
- **Search** filters full name, short name, owner.
- **Rows:** name, public/private badge, language, default branch, last updated; link out to GitHub.
- **States:** skeleton list, empty, API error with link to Integrations (reconnect).

### Create project modal (`dashboard/src/components/CreateProjectModal.tsx`)
- On open: loads GitHub integration status.
- **If connected:** **Tabs** — **From GitHub** (default) vs **Manual URL**.
  - **From GitHub:** optional installation selector when `installations.length > 1`, **GithubRepoPicker**, then **branch** via `GET .../branches` (dropdown) or manual branch input if listing fails.
  - **Manual URL:** same repo URL + branch fields as before.
- **If not connected:** **Alert** with link to `/dashboard/integrations` + full manual repo URL + branch fields (unchanged server contract: `createProject` still sends `repoUrl` + `branch`; installation id is used only client-side for GitHub API calls).

---

## How to verify

1. Engine: `GITHUB_APP_ID`, `GITHUB_APP_PRIVATE_KEY`, DB migrated with `GitHubInstallation`.
2. Sign in → **Integrations** → **Connect GitHub** → complete install → land on `/dashboard/integrations?github=connected`.
3. **New project** → **From GitHub** → pick repo → confirm branches load → create project.
4. Optional: multiple org installs → switch installation in modal → repo list refreshes.

---

## Operations / GitHub App settings

- **Callback URL** should be `{PUBLIC_ORIGIN}/api/auth/github/callback` (unchanged path; redirect destination is now the SPA).
- Users land on **`/dashboard/integrations`** after success.

---

## Notes / limitations

- **Installation token** is not stored or sent to `POST /projects`; only **clone URL + branch** are persisted on the project, matching existing backend behavior.
- Brand icon: **Cable** used for Integrations in the sidebar (Lucide build here omits a `Github` export).