### PR TITLE
Settings public URL & HTTPS; nginx/certbot APIs; GitHub integration updates

### DIFF
--- a/dashboard/src/components/CreateProjectModal.tsx
+++ b/dashboard/src/components/CreateProjectModal.tsx
@@ -4,7 +4,7 @@ import { Info } from "lucide-react";
 import {
   ApiError,
   createProject,
-  getGithubIntegrationStatus,
+  getGithubInstallation,
   getGithubRepoBranches,
   type GithubInstallationSummary,
   type GithubRepoRow,
@@ -93,15 +93,16 @@ export function CreateProjectModal({
     if (!open) return;
     let cancelled = false;
     setGhLoading(true);
-    void getGithubIntegrationStatus()
-      .then((s) => {
+    void getGithubInstallation()
+      .then((r) => {
         if (cancelled) return;
-        setGhConnected(s.connected);
-        setGhInstallations(s.installations);
+        const connected = r.installation !== null;
+        setGhConnected(connected);
+        setGhInstallations(r.installations);
         const id =
-          s.installation?.installationId ?? s.installations[0]?.installationId ?? null;
+          r.installation?.installationId ?? r.installations[0]?.installationId ?? null;
         setSelectedInstallationId(id);
-        setGhSource(s.connected ? "github" : "manual");
+        setGhSource(connected ? "github" : "manual");
       })
       .catch(() => {
         if (!cancelled) {

--- a/dashboard/src/components/Layout.tsx
+++ b/dashboard/src/components/Layout.tsx
@@ -67,6 +67,7 @@ export function Layout() {
   const navigate = useNavigate();
   const [serverOk, setServerOk] = useState(true);
   const [setupGate, setSetupGate] = useState<"loading" | "ready">("loading");
+  const [needsRestartBanner, setNeedsRestartBanner] = useState(false);
   const [createProjectOpen, setCreateProjectOpen] = useState(false);
   const [searchOpen, setSearchOpen] = useState(false);
   const [projects, setProjects] = useState<Project[]>([]);
@@ -77,9 +78,11 @@ export function Layout() {
     void getSetupStatus()
       .then((s) => {
         if (cancelled) return;
-        const incomplete = !s.configured || !s.dbConnected || (s.needsRestart ?? false);
+        const incomplete = !s.configured || !s.dbConnected;
         if (incomplete) {
           navigate("/setup", { replace: true });
+        } else {
+          setNeedsRestartBanner(Boolean(s.needsRestart));
         }
         setSetupGate("ready");
       })
@@ -396,6 +399,20 @@ export function Layout() {
             </div>
 
             <UpdateAvailableBanner />
+            {needsRestartBanner ? (
+              <div
+                className="border-b border-amber-300/80 bg-amber-50 px-4 py-2.5 text-center text-sm text-amber-950"
+                role="status"
+              >
+                <strong className="font-semibold">Restart required:</strong>{" "}
+                <code className="rounded bg-amber-100/80 px-1 font-mono text-xs">DATABASE_URL</code> is in{" "}
+                <code className="rounded bg-amber-100/80 px-1 font-mono text-xs">.env</code> but this API process has not
+                loaded it. Restart the API and worker.&nbsp;
+                <code className="mt-1 inline-block rounded bg-amber-100/80 px-1.5 py-0.5 font-mono text-xs">
+                  pm2 restart versiongate-api versiongate-worker
+                </code>
+              </div>
+            ) : null}
             <div className="flex w-full min-w-0 flex-1 flex-col gap-4 bg-muted/30 px-4 py-4 md:px-6 md:py-6 lg:px-8">
               {setupGate === "loading" ? (
                 <div className="flex flex-1 items-center justify-center text-muted-foreground">Loading…</div>

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -335,6 +335,12 @@ export interface InstanceSettings {
   needsRestart: boolean;
   encryptionKeyConfigured: boolean;
   geminiConfigured: boolean;
+  /** Public hostname or IPv4 from `.env` (`PUBLIC_DOMAIN`). */
+  publicDomain: string;
+  /** URL path prefix where the app is exposed (`PUBLIC_BASE_PATH`, e.g. `/` or `/versiongate`). */
+  publicBasePath: string;
+  /** Let's Encrypt contact email from `.env` (`CERTBOT_EMAIL`). */
+  certbotEmail: string;
   selfUpdateConfigured: boolean;
   selfUpdateGitBranch: string;
   selfUpdatePollMs: number;
@@ -383,6 +389,23 @@ export function patchInstanceEnv(env: Record<string, string>): Promise<{
   keysWritten: string[];
 }> {
   return request("PATCH", "/settings/env", { env });
+}
+
+export function applyNginxSite(body: {
+  publicDomain?: string;
+  publicBasePath?: string;
+}): Promise<{
+  ok: boolean;
+  message: string;
+  path: string;
+  publicDomain: string;
+  publicBasePath: string;
+}> {
+  return request("POST", "/settings/nginx/apply", body);
+}
+
+export function requestCertbotSsl(body: { email?: string }): Promise<{ ok: boolean; message: string }> {
+  return request("POST", "/settings/ssl/certbot", body);
 }
 
 export function applySetup(body: {
@@ -471,6 +494,15 @@ export interface GithubBranchRow {
 export interface GithubBranchesResponse {
   installationId: string;
   branches: GithubBranchRow[];
+}
+
+export interface GithubInstallationGateResponse {
+  installation: GithubInstallationSummary | null;
+  installations: GithubInstallationSummary[];
+}
+
+export function getGithubInstallation(): Promise<GithubInstallationGateResponse> {
+  return request("GET", "/github/installation", undefined, githubApiBase());
 }
 
 export function getGithubIntegrationStatus(): Promise<GithubIntegrationStatus> {

--- a/dashboard/src/pages/Integrations.tsx
+++ b/dashboard/src/pages/Integrations.tsx
@@ -7,7 +7,12 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
-import { ApiError, getGithubIntegrationStatus, type GithubIntegrationStatus } from "@/lib/api";
+import {
+  ApiError,
+  getGithubInstallation,
+  getGithubIntegrationStatus,
+  type GithubInstallationSummary,
+} from "@/lib/api";
 import { Separator } from "@/components/ui/separator";
 import { buttonVariants } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
@@ -17,37 +22,59 @@ const INSTALL_HREF = "/api/auth/github/install";
 
 export function Integrations() {
   const [searchParams, setSearchParams] = useSearchParams();
-  const [loading, setLoading] = useState(true);
-  const [status, setStatus] = useState<GithubIntegrationStatus | null>(null);
-  const [error, setError] = useState<string | null>(null);
+
+  /** Until first `/api/github/installation` response — avoid flashing Connect vs Connected. */
+  const [gateReady, setGateReady] = useState(false);
+  const [primaryInstallation, setPrimaryInstallation] = useState<GithubInstallationSummary | null>(null);
+  const [installationsList, setInstallationsList] = useState<GithubInstallationSummary[]>([]);
+  const [gateError, setGateError] = useState<string | null>(null);
+
+  const [avatarUrl, setAvatarUrl] = useState<string | null>(null);
 
   useEffect(() => {
     let cancelled = false;
     void (async () => {
-      setLoading(true);
-      setError(null);
+      setGateReady(false);
+      setGateError(null);
       try {
-        const s = await getGithubIntegrationStatus();
-        if (!cancelled) setStatus(s);
+        const r = await getGithubInstallation();
+        if (cancelled) return;
+        setPrimaryInstallation(r.installation);
+        setInstallationsList(r.installations);
       } catch (e) {
         if (!cancelled) {
-          if (e instanceof ApiError && e.status === 503) {
-            setError(
-              "GitHub App is not configured on this server. Set GITHUB_APP_ID and GITHUB_APP_PRIVATE_KEY on the engine."
-            );
-          } else {
-            setError(e instanceof ApiError ? e.message : "Failed to load GitHub status");
-          }
-          setStatus(null);
+          setGateError(e instanceof ApiError ? e.message : "Failed to load GitHub installation.");
+          setPrimaryInstallation(null);
+          setInstallationsList([]);
         }
       } finally {
-        if (!cancelled) setLoading(false);
+        if (!cancelled) setGateReady(true);
       }
     })();
     return () => {
       cancelled = true;
     };
   }, []);
+
+  /** Optional avatar when GitHub App credentials exist on the server (does not affect connected/disconnected). */
+  useEffect(() => {
+    if (!primaryInstallation) {
+      setAvatarUrl(null);
+      return;
+    }
+    let cancelled = false;
+    void getGithubIntegrationStatus()
+      .then((s) => {
+        if (cancelled) return;
+        setAvatarUrl(s.installation?.avatarUrl ?? null);
+      })
+      .catch(() => {
+        if (!cancelled) setAvatarUrl(null);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [primaryInstallation?.installationId]);
 
   const githubQuery = useMemo(() => {
     const g = searchParams.get("github");
@@ -74,7 +101,7 @@ export function Integrations() {
     setSearchParams({}, { replace: true });
   }, [githubQuery, setSearchParams]);
 
-  const connected = status?.connected && status.installation;
+  const connected = primaryInstallation !== null;
 
   return (
     <div className="mx-auto flex w-full max-w-3xl flex-col gap-8">
@@ -98,71 +125,91 @@ export function Integrations() {
           </div>
         </CardHeader>
         <CardContent className="space-y-6">
-          {loading ? (
-            <div className="flex items-center gap-4">
-              <Skeleton className="size-14 rounded-full" />
-              <div className="grid flex-1 gap-2">
-                <Skeleton className="h-5 w-48" />
-                <Skeleton className="h-4 w-72" />
-              </div>
-            </div>
-          ) : error ? (
-            <div className="rounded-lg border border-destructive/25 bg-destructive/5 px-4 py-3 text-sm text-destructive">
-              {error}
-              {error.toLowerCase().includes("not configured") ? (
-                <p className="mt-2 text-muted-foreground">
-                  Ask your operator to set <code className="rounded bg-muted px-1 font-mono text-xs">GITHUB_APP_ID</code>{" "}
-                  and <code className="rounded bg-muted px-1 font-mono text-xs">GITHUB_APP_PRIVATE_KEY</code>.
-                </p>
-              ) : null}
-            </div>
-          ) : connected && status.installation ? (
-            <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
-              <div className="flex items-start gap-4">
-                <Avatar size="lg" className="size-14 border border-border">
-                  {status.installation.avatarUrl ? (
-                    <AvatarImage src={status.installation.avatarUrl} alt="" />
-                  ) : null}
-                  <AvatarFallback className="bg-muted text-lg font-semibold">
-                    {status.installation.githubAccountLogin.slice(0, 2).toUpperCase()}
-                  </AvatarFallback>
-                </Avatar>
-                <div className="min-w-0 space-y-1">
-                  <div className="flex flex-wrap items-center gap-2">
-                    <p className="truncate font-mono text-base font-semibold text-foreground">
-                      {status.installation.githubAccountLogin}
-                    </p>
-                    <Badge className="font-normal">Connected</Badge>
-                    <Badge variant="outline" className="font-normal capitalize">
-                      {status.installation.githubAccountType}
-                    </Badge>
-                  </div>
-                  <p className="text-xs text-muted-foreground">
-                    Installation ID <span className="font-mono">{status.installation.installationId}</span>
-                  </p>
-                  {status.installations.length > 1 ? (
-                    <p className="text-xs text-muted-foreground">
-                      + {status.installations.length - 1} other installation
-                      {status.installations.length > 2 ? "s" : ""} linked to your account
-                    </p>
-                  ) : null}
+          {!gateReady ? (
+            <div className="space-y-4" aria-busy="true" aria-label="Loading GitHub integration">
+              <div className="flex items-center gap-4">
+                <Skeleton className="size-14 shrink-0 rounded-full" />
+                <div className="grid min-w-0 flex-1 gap-2">
+                  <Skeleton className="h-5 w-48 max-w-full" />
+                  <Skeleton className="h-4 w-72 max-w-full" />
+                  <Skeleton className="h-4 w-40 max-w-full" />
                 </div>
               </div>
-              <div className="flex shrink-0 flex-wrap gap-2">
-                <a
-                  href={MANAGE_APP_HREF}
-                  target="_blank"
-                  rel="noreferrer"
-                  className={cn(buttonVariants({ variant: "outline", size: "sm" }), "inline-flex gap-1.5")}
-                >
-                  <ExternalLink className="size-3.5" />
-                  Manage on GitHub
-                </a>
-                <a href={INSTALL_HREF} className={cn(buttonVariants({ variant: "secondary", size: "sm" }))}>
-                  Add another org
-                </a>
-              </div>
+              <Skeleton className="h-9 w-full max-w-xs rounded-lg" />
             </div>
+          ) : gateError ? (
+            <div className="rounded-lg border border-destructive/25 bg-destructive/5 px-4 py-3 text-sm text-destructive">
+              {gateError}
+            </div>
+          ) : connected && primaryInstallation ? (
+            <>
+              <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+                <div className="flex items-start gap-4">
+                  <Avatar size="lg" className="size-14 border border-border">
+                    {avatarUrl ? <AvatarImage src={avatarUrl} alt="" /> : null}
+                    <AvatarFallback className="bg-muted text-lg font-semibold">
+                      {primaryInstallation.githubAccountLogin.slice(0, 2).toUpperCase()}
+                    </AvatarFallback>
+                  </Avatar>
+                  <div className="min-w-0 space-y-1">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <p className="truncate font-mono text-base font-semibold text-foreground">
+                        {primaryInstallation.githubAccountLogin}
+                      </p>
+                      <Badge className="font-normal">Connected</Badge>
+                      <Badge variant="outline" className="font-normal capitalize">
+                        {primaryInstallation.githubAccountType}
+                      </Badge>
+                    </div>
+                    <p className="text-xs text-muted-foreground">
+                      Installation ID <span className="font-mono">{primaryInstallation.installationId}</span>
+                    </p>
+                    {installationsList.length > 1 ? (
+                      <p className="text-xs text-muted-foreground">
+                        + {installationsList.length - 1} other installation
+                        {installationsList.length > 2 ? "s" : ""} linked to your account
+                      </p>
+                    ) : null}
+                  </div>
+                </div>
+                <div className="flex shrink-0 flex-wrap gap-2">
+                  <a
+                    href={MANAGE_APP_HREF}
+                    target="_blank"
+                    rel="noreferrer"
+                    className={cn(buttonVariants({ variant: "outline", size: "sm" }), "inline-flex gap-1.5")}
+                  >
+                    <ExternalLink className="size-3.5" />
+                    Manage on GitHub
+                  </a>
+                  <a href={INSTALL_HREF} className={cn(buttonVariants({ variant: "secondary", size: "sm" }))}>
+                    Add another org
+                  </a>
+                </div>
+              </div>
+              {installationsList.length > 1 ? (
+                <>
+                  <Separator />
+                  <div>
+                    <p className="mb-2 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                      All installations
+                    </p>
+                    <ul className="grid gap-2 text-sm">
+                      {installationsList.map((i) => (
+                        <li
+                          key={i.installationId}
+                          className="flex flex-wrap items-center justify-between gap-2 rounded-md border border-border bg-muted/30 px-3 py-2"
+                        >
+                          <span className="font-mono font-medium">{i.githubAccountLogin}</span>
+                          <span className="text-xs capitalize text-muted-foreground">{i.githubAccountType}</span>
+                          <span className="font-mono text-xs text-muted-foreground">{i.installationId}</span>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                </>
+              ) : null}
+            </>
           ) : (
             <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
               <p className="text-sm text-muted-foreground">
@@ -173,34 +220,14 @@ export function Integrations() {
               </a>
             </div>
           )}
-
-          {!loading && !error && status?.connected && status.installations.length > 1 ? (
-            <>
-              <Separator />
-              <div>
-                <p className="mb-2 text-xs font-medium uppercase tracking-wide text-muted-foreground">
-                  All installations
-                </p>
-                <ul className="grid gap-2 text-sm">
-                  {status.installations.map((i) => (
-                    <li
-                      key={i.installationId}
-                      className="flex flex-wrap items-center justify-between gap-2 rounded-md border border-border bg-muted/30 px-3 py-2"
-                    >
-                      <span className="font-mono font-medium">{i.githubAccountLogin}</span>
-                      <span className="text-xs capitalize text-muted-foreground">{i.githubAccountType}</span>
-                      <span className="font-mono text-xs text-muted-foreground">{i.installationId}</span>
-                    </li>
-                  ))}
-                </ul>
-              </div>
-            </>
-          ) : null}
         </CardContent>
       </Card>
 
       <p className="text-center text-xs text-muted-foreground">
-        After connecting, use <Link className="text-primary underline-offset-2 hover:underline" to="/projects">New project</Link>{" "}
+        After connecting, use{" "}
+        <Link className="text-primary underline-offset-2 hover:underline" to="/projects">
+          New project
+        </Link>{" "}
         to pick a repository and branch.
       </p>
     </div>

--- a/dashboard/src/pages/Settings.tsx
+++ b/dashboard/src/pages/Settings.tsx
@@ -7,6 +7,7 @@ import { Separator } from "@/components/ui/separator";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import {
+  applyNginxSite,
   applySelfUpdateFromSettings,
   checkSelfUpdateFromSettings,
   enableSelfUpdateFromSettings,
@@ -14,6 +15,7 @@ import {
   getSelfUpdateSettings,
   getSetupStatus,
   patchInstanceEnv,
+  requestCertbotSsl,
   type InstanceSettings,
   type SelfUpdateSettingsResponse,
   type SetupStatus,
@@ -21,6 +23,8 @@ import {
 import { toast } from "sonner";
 import { cn } from "@/lib/utils";
 import { DonutChart } from "@/components/charts/DonutChart";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Globe } from "lucide-react";
 
 function Row({ label, value }: { label: string; value: ReactNode }) {
   return (
@@ -45,6 +49,18 @@ const textareaClass = cn(
   "disabled:cursor-not-allowed disabled:opacity-50"
 );
 
+function normalizeBasePathInput(raw: string): string {
+  let p = raw.trim();
+  if (!p || p === "/") return "/";
+  if (!p.startsWith("/")) p = `/${p}`;
+  if (p.length > 1) p = p.replace(/\/+$/, "");
+  return p === "" ? "/" : p;
+}
+
+function looksLikeIpv4(host: string): boolean {
+  return /^\d{1,3}(\.\d{1,3}){3}$/.test(host.trim());
+}
+
 export function Settings() {
   const [instance, setInstance] = useState<InstanceSettings | null>(null);
   const [setup, setSetup] = useState<SetupStatus | null>(null);
@@ -54,25 +70,54 @@ export function Settings() {
   const [selfUpdate, setSelfUpdate] = useState<SelfUpdateSettingsResponse | null>(null);
   const [suOpts, setSuOpts] = useState({ branch: "", pollMs: "", autoApply: "false" });
   const [suBusy, setSuBusy] = useState<"enable" | "check" | "apply" | "saveOpts" | null>(null);
+  const [publicDomainDraft, setPublicDomainDraft] = useState("");
+  const [publicBasePathDraft, setPublicBasePathDraft] = useState("/");
+  const [certbotEmailDraft, setCertbotEmailDraft] = useState("");
+  const [publicUrlSaving, setPublicUrlSaving] = useState(false);
+  const [nginxApplying, setNginxApplying] = useState(false);
+  const [certbotRunning, setCertbotRunning] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
     void (async () => {
       setLoading(true);
       try {
-        const [i, s, su] = await Promise.all([getInstanceSettings(), getSetupStatus(), getSelfUpdateSettings()]);
-        if (!cancelled) {
-          setInstance(i);
-          setSetup(s);
+        const [i, s] = await Promise.all([getInstanceSettings(), getSetupStatus()]);
+        if (cancelled) return;
+        setInstance(i);
+        setSetup(s);
+        setPublicDomainDraft(i.publicDomain ?? "");
+        setPublicBasePathDraft(i.publicBasePath ?? "/");
+        setCertbotEmailDraft(i.certbotEmail ?? "");
+
+        try {
+          const su = await getSelfUpdateSettings();
+          if (cancelled) return;
           setSelfUpdate(su);
           setSuOpts({
             branch: su.branch,
             pollMs: su.pollMs > 0 ? String(su.pollMs) : "",
             autoApply: su.autoApply ? "true" : "false",
           });
+        } catch {
+          const fallback: SelfUpdateSettingsResponse = {
+            configured: i.selfUpdateConfigured,
+            branch: i.selfUpdateGitBranch,
+            pollMs: i.selfUpdatePollMs,
+            autoApply: i.selfUpdateAutoApply,
+            git: null,
+          };
+          if (!cancelled) {
+            setSelfUpdate(fallback);
+            setSuOpts({
+              branch: fallback.branch,
+              pollMs: fallback.pollMs > 0 ? String(fallback.pollMs) : "",
+              autoApply: fallback.autoApply ? "true" : "false",
+            });
+          }
         }
       } catch (e) {
-        toast.error(e instanceof Error ? e.message : "Failed to load settings");
+        if (!cancelled) toast.error(e instanceof Error ? e.message : "Failed to load settings");
       } finally {
         if (!cancelled) setLoading(false);
       }
@@ -110,20 +155,54 @@ export function Settings() {
     ];
   }, [instance]);
 
+  const publicUrlPreview = useMemo(() => {
+    const host = publicDomainDraft.trim().toLowerCase();
+    const path = normalizeBasePathInput(publicBasePathDraft);
+    if (!host) return null;
+    const proto = looksLikeIpv4(host) ? "http" : "https";
+    const origin = `${proto}://${host}`;
+    return path === "/" ? origin : `${origin}${path}`;
+  }, [publicDomainDraft, publicBasePathDraft]);
+
   const setEnvField = (key: string, value: string) => {
     setEnvDraft((d) => ({ ...d, [key]: value }));
   };
 
   const refreshSelfUpdate = async () => {
-    const su = await getSelfUpdateSettings();
-    setSelfUpdate(su);
-    setSuOpts({
-      branch: su.branch,
-      pollMs: su.pollMs > 0 ? String(su.pollMs) : "",
-      autoApply: su.autoApply ? "true" : "false",
-    });
+    try {
+      const su = await getSelfUpdateSettings();
+      setSelfUpdate(su);
+      setSuOpts({
+        branch: su.branch,
+        pollMs: su.pollMs > 0 ? String(su.pollMs) : "",
+        autoApply: su.autoApply ? "true" : "false",
+      });
+    } catch {
+      const i = await getInstanceSettings();
+      setInstance(i);
+      const fallback: SelfUpdateSettingsResponse = {
+        configured: i.selfUpdateConfigured,
+        branch: i.selfUpdateGitBranch,
+        pollMs: i.selfUpdatePollMs,
+        autoApply: i.selfUpdateAutoApply,
+        git: null,
+      };
+      setSelfUpdate(fallback);
+      setSuOpts({
+        branch: fallback.branch,
+        pollMs: fallback.pollMs > 0 ? String(fallback.pollMs) : "",
+        autoApply: fallback.autoApply ? "true" : "false",
+      });
+      setPublicDomainDraft(i.publicDomain ?? "");
+      setPublicBasePathDraft(i.publicBasePath ?? "/");
+      setCertbotEmailDraft(i.certbotEmail ?? "");
+      return;
+    }
     const i = await getInstanceSettings();
     setInstance(i);
+    setPublicDomainDraft(i.publicDomain ?? "");
+    setPublicBasePathDraft(i.publicBasePath ?? "/");
+    setCertbotEmailDraft(i.certbotEmail ?? "");
   };
 
   const onEnableSelfUpdate = async () => {
@@ -209,6 +288,80 @@ export function Settings() {
     }
   };
 
+  const onSavePublicUrlEnv = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const domain = publicDomainDraft.trim().toLowerCase();
+    const basePath = normalizeBasePathInput(publicBasePathDraft);
+    const email = certbotEmailDraft.trim();
+    const env: Record<string, string> = {};
+    if (domain) env.PUBLIC_DOMAIN = domain;
+    env.PUBLIC_BASE_PATH = basePath;
+    if (email) env.CERTBOT_EMAIL = email;
+    if (Object.keys(env).length === 0) {
+      toast.error("Enter a public hostname, base path, or Certbot email.");
+      return;
+    }
+    setPublicUrlSaving(true);
+    try {
+      const r = await patchInstanceEnv(env);
+      toast.success(r.message);
+      const i = await getInstanceSettings();
+      setInstance(i);
+      setPublicDomainDraft(i.publicDomain ?? "");
+      setPublicBasePathDraft(i.publicBasePath ?? "/");
+      setCertbotEmailDraft(i.certbotEmail ?? "");
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Failed to save public URL");
+    } finally {
+      setPublicUrlSaving(false);
+    }
+  };
+
+  const onApplyNginxSite = async () => {
+    const domain = publicDomainDraft.trim().toLowerCase();
+    if (!domain) {
+      toast.error("Enter a public hostname (or save PUBLIC_DOMAIN to .env first).");
+      return;
+    }
+    setNginxApplying(true);
+    try {
+      const r = await applyNginxSite({
+        publicDomain: domain,
+        publicBasePath: normalizeBasePathInput(publicBasePathDraft),
+      });
+      toast.success(r.message);
+      const i = await getInstanceSettings();
+      setInstance(i);
+      setPublicDomainDraft(i.publicDomain ?? "");
+      setPublicBasePathDraft(i.publicBasePath ?? "/");
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Nginx apply failed");
+    } finally {
+      setNginxApplying(false);
+    }
+  };
+
+  const onRunCertbotSsl = async () => {
+    const domain = publicDomainDraft.trim().toLowerCase();
+    if (looksLikeIpv4(domain)) {
+      toast.error("Let's Encrypt needs a DNS hostname, not an IP address.");
+      return;
+    }
+    if (!certbotEmailDraft.trim()) {
+      toast.error("Enter a Let's Encrypt contact email (saved with public URL or below).");
+      return;
+    }
+    setCertbotRunning(true);
+    try {
+      const r = await requestCertbotSsl({ email: certbotEmailDraft.trim() });
+      toast.success(r.message);
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Certbot failed");
+    } finally {
+      setCertbotRunning(false);
+    }
+  };
+
   const onSaveEnv = async (e: React.FormEvent) => {
     e.preventDefault();
     const env: Record<string, string> = {};
@@ -228,6 +381,9 @@ export function Settings() {
       const [i, s] = await Promise.all([getInstanceSettings(), getSetupStatus()]);
       setInstance(i);
       setSetup(s);
+      setPublicDomainDraft(i.publicDomain ?? "");
+      setPublicBasePathDraft(i.publicBasePath ?? "/");
+      setCertbotEmailDraft(i.certbotEmail ?? "");
     } catch (err) {
       toast.error(err instanceof Error ? err.message : "Failed to update .env");
     } finally {
@@ -235,7 +391,7 @@ export function Settings() {
     }
   };
 
-  if (loading || !instance || !setup || !selfUpdate) {
+  if (loading || !instance || !setup) {
     return (
       <div className="w-full max-w-4xl space-y-8">
         <Skeleton className="h-10 w-64" />
@@ -244,6 +400,15 @@ export function Settings() {
       </div>
     );
   }
+
+  const selfUpdateSafe: SelfUpdateSettingsResponse =
+    selfUpdate ?? {
+      configured: instance.selfUpdateConfigured,
+      branch: instance.selfUpdateGitBranch,
+      pollMs: instance.selfUpdatePollMs,
+      autoApply: instance.selfUpdateAutoApply,
+      git: null,
+    };
 
   return (
     <div className="w-full max-w-4xl space-y-10">
@@ -266,6 +431,8 @@ export function Settings() {
               <Row label="Docker network" value={instance.dockerNetwork} />
               <Row label="Projects root" value={instance.projectsRootPath} />
               <Row label="Nginx config path" value={instance.nginxConfigPath} />
+              <Row label="Public hostname" value={instance.publicDomain || "—"} />
+              <Row label="Public base path" value={instance.publicBasePath || "/"} />
               <Row
                 label="Prisma schema sync"
                 value={
@@ -288,6 +455,103 @@ export function Settings() {
         </Card>
       </div>
 
+      <Card id="public-url" className="border-border/50 bg-card/60 ring-1 ring-border/30 scroll-mt-24">
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Globe className="size-5 text-muted-foreground" aria-hidden />
+            Public URL and HTTPS
+          </CardTitle>
+          <CardDescription>
+            Same options as setup: deploy behind a hostname (and optional path like{" "}
+            <code className="rounded bg-muted px-1 font-mono text-xs">/versiongate</code>). Point DNS at this server, then apply nginx and run Certbot for TLS.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          <Alert>
+            <AlertTitle>DNS</AlertTitle>
+            <AlertDescription>
+              Add an <strong>A</strong> record for your hostname to this server&apos;s public IPv4 (cloud panel or{" "}
+              <code className="rounded bg-muted px-1 font-mono text-xs">curl -4 ifconfig.me</code> on the host). Propagation must finish before
+              Let&apos;s Encrypt can validate.
+            </AlertDescription>
+          </Alert>
+
+          <form onSubmit={(e) => void onSavePublicUrlEnv(e)} className="space-y-4">
+            <div className="grid gap-4 sm:grid-cols-2">
+              <div className="space-y-2">
+                <p className="text-sm font-medium text-foreground">Public hostname</p>
+                <Input
+                  placeholder="example.com"
+                  value={publicDomainDraft}
+                  onChange={(e) => setPublicDomainDraft(e.target.value)}
+                  autoComplete="off"
+                />
+                <p className="text-xs text-muted-foreground">Hostname or IPv4 for HTTP. TLS requires a hostname.</p>
+              </div>
+              <div className="space-y-2">
+                <p className="text-sm font-medium text-foreground">URL base path</p>
+                <Input
+                  placeholder="/ or /versiongate"
+                  value={publicBasePathDraft}
+                  onChange={(e) => setPublicBasePathDraft(e.target.value)}
+                  autoComplete="off"
+                />
+                <p className="text-xs text-muted-foreground">A leading slash is added if you omit it.</p>
+              </div>
+            </div>
+            <div className="space-y-2 sm:max-w-md">
+              <p className="text-sm font-medium text-foreground">Let&apos;s Encrypt contact email</p>
+              <Input
+                type="email"
+                placeholder="you@example.com"
+                value={certbotEmailDraft}
+                onChange={(e) => setCertbotEmailDraft(e.target.value)}
+                autoComplete="email"
+              />
+            </div>
+            {publicUrlPreview ? (
+              <p className="text-sm text-muted-foreground">
+                Preview:&nbsp;
+                <span className="font-mono text-foreground">{publicUrlPreview}</span>
+              </p>
+            ) : null}
+            {normalizeBasePathInput(publicBasePathDraft) !== "/" ? (
+              <p className="rounded-md border border-amber-300/80 bg-amber-50 px-3 py-2 text-sm text-amber-950">
+                Subpath URLs need the dashboard built with the same Vite <code className="font-mono text-xs">base</code>; otherwise static assets may
+                break. Using <code className="font-mono text-xs">/</code> is simplest.
+              </p>
+            ) : null}
+            <div className="flex flex-wrap gap-2">
+              <Button type="submit" size="sm" disabled={publicUrlSaving}>
+                {publicUrlSaving ? "Saving…" : "Save to .env"}
+              </Button>
+              <Button type="button" variant="outline" size="sm" disabled={nginxApplying} onClick={() => void onApplyNginxSite()}>
+                {nginxApplying ? "Applying…" : "Write nginx config & reload"}
+              </Button>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                disabled={
+                  certbotRunning ||
+                  looksLikeIpv4(publicDomainDraft) ||
+                  !publicDomainDraft.trim() ||
+                  !certbotEmailDraft.trim()
+                }
+                onClick={() => void onRunCertbotSsl()}
+              >
+                {certbotRunning ? "Certbot…" : "Obtain SSL (certbot --nginx)"}
+              </Button>
+            </div>
+            <p className="text-xs text-muted-foreground">
+              <span className="font-medium text-foreground">Suggested order:</span> save hostname and email → DNS A record → write nginx (HTTP on port 80) →
+              Certbot. Certbot reads <code className="rounded bg-muted px-1 font-mono">PUBLIC_DOMAIN</code> from <code className="rounded bg-muted px-1 font-mono">.env</code>
+              — use Save or nginx apply first. Requires <code className="rounded bg-muted px-1 font-mono">certbot</code> and permission to reload nginx on the host.
+            </p>
+          </form>
+        </CardContent>
+      </Card>
+
       <Card id="application-updates" className="border-border/50 bg-card/60 ring-1 ring-border/30 scroll-mt-24">
         <CardHeader>
           <CardTitle>Application updates</CardTitle>
@@ -300,42 +564,42 @@ export function Settings() {
         </CardHeader>
         <CardContent className="space-y-6">
           <div className="flex flex-wrap items-center gap-2">
-            <Badge variant={selfUpdate.configured ? "default" : "secondary"} className="font-mono text-xs">
-              {selfUpdate.configured ? "Self-update enabled" : "Not enabled"}
+            <Badge variant={selfUpdateSafe.configured ? "default" : "secondary"} className="font-mono text-xs">
+              {selfUpdateSafe.configured ? "Self-update enabled" : "Not enabled"}
             </Badge>
-            {!selfUpdate.configured ? (
+            {!selfUpdateSafe.configured ? (
               <Button type="button" size="sm" disabled={suBusy !== null} onClick={() => void onEnableSelfUpdate()}>
                 {suBusy === "enable" ? "Enabling…" : "Enable in-dashboard updates"}
               </Button>
             ) : null}
           </div>
 
-          {selfUpdate.configured ? (
+          {selfUpdateSafe.configured ? (
             <>
               <dl className="space-y-3">
-                <Row label="Tracked branch" value={selfUpdate.branch} />
-                <Row label="Poll interval (ms)" value={selfUpdate.pollMs > 0 ? String(selfUpdate.pollMs) : "off"} />
-                <Row label="Auto-apply on poll" value={boolBadge(selfUpdate.autoApply, "Yes", "No")} />
+                <Row label="Tracked branch" value={selfUpdateSafe.branch} />
+                <Row label="Poll interval (ms)" value={selfUpdateSafe.pollMs > 0 ? String(selfUpdateSafe.pollMs) : "off"} />
+                <Row label="Auto-apply on poll" value={boolBadge(selfUpdateSafe.autoApply, "Yes", "No")} />
               </dl>
-              {selfUpdate.git ? (
+              {selfUpdateSafe.git ? (
                 <div className="rounded-lg border border-border/60 bg-muted/20 px-3 py-2 text-sm">
                   <p className="font-mono text-xs text-muted-foreground">
                     Local{" "}
                     <span className="text-foreground">
-                      {selfUpdate.git.currentCommit ? selfUpdate.git.currentCommit.slice(0, 7) : "—"}
+                      {selfUpdateSafe.git.currentCommit ? selfUpdateSafe.git.currentCommit.slice(0, 7) : "—"}
                     </span>
-                    {selfUpdate.git.remoteCommit ? (
+                    {selfUpdateSafe.git.remoteCommit ? (
                       <>
                         {" "}
-                        · remote <span className="text-foreground">{selfUpdate.git.remoteCommit.slice(0, 7)}</span>
+                        · remote <span className="text-foreground">{selfUpdateSafe.git.remoteCommit.slice(0, 7)}</span>
                       </>
                     ) : null}
                   </p>
-                  {selfUpdate.git.message ? (
-                    <p className="mt-1 text-amber-800">{selfUpdate.git.message}</p>
-                  ) : selfUpdate.git.behind ? (
+                  {selfUpdateSafe.git.message ? (
+                    <p className="mt-1 text-amber-800">{selfUpdateSafe.git.message}</p>
+                  ) : selfUpdateSafe.git.behind ? (
                     <p className="mt-1 text-foreground">Remote is ahead — you can update.</p>
-                  ) : selfUpdate.git.isGitRepo ? (
+                  ) : selfUpdateSafe.git.isGitRepo ? (
                     <p className="mt-1 text-muted-foreground">Up to date with origin.</p>
                   ) : (
                     <p className="mt-1 text-muted-foreground">Not a git checkout — use your image or package pipeline.</p>
@@ -353,7 +617,7 @@ export function Settings() {
                   type="button"
                   size="sm"
                   disabled={
-                    suBusy !== null || !selfUpdate.git?.isGitRepo || !selfUpdate.git.behind || Boolean(selfUpdate.git.message)
+                    suBusy !== null || !selfUpdateSafe.git?.isGitRepo || !selfUpdateSafe.git.behind || Boolean(selfUpdateSafe.git.message)
                   }
                   onClick={() => void onApplySelfUpdate()}
                 >

--- a/src/controllers/github-app.controller.ts
+++ b/src/controllers/github-app.controller.ts
@@ -160,6 +160,42 @@ async function avatarForInstallation(row: GitHubInstallation, octokit: Octokit):
   }
 }
 
+/** GET /api/github/installation — session; DB only (no GitHub App env required). */
+export async function githubInstallationRecordHandler(req: FastifyRequest, reply: FastifyReply): Promise<void> {
+  const raw = getSessionTokenFromRequest(req.headers.cookie);
+  const user = await getUserFromSessionToken(raw);
+  if (!user) {
+    reply.code(401).send({ error: "Unauthorized", message: "Sign in required", code: "AUTH_REQUIRED" });
+    return;
+  }
+
+  const rows = await prisma.gitHubInstallation.findMany({
+    where: { userId: user.id },
+    orderBy: { createdAt: "desc" },
+  });
+
+  if (rows.length === 0) {
+    reply.code(200).send({ installation: null, installations: [] });
+    return;
+  }
+
+  const primary = rows[0];
+  reply.code(200).send({
+    installation: {
+      installationId: primary.installationId.toString(),
+      githubAccountLogin: primary.githubAccountLogin,
+      githubAccountType: primary.githubAccountType,
+      createdAt: primary.createdAt.toISOString(),
+    },
+    installations: rows.map((r) => ({
+      installationId: r.installationId.toString(),
+      githubAccountLogin: r.githubAccountLogin,
+      githubAccountType: r.githubAccountType,
+      createdAt: r.createdAt.toISOString(),
+    })),
+  });
+}
+
 /** GET /api/github/status — session; connected GitHub App installs + avatar for primary. */
 export async function githubIntegrationStatusHandler(req: FastifyRequest, reply: FastifyReply): Promise<void> {
   if (!githubAppReady()) {

--- a/src/controllers/settings.controller.ts
+++ b/src/controllers/settings.controller.ts
@@ -1,5 +1,6 @@
 import { randomBytes } from "crypto";
-import { readFileSync, existsSync } from "fs";
+import { readFileSync, existsSync, writeFileSync } from "fs";
+import { execFileSync } from "child_process";
 import { join } from "path";
 import { FastifyRequest, FastifyReply } from "fastify";
 import {
@@ -14,6 +15,8 @@ import { mergeIntoDotenv, writeEnvWithBackup } from "../utils/env-file";
 import { logger } from "../utils/logger";
 import { applySelfUpdate, getSelfUpdateStatus } from "../services/self-update.service";
 import { kickSelfUpdatePoll } from "../services/self-update-poll";
+import { isValidHostname, isValidIpv4Address } from "../utils/domain-validation";
+import { generateVersionGateNginxConf, normalizePublicBasePath } from "../utils/nginx-versiongate-site";
 
 const DB_URL_REGEX = /^DATABASE_URL\s*=\s*"?([^"\n\r]+)"?\s*$/m;
 
@@ -22,6 +25,25 @@ function readDatabaseUrlFromFile(): string | null {
   const content = readFileSync(envFilePath, "utf-8");
   const match = content.match(DB_URL_REGEX);
   return match?.[1] ?? null;
+}
+
+/** Reads a simple `KEY=value` from `.env` (quoted values stripped). */
+function readEnvKeyFromFile(key: string): string | null {
+  if (!existsSync(envFilePath)) return null;
+  const content = readFileSync(envFilePath, "utf-8");
+  for (const line of content.split(/\r?\n/)) {
+    const m = line.match(/^\s*([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*)$/);
+    if (!m || m[1] !== key) continue;
+    let v = m[2].trim();
+    if (
+      (v.startsWith('"') && v.endsWith('"')) ||
+      (v.startsWith("'") && v.endsWith("'"))
+    ) {
+      v = v.slice(1, -1);
+    }
+    return v;
+  }
+  return null;
 }
 
 async function canConnectToDatabase(databaseUrl: string): Promise<boolean> {
@@ -68,6 +90,10 @@ export async function getInstanceSettingsHandler(
   const encryptionKeyConfigured = Boolean(process.env.ENCRYPTION_KEY?.trim());
   const geminiConfigured = Boolean(config.geminiApiKey?.trim());
 
+  const publicDomain = readEnvKeyFromFile("PUBLIC_DOMAIN") ?? "";
+  const publicBasePath = normalizePublicBasePath(readEnvKeyFromFile("PUBLIC_BASE_PATH") ?? "/");
+  const certbotEmail = readEnvKeyFromFile("CERTBOT_EMAIL") ?? "";
+
   return reply.code(200).send({
     engineVersion,
     nodeEnv: process.env.NODE_ENV ?? "development",
@@ -82,6 +108,9 @@ export async function getInstanceSettingsHandler(
     needsRestart,
     encryptionKeyConfigured,
     geminiConfigured,
+    publicDomain,
+    publicBasePath,
+    certbotEmail,
     selfUpdateConfigured: Boolean(selfUpdateSecretLive()),
     selfUpdateGitBranch: selfUpdateBranchLive(),
     selfUpdatePollMs: selfUpdatePollMsLive(),
@@ -108,6 +137,9 @@ const PATCHABLE_ENV_KEYS = new Set([
   "SELF_UPDATE_GIT_BRANCH",
   "SELF_UPDATE_POLL_MS",
   "SELF_UPDATE_AUTO_APPLY",
+  "PUBLIC_DOMAIN",
+  "PUBLIC_BASE_PATH",
+  "CERTBOT_EMAIL",
 ]);
 
 interface PatchEnvBody {
@@ -192,6 +224,32 @@ export async function patchInstanceEnvHandler(
       });
     }
     updates.SELF_UPDATE_GIT_BRANCH = b;
+  }
+
+  if (updates.PUBLIC_DOMAIN !== undefined) {
+    const d = updates.PUBLIC_DOMAIN.trim().toLowerCase();
+    if (d && !isValidIpv4Address(d) && !isValidHostname(d)) {
+      return reply.code(400).send({
+        error: "ValidationError",
+        message: "PUBLIC_DOMAIN must be a valid hostname or IPv4 address",
+      });
+    }
+    updates.PUBLIC_DOMAIN = d;
+  }
+
+  if (updates.PUBLIC_BASE_PATH !== undefined) {
+    updates.PUBLIC_BASE_PATH = normalizePublicBasePath(updates.PUBLIC_BASE_PATH);
+  }
+
+  if (updates.CERTBOT_EMAIL !== undefined) {
+    const em = updates.CERTBOT_EMAIL.trim();
+    if (em && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(em)) {
+      return reply.code(400).send({
+        error: "ValidationError",
+        message: "CERTBOT_EMAIL must be a valid email address",
+      });
+    }
+    updates.CERTBOT_EMAIL = em;
   }
 
   try {
@@ -292,4 +350,163 @@ export async function postSelfUpdateApplyHandler(_req: FastifyRequest, reply: Fa
   const result = await applySelfUpdate(selfUpdateBranchLive());
   /** Always 200: outcome is in `result.ok` / `result.error` (avoids generic client treating merge/build failure as an HTTP exception). */
   reply.code(200).send(result);
+}
+
+function reloadNginxBestEffort(): void {
+  try {
+    execFileSync("nginx", ["-t"], { stdio: "pipe" });
+    execFileSync("nginx", ["-s", "reload"], { stdio: "pipe" });
+    return;
+  } catch (err) {
+    logger.debug({ err }, "nginx reload as current user failed — trying sudo");
+  }
+  execFileSync("sudo", ["-n", "/usr/sbin/nginx", "-t"], { stdio: "pipe" });
+  execFileSync("sudo", ["-n", "/usr/sbin/nginx", "-s", "reload"], { stdio: "pipe" });
+}
+
+interface ApplyNginxBody {
+  publicDomain?: string;
+  publicBasePath?: string;
+}
+
+/** Writes HTTP reverse-proxy config for VersionGate and reloads nginx. */
+export async function postNginxApplySiteHandler(
+  req: FastifyRequest<{ Body: ApplyNginxBody }>,
+  reply: FastifyReply
+): Promise<void> {
+  const body = req.body ?? {};
+  let domainRaw = (typeof body.publicDomain === "string" ? body.publicDomain : "").trim().toLowerCase();
+  if (!domainRaw) domainRaw = (readEnvKeyFromFile("PUBLIC_DOMAIN") ?? "").trim().toLowerCase();
+
+  const basePath = normalizePublicBasePath(
+    typeof body.publicBasePath === "string"
+      ? body.publicBasePath
+      : readEnvKeyFromFile("PUBLIC_BASE_PATH") ?? "/"
+  );
+
+  if (!domainRaw) {
+    return reply.code(400).send({
+      error: "BadRequest",
+      message: "Set Public hostname below or PUBLIC_DOMAIN in .env before applying nginx.",
+    });
+  }
+
+  const domainIsIp = isValidIpv4Address(domainRaw);
+  const domainIsHostname = isValidHostname(domainRaw);
+  if (!domainIsIp && !domainIsHostname) {
+    return reply.code(400).send({ error: "BadRequest", message: "Invalid public hostname or IP address." });
+  }
+
+  const conf = generateVersionGateNginxConf({
+    serverName: domainIsIp ? "_" : domainRaw,
+    defaultServer: domainIsIp,
+    upstreamHost: "127.0.0.1",
+    upstreamPort: config.port,
+    basePath,
+  });
+
+  const outPath = config.nginxConfigPath;
+  try {
+    writeFileSync(outPath, conf, "utf-8");
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    logger.error({ err }, "postNginxApplySite: write failed");
+    return reply.code(500).send({ error: "WriteError", message: msg });
+  }
+
+  try {
+    reloadNginxBestEffort();
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    logger.error({ err }, "postNginxApplySite: nginx reload failed");
+    return reply.code(500).send({
+      error: "NginxReloadFailed",
+      message:
+        "The config file was written but nginx reload failed (often requires root). Path: " +
+        outPath +
+        ". Try: sudo nginx -t && sudo nginx -s reload",
+      detail: msg,
+    });
+  }
+
+  try {
+    const next = mergeIntoDotenv({
+      PUBLIC_DOMAIN: domainRaw,
+      PUBLIC_BASE_PATH: basePath === "/" ? "/" : basePath,
+    });
+    writeEnvWithBackup(next);
+  } catch (err) {
+    logger.warn({ err }, "postNginxApplySite: could not persist PUBLIC_DOMAIN / PUBLIC_BASE_PATH to .env");
+  }
+
+  reply.code(200).send({
+    ok: true,
+    message: "Nginx configuration applied and nginx reloaded.",
+    path: outPath,
+    publicDomain: domainRaw,
+    publicBasePath: basePath,
+  });
+}
+
+interface CertbotBody {
+  email?: string;
+}
+
+/** Runs non-interactive Certbot nginx installer for PUBLIC_DOMAIN (hostname only). */
+export async function postCertbotSslHandler(
+  req: FastifyRequest<{ Body: CertbotBody }>,
+  reply: FastifyReply
+): Promise<void> {
+  const domain = (readEnvKeyFromFile("PUBLIC_DOMAIN") ?? "").trim().toLowerCase();
+  if (!domain || !isValidHostname(domain)) {
+    return reply.code(400).send({
+      error: "BadRequest",
+      message:
+        "PUBLIC_DOMAIN must be a DNS hostname (not a raw IP) for Let's Encrypt. Save it under Public URL first, then update DNS.",
+    });
+  }
+
+  const emailRaw =
+    (typeof req.body?.email === "string" ? req.body.email.trim() : "") ||
+    (readEnvKeyFromFile("CERTBOT_EMAIL") ?? "").trim();
+  if (!emailRaw || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(emailRaw)) {
+    return reply.code(400).send({
+      error: "BadRequest",
+      message: "Provide a Let's Encrypt contact email (form field or CERTBOT_EMAIL in .env).",
+    });
+  }
+
+  const args = [
+    "--nginx",
+    "-d",
+    domain,
+    "--non-interactive",
+    "--agree-tos",
+    "--email",
+    emailRaw,
+    "--redirect",
+  ];
+
+  try {
+    try {
+      execFileSync("certbot", args, { stdio: "pipe", timeout: 240_000 });
+    } catch (directErr) {
+      logger.debug({ err: directErr }, "certbot as current user failed — trying sudo -n");
+      execFileSync("sudo", ["-n", "certbot", ...args], { stdio: "pipe", timeout: 240_000 });
+    }
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    logger.error({ err }, "certbot failed");
+    return reply.code(500).send({
+      error: "CertbotFailed",
+      message:
+        "Certbot could not obtain or install a certificate. Ensure DNS points to this server, ports 80/443 are reachable, certbot is installed, and nginx is healthy.",
+      detail: msg.slice(0, 1200),
+    });
+  }
+
+  reply.code(200).send({
+    ok: true,
+    message: "Certbot completed. Reload the site over HTTPS and consider COOKIE_SECURE=true if you serve only HTTPS.",
+  });
 }

--- a/src/controllers/setup.controller.ts
+++ b/src/controllers/setup.controller.ts
@@ -18,6 +18,8 @@ import {
   SESSION_MAX_AGE_SEC,
 } from "../services/auth.service";
 import { buildSetSessionCookie } from "../utils/cookie";
+import { isValidHostname, isValidIpv4Address } from "../utils/domain-validation";
+import { generateVersionGateNginxConf } from "../utils/nginx-versiongate-site";
 
 interface SetupApplyBody {
   domain: string;
@@ -30,7 +32,6 @@ interface SetupApplyBody {
 const NGINX_CONF_PATH = "/etc/nginx/conf.d/versiongate.conf";
 const DB_URL_REGEX = /^DATABASE_URL\s*=\s*"?([^"\n\r]+)"?\s*$/m;
 const ENCRYPTION_KEY_REGEX = /^ENCRYPTION_KEY\s*=\s*"?([0-9a-fA-F]{64})"?\s*$/m;
-const HOSTNAME_LABEL_REGEX = /^[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?$/;
 
 function getEnvPath(): string {
   return envFilePath;
@@ -57,30 +58,6 @@ function readExistingEncryptionKey(): string | null {
   const content = readFileSync(envPath, "utf-8");
   const match = content.match(ENCRYPTION_KEY_REGEX);
   return match ? match[1] : null;
-}
-
-function isValidIpv4Address(value: string): boolean {
-  const octets = value.split(".");
-  if (octets.length !== 4) {
-    return false;
-  }
-
-  return octets.every((octet) => {
-    if (!/^\d{1,3}$/.test(octet)) {
-      return false;
-    }
-    const parsed = Number.parseInt(octet, 10);
-    return parsed >= 0 && parsed <= 255;
-  });
-}
-
-function isValidHostname(value: string): boolean {
-  if (value.length === 0 || value.length > 253 || value.startsWith(".") || value.endsWith(".")) {
-    return false;
-  }
-
-  const labels = value.split(".");
-  return labels.every((label) => HOSTNAME_LABEL_REGEX.test(label));
 }
 
 function escapeEnvValue(value: string): string {
@@ -204,6 +181,8 @@ NODE_ENV=production
 DOCKER_NETWORK="versiongate-net"
 NGINX_CONFIG_PATH="${NGINX_CONF_PATH}"
 PROJECTS_ROOT_PATH="${escapeEnvValue(projectsRootPath)}"
+PUBLIC_DOMAIN="${escapeEnvValue(normalizedDomain)}"
+PUBLIC_BASE_PATH="/"
 ENCRYPTION_KEY="${encryptionKey}"
 `;
 
@@ -283,28 +262,13 @@ ENCRYPTION_KEY="${encryptionKey}"
 
   // 4. Write Nginx config (best-effort — may not have permissions)
   try {
-    const serverName = domainIsIp ? "_" : normalizedDomain;
-    const listenDirective = domainIsIp ? "listen 80 default_server;" : "listen 80;";
-
-    const nginxConf = `server {
-    ${listenDirective}
-    server_name ${serverName};
-
-    client_max_body_size 50M;
-
-    location / {
-        proxy_pass         http://127.0.0.1:9090;
-        proxy_http_version 1.1;
-        proxy_set_header   Upgrade $http_upgrade;
-        proxy_set_header   Connection 'upgrade';
-        proxy_set_header   Host $host;
-        proxy_set_header   X-Real-IP $remote_addr;
-        proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header   X-Forwarded-Proto $scheme;
-        proxy_cache_bypass $http_upgrade;
-    }
-}
-`;
+    const nginxConf = generateVersionGateNginxConf({
+      serverName: domainIsIp ? "_" : normalizedDomain,
+      defaultServer: domainIsIp,
+      upstreamHost: "127.0.0.1",
+      upstreamPort: 9090,
+      basePath: "/",
+    });
     writeFileSync(NGINX_CONF_PATH, nginxConf, "utf-8");
 
     try {

--- a/src/routes/github-app.routes.ts
+++ b/src/routes/github-app.routes.ts
@@ -3,6 +3,7 @@ import { requireDatabaseConfigured } from "../middleware/require-database";
 import {
   githubAppWebhookHandler,
   githubCallbackHandler,
+  githubInstallationRecordHandler,
   githubIntegrationStatusHandler,
   githubInstallHandler,
   githubRepoBranchesHandler,
@@ -13,6 +14,7 @@ export async function githubAppRoutes(app: FastifyInstance): Promise<void> {
   app.addHook("preHandler", requireDatabaseConfigured);
   app.get("/auth/github/install", githubInstallHandler);
   app.get("/auth/github/callback", githubCallbackHandler);
+  app.get("/github/installation", githubInstallationRecordHandler);
   app.get("/github/status", githubIntegrationStatusHandler);
   app.get("/github/repos/:owner/:repo/branches", githubRepoBranchesHandler);
   app.get("/github/repos", githubReposHandler);

--- a/src/routes/settings.routes.ts
+++ b/src/routes/settings.routes.ts
@@ -6,6 +6,8 @@ import {
   postSelfUpdateEnableHandler,
   postSelfUpdateCheckHandler,
   postSelfUpdateApplyHandler,
+  postNginxApplySiteHandler,
+  postCertbotSslHandler,
 } from "../controllers/settings.controller";
 
 export async function settingsRoutes(app: FastifyInstance): Promise<void> {
@@ -14,6 +16,8 @@ export async function settingsRoutes(app: FastifyInstance): Promise<void> {
   app.post("/settings/self-update/enable", { handler: postSelfUpdateEnableHandler });
   app.post("/settings/self-update/check", { handler: postSelfUpdateCheckHandler });
   app.post("/settings/self-update/apply", { handler: postSelfUpdateApplyHandler });
+  app.post("/settings/nginx/apply", { handler: postNginxApplySiteHandler });
+  app.post("/settings/ssl/certbot", { handler: postCertbotSslHandler });
   app.patch("/settings/env", {
     schema: {
       body: {

--- a/src/utils/domain-validation.ts
+++ b/src/utils/domain-validation.ts
@@ -1,0 +1,25 @@
+const HOSTNAME_LABEL_REGEX = /^[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?$/;
+
+export function isValidIpv4Address(value: string): boolean {
+  const octets = value.split(".");
+  if (octets.length !== 4) {
+    return false;
+  }
+
+  return octets.every((octet) => {
+    if (!/^\d{1,3}$/.test(octet)) {
+      return false;
+    }
+    const parsed = Number.parseInt(octet, 10);
+    return parsed >= 0 && parsed <= 255;
+  });
+}
+
+export function isValidHostname(value: string): boolean {
+  if (value.length === 0 || value.length > 253 || value.startsWith(".") || value.endsWith(".")) {
+    return false;
+  }
+
+  const labels = value.split(".");
+  return labels.every((label) => HOSTNAME_LABEL_REGEX.test(label));
+}

--- a/src/utils/nginx-versiongate-site.ts
+++ b/src/utils/nginx-versiongate-site.ts
@@ -1,0 +1,66 @@
+/** Normalize base path: always starts with "/", no trailing slash except "/". */
+export function normalizePublicBasePath(raw: string | undefined): string {
+  let p = (raw ?? "/").trim();
+  if (!p.startsWith("/")) p = `/${p}`;
+  if (p.length > 1) p = p.replace(/\/+$/, "");
+  return p === "" ? "/" : p;
+}
+
+export interface VersionGateNginxOptions {
+  /** `server_name` value — hostname, or `_` when binding by IP. */
+  serverName: string;
+  /** When true, use `listen 80 default_server;` (IPv4-only setup wizard style). */
+  defaultServer: boolean;
+  upstreamHost: string;
+  upstreamPort: number;
+  /** URL path prefix where the app is mounted (e.g. `/` or `/versiongate`). */
+  basePath: string;
+}
+
+/**
+ * Single HTTP server block proxying to the VersionGate API (Fastify).
+ * Run Certbot afterward to add TLS (`certbot --nginx`).
+ */
+export function generateVersionGateNginxConf(opts: VersionGateNginxOptions): string {
+  const base = normalizePublicBasePath(opts.basePath);
+  const listen = opts.defaultServer ? "listen 80 default_server;" : "listen 80;";
+  const upstream = `http://${opts.upstreamHost}:${opts.upstreamPort}`;
+
+  const proxyHeaders = `        proxy_http_version 1.1;
+        proxy_set_header   Upgrade $http_upgrade;
+        proxy_set_header   Connection 'upgrade';
+        proxy_set_header   Host $host;
+        proxy_set_header   X-Real-IP $remote_addr;
+        proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto $scheme;
+        proxy_cache_bypass $http_upgrade;`;
+
+  let locationBlock: string;
+  if (base === "/") {
+    locationBlock = `    location / {
+        proxy_pass         ${upstream};
+${proxyHeaders}
+    }`;
+  } else {
+    const prefix = base.endsWith("/") ? base.slice(0, -1) : base;
+    locationBlock = `    location = ${prefix} {
+        return 302 ${prefix}/;
+    }
+
+    location ${prefix}/ {
+        rewrite ^${prefix}/(.*)$ /$1 break;
+        proxy_pass         ${upstream};
+${proxyHeaders}
+    }`;
+  }
+
+  return `server {
+    ${listen}
+    server_name ${opts.serverName};
+
+    client_max_body_size 50M;
+
+${locationBlock}
+}
+`;
+}


### PR DESCRIPTION
## Summary

This PR adds **public hostname / base path / HTTPS** controls to the dashboard Settings page (aligned with setup wizard behavior), extends the **settings API** for nginx and Certbot, improves **layout** when a DB restart is required, and includes **GitHub App integration** UI/controller updates that were developed on this branch.

### Dashboard
- **Settings**: Edit `PUBLIC_DOMAIN`, `PUBLIC_BASE_PATH`, `CERTBOT_EMAIL`; DNS guidance; save to `.env`; **Write nginx config & reload**; **Obtain SSL** via Certbot. Loading no longer blocks on self-update API failures.
- **Layout**: Banner when `DATABASE_URL` is in `.env` but the process has not loaded it (no redirect loop into setup).

### Backend
- Shared **domain validation** and **nginx site** generator; **PATCH** support for public URL env keys; **POST** `/settings/nginx/apply` and `/settings/ssl/certbot`; setup wizard uses the nginx helper.

### GitHub
- Controller/routes and **Integrations** / **Create project** flow updates.

## Testing
- `bunx tsc --noEmit` (root + dashboard)
- `cd dashboard && bun run build`

## Ops notes
- Certbot and nginx reload require appropriate packages and privileges on the host (`sudo -n` fallback where implemented).

Made with [Cursor](https://cursor.com)