### PR TITLE
fix(dashboard): register /settings route

### DIFF
--- a/dashboard/src/main.tsx
+++ b/dashboard/src/main.tsx
@@ -12,6 +12,7 @@ import { Integrations } from "@/pages/Integrations";
 import { Setup } from "@/pages/Setup";
 import { Activity } from "@/pages/Activity";
 import { Login } from "@/pages/Login";
+import { Settings } from "@/pages/Settings";
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
@@ -28,6 +29,7 @@ createRoot(document.getElementById("root")!).render(
           <Route path="/system" element={<SystemHealth />} />
           <Route path="/server" element={<Navigate to="/system" replace />} />
           <Route path="/dashboard/integrations" element={<Integrations />} />
+          <Route path="/settings" element={<Settings />} />
           <Route path="*" element={<Navigate to="/" replace />} />
         </Route>
       </Routes>


### PR DESCRIPTION
This pull request adds a new route for the `Settings` page to the dashboard application. The main changes are:

**Routing and Navigation:**

* Added the `Settings` component to the import statements in `dashboard/src/main.tsx`, making it available for use in the routing configuration.
* Introduced a new route at `/settings` that renders the `Settings` component, allowing users to access the settings page from the dashboard.