### PR TITLE
GitHub App integration, Settings (URL/HTTPS/nginx/Certbot), and dashboard hostname UX

### DIFF
--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -404,7 +404,11 @@ export function applyNginxSite(body: {
   return request("POST", "/settings/nginx/apply", body);
 }
 
-export function requestCertbotSsl(body: { email?: string }): Promise<{ ok: boolean; message: string }> {
+export function requestCertbotSsl(body: {
+  email?: string;
+  /** Sent to API so `.env` matches the form before Certbot runs (recommended when switching subdomain). */
+  publicDomain?: string;
+}): Promise<{ ok: boolean; message: string }> {
   return request("POST", "/settings/ssl/certbot", body);
 }
 

--- a/dashboard/src/lib/public-url.ts
+++ b/dashboard/src/lib/public-url.ts
@@ -1,0 +1,22 @@
+/** Matches backend `normalizePublicBasePath` (leading slash, no trailing slash except `/`). */
+export function normalizePublicBasePath(raw: string): string {
+  let p = raw.trim();
+  if (!p || p === "/") return "/";
+  if (!p.startsWith("/")) p = `/${p}`;
+  if (p.length > 1) p = p.replace(/\/+$/, "");
+  return p === "" ? "/" : p;
+}
+
+export function looksLikeIpv4(host: string): boolean {
+  return /^\d{1,3}(\.\d{1,3}){3}$/.test(host.trim());
+}
+
+/** Preview URL for the dashboard (scheme guessed: HTTP for raw IPv4, HTTPS for hostnames). */
+export function formatPublicDashboardUrl(publicDomain: string, publicBasePath: string): string | null {
+  const host = publicDomain.trim().toLowerCase();
+  if (!host) return null;
+  const path = normalizePublicBasePath(publicBasePath || "/");
+  const proto = looksLikeIpv4(host) ? "http" : "https";
+  const origin = `${proto}://${host}`;
+  return path === "/" ? origin : `${origin}${path}`;
+}

--- a/dashboard/src/pages/Overview.tsx
+++ b/dashboard/src/pages/Overview.tsx
@@ -4,11 +4,13 @@ import { SimpleBarChart } from "@/components/charts/SimpleBarChart";
 import { Link, useNavigate } from "react-router-dom";
 import {
   getAllDeployments,
+  getInstanceSettings,
   getProjects,
   listAllJobs,
   listProjectJobs,
   triggerDeploy,
   type Deployment,
+  type InstanceSettings,
   type JobRecord,
   type Project,
 } from "@/lib/api";
@@ -36,8 +38,9 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { BookOpen, Shield, Terminal } from "lucide-react";
+import { formatPublicDashboardUrl, normalizePublicBasePath } from "@/lib/public-url";
 import { AggregateJobLogStream } from "@/components/AggregateJobLogStream";
+import { BookOpen, Globe, Shield, Terminal } from "lucide-react";
 
 function timeAgo(date: string): string {
   const seconds = Math.floor((Date.now() - new Date(date).getTime()) / 1000);
@@ -64,19 +67,22 @@ export function Overview() {
   const [latestJobs, setLatestJobs] = useState<Record<string, JobRecord | undefined>>({});
   const [recentJobs, setRecentJobs] = useState<JobRecord[]>([]);
   const [loading, setLoading] = useState(true);
+  const [instanceSettings, setInstanceSettings] = useState<InstanceSettings | null>(null);
   const [deleteTarget, setDeleteTarget] = useState<Project | null>(null);
 
   const load = async () => {
     setLoading(true);
     try {
-      const [p, d, allJobs] = await Promise.all([
+      const [p, d, allJobs, inst] = await Promise.all([
         getProjects(),
         getAllDeployments(),
         listAllJobs({ limit: 5 }),
+        getInstanceSettings().catch(() => null),
       ]);
       setProjects(p.projects);
       setDeployments(d.deployments);
       setRecentJobs(allJobs.jobs);
+      setInstanceSettings(inst);
 
       const jobEntries = await Promise.all(
         p.projects.map(async (proj) => {
@@ -140,6 +146,11 @@ export function Overview() {
       .map(([name, value]) => ({ name, value }));
   }, [recentJobs]);
 
+  const dashboardPublicUrl = useMemo(() => {
+    if (!instanceSettings) return null;
+    return formatPublicDashboardUrl(instanceSettings.publicDomain ?? "", instanceSettings.publicBasePath ?? "/");
+  }, [instanceSettings]);
+
   const onDeploy = async (projectId: string) => {
     try {
       const r = await triggerDeploy(projectId);
@@ -202,6 +213,55 @@ export function Overview() {
           <Button onClick={launchCreate}>Add project</Button>
         </div>
       </div>
+
+      <Card className="border-border/80 bg-card shadow-sm">
+        <CardHeader className="pb-3">
+          <CardTitle className="flex items-center gap-2 text-base">
+            <Globe className="size-5 text-muted-foreground" aria-hidden />
+            Dashboard hostname &amp; URL
+          </CardTitle>
+          <CardDescription>
+            Where this VersionGate UI is meant to be reached (DNS hostname and optional path). Change these when you move to a new domain or subdomain.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+          <div className="min-w-0 flex-1 space-y-2">
+            {dashboardPublicUrl ? (
+              <>
+                <a
+                  href={dashboardPublicUrl}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="break-all font-mono text-sm text-primary underline decoration-primary/40 underline-offset-2 hover:decoration-primary"
+                >
+                  {dashboardPublicUrl}
+                </a>
+                {instanceSettings ? (
+                  <p className="text-xs text-muted-foreground">
+                    Hostname{" "}
+                    <span className="font-mono text-foreground">{instanceSettings.publicDomain || "—"}</span>
+                    {" · "}
+                    Path{" "}
+                    <span className="font-mono text-foreground">
+                      {normalizePublicBasePath(instanceSettings.publicBasePath || "/")}
+                    </span>
+                  </p>
+                ) : null}
+              </>
+            ) : (
+              <p className="text-sm text-muted-foreground">
+                No public hostname configured yet. Set the domain or subdomain where operators should open VersionGate, then point DNS and nginx at this server.
+              </p>
+            )}
+          </div>
+          <Link
+            to="/settings#dashboard-url"
+            className={buttonVariants({ variant: "default", size: "sm", className: "w-full shrink-0 sm:w-auto" })}
+          >
+            Change domain &amp; hostname
+          </Link>
+        </CardContent>
+      </Card>
 
       <div className="grid gap-4 md:grid-cols-3">
         <Card className="border-primary/25 bg-primary text-primary-foreground shadow-md">

--- a/dashboard/src/pages/Settings.tsx
+++ b/dashboard/src/pages/Settings.tsx
@@ -7,6 +7,7 @@ import { Separator } from "@/components/ui/separator";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import {
+  ApiError,
   applyNginxSite,
   applySelfUpdateFromSettings,
   checkSelfUpdateFromSettings,
@@ -25,6 +26,7 @@ import { cn } from "@/lib/utils";
 import { DonutChart } from "@/components/charts/DonutChart";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Globe } from "lucide-react";
+import { formatPublicDashboardUrl, looksLikeIpv4, normalizePublicBasePath } from "@/lib/public-url";
 
 function Row({ label, value }: { label: string; value: ReactNode }) {
   return (
@@ -48,18 +50,6 @@ const textareaClass = cn(
   "placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50",
   "disabled:cursor-not-allowed disabled:opacity-50"
 );
-
-function normalizeBasePathInput(raw: string): string {
-  let p = raw.trim();
-  if (!p || p === "/") return "/";
-  if (!p.startsWith("/")) p = `/${p}`;
-  if (p.length > 1) p = p.replace(/\/+$/, "");
-  return p === "" ? "/" : p;
-}
-
-function looksLikeIpv4(host: string): boolean {
-  return /^\d{1,3}(\.\d{1,3}){3}$/.test(host.trim());
-}
 
 export function Settings() {
   const [instance, setInstance] = useState<InstanceSettings | null>(null);
@@ -129,13 +119,16 @@ export function Settings() {
 
   useEffect(() => {
     if (typeof window === "undefined") return;
-    if (window.location.hash === "#application-updates") {
+    const scrollToHash = () => {
+      const id = window.location.hash.replace(/^#/, "");
+      if (id !== "application-updates" && id !== "dashboard-url") return;
       window.requestAnimationFrame(() => {
-        document
-          .getElementById("application-updates")
-          ?.scrollIntoView({ behavior: "smooth", block: "start" });
+        document.getElementById(id)?.scrollIntoView({ behavior: "smooth", block: "start" });
       });
-    }
+    };
+    scrollToHash();
+    window.addEventListener("hashchange", scrollToHash);
+    return () => window.removeEventListener("hashchange", scrollToHash);
   }, []);
 
   const checkSummary = useMemo(() => {
@@ -156,12 +149,7 @@ export function Settings() {
   }, [instance]);
 
   const publicUrlPreview = useMemo(() => {
-    const host = publicDomainDraft.trim().toLowerCase();
-    const path = normalizeBasePathInput(publicBasePathDraft);
-    if (!host) return null;
-    const proto = looksLikeIpv4(host) ? "http" : "https";
-    const origin = `${proto}://${host}`;
-    return path === "/" ? origin : `${origin}${path}`;
+    return formatPublicDashboardUrl(publicDomainDraft, publicBasePathDraft);
   }, [publicDomainDraft, publicBasePathDraft]);
 
   const setEnvField = (key: string, value: string) => {
@@ -291,7 +279,7 @@ export function Settings() {
   const onSavePublicUrlEnv = async (e: React.FormEvent) => {
     e.preventDefault();
     const domain = publicDomainDraft.trim().toLowerCase();
-    const basePath = normalizeBasePathInput(publicBasePathDraft);
+    const basePath = normalizePublicBasePath(publicBasePathDraft);
     const email = certbotEmailDraft.trim();
     const env: Record<string, string> = {};
     if (domain) env.PUBLIC_DOMAIN = domain;
@@ -327,7 +315,7 @@ export function Settings() {
     try {
       const r = await applyNginxSite({
         publicDomain: domain,
-        publicBasePath: normalizeBasePathInput(publicBasePathDraft),
+        publicBasePath: normalizePublicBasePath(publicBasePathDraft),
       });
       toast.success(r.message);
       const i = await getInstanceSettings();
@@ -353,10 +341,22 @@ export function Settings() {
     }
     setCertbotRunning(true);
     try {
-      const r = await requestCertbotSsl({ email: certbotEmailDraft.trim() });
+      const r = await requestCertbotSsl({
+        email: certbotEmailDraft.trim(),
+        publicDomain: domain || undefined,
+      });
       toast.success(r.message);
+      const i = await getInstanceSettings();
+      setInstance(i);
+      setPublicDomainDraft(i.publicDomain ?? "");
     } catch (err) {
-      toast.error(err instanceof Error ? err.message : "Certbot failed");
+      let msg = err instanceof Error ? err.message : "Certbot failed";
+      let detail: string | undefined;
+      if (err instanceof ApiError && err.body && typeof err.body === "object") {
+        const d = (err.body as { detail?: unknown }).detail;
+        if (typeof d === "string" && d.trim()) detail = d.trim().slice(0, 800);
+      }
+      toast.error(msg, detail ? { description: detail } : undefined);
     } finally {
       setCertbotRunning(false);
     }
@@ -455,15 +455,16 @@ export function Settings() {
         </Card>
       </div>
 
-      <Card id="public-url" className="border-border/50 bg-card/60 ring-1 ring-border/30 scroll-mt-24">
+      <Card id="dashboard-url" className="border-border/50 bg-card/60 ring-1 ring-border/30 scroll-mt-24">
         <CardHeader>
           <CardTitle className="flex items-center gap-2">
             <Globe className="size-5 text-muted-foreground" aria-hidden />
-            Public URL and HTTPS
+            Dashboard URL &amp; hostname
           </CardTitle>
           <CardDescription>
-            Same options as setup: deploy behind a hostname (and optional path like{" "}
-            <code className="rounded bg-muted px-1 font-mono text-xs">/versiongate</code>). Point DNS at this server, then apply nginx and run Certbot for TLS.
+            Change the <strong className="font-medium text-foreground">domain / hostname</strong> and optional{" "}
+            <strong className="font-medium text-foreground">URL path</strong> where users open VersionGate (same as first-time setup). Below you can also
+            configure HTTPS.
           </CardDescription>
         </CardHeader>
         <CardContent className="space-y-6">
@@ -479,24 +480,29 @@ export function Settings() {
           <form onSubmit={(e) => void onSavePublicUrlEnv(e)} className="space-y-4">
             <div className="grid gap-4 sm:grid-cols-2">
               <div className="space-y-2">
-                <p className="text-sm font-medium text-foreground">Public hostname</p>
+                <p className="text-sm font-medium text-foreground">Hostname (domain)</p>
                 <Input
-                  placeholder="example.com"
+                  placeholder="versiongate.example.com"
                   value={publicDomainDraft}
                   onChange={(e) => setPublicDomainDraft(e.target.value)}
                   autoComplete="off"
                 />
-                <p className="text-xs text-muted-foreground">Hostname or IPv4 for HTTP. TLS requires a hostname.</p>
+                <p className="text-xs text-muted-foreground">
+                  DNS name or IP shown in the browser (apex <code className="font-mono text-[11px]">example.com</code>, subdomain, or IPv4). TLS needs a
+                  hostname, not only an IP.
+                </p>
               </div>
               <div className="space-y-2">
-                <p className="text-sm font-medium text-foreground">URL base path</p>
+                <p className="text-sm font-medium text-foreground">URL path (optional)</p>
                 <Input
                   placeholder="/ or /versiongate"
                   value={publicBasePathDraft}
                   onChange={(e) => setPublicBasePathDraft(e.target.value)}
                   autoComplete="off"
                 />
-                <p className="text-xs text-muted-foreground">A leading slash is added if you omit it.</p>
+                <p className="text-xs text-muted-foreground">
+                  Path after the hostname if VersionGate is not at the site root. A leading slash is added if omitted.
+                </p>
               </div>
             </div>
             <div className="space-y-2 sm:max-w-md">
@@ -515,7 +521,7 @@ export function Settings() {
                 <span className="font-mono text-foreground">{publicUrlPreview}</span>
               </p>
             ) : null}
-            {normalizeBasePathInput(publicBasePathDraft) !== "/" ? (
+            {normalizePublicBasePath(publicBasePathDraft) !== "/" ? (
               <p className="rounded-md border border-amber-300/80 bg-amber-50 px-3 py-2 text-sm text-amber-950">
                 Subpath URLs need the dashboard built with the same Vite <code className="font-mono text-xs">base</code>; otherwise static assets may
                 break. Using <code className="font-mono text-xs">/</code> is simplest.
@@ -544,9 +550,11 @@ export function Settings() {
               </Button>
             </div>
             <p className="text-xs text-muted-foreground">
-              <span className="font-medium text-foreground">Suggested order:</span> save hostname and email → DNS A record → write nginx (HTTP on port 80) →
-              Certbot. Certbot reads <code className="rounded bg-muted px-1 font-mono">PUBLIC_DOMAIN</code> from <code className="rounded bg-muted px-1 font-mono">.env</code>
-              — use Save or nginx apply first. Requires <code className="rounded bg-muted px-1 font-mono">certbot</code> and permission to reload nginx on the host.
+              <span className="font-medium text-foreground">Suggested order:</span> set hostname to the exact name you want a certificate for (e.g.{" "}
+              <code className="font-mono text-xs">versiongate.dineshkorukonda.online</code>) → add a DNS <strong>A</strong> or <strong>CNAME</strong> for that
+              name to this server → <strong>Write nginx config &amp; reload</strong> (so <code className="font-mono text-xs">server_name</code> matches) →
+              then <strong>Obtain SSL</strong>. Apex DNS alone does not cover a subdomain—you need a record for the subdomain itself. Running SSL writes the hostname to{" "}
+              <code className="rounded bg-muted px-1 font-mono">.env</code>. Requires <code className="rounded bg-muted px-1 font-mono">certbot</code>, nginx on port 80, and reload privileges (often sudo).
             </p>
           </form>
         </CardContent>

--- a/dashboard/src/pages/Setup.tsx
+++ b/dashboard/src/pages/Setup.tsx
@@ -128,7 +128,7 @@ export function Setup() {
             <form onSubmit={(e) => void onSubmit(e)} className="space-y-4">
               <div className="space-y-2">
                 <label htmlFor="vg-domain" className="text-sm font-medium">
-                  Public hostname or IP
+                  Hostname (domain or IP)
                 </label>
                 <Input
                   id="vg-domain"

--- a/src/controllers/settings.controller.ts
+++ b/src/controllers/settings.controller.ts
@@ -450,6 +450,8 @@ export async function postNginxApplySiteHandler(
 
 interface CertbotBody {
   email?: string;
+  /** When set, validated and merged into `.env` as PUBLIC_DOMAIN before Certbot runs (avoids stale apex domain). */
+  publicDomain?: string;
 }
 
 /** Runs non-interactive Certbot nginx installer for PUBLIC_DOMAIN (hostname only). */
@@ -457,12 +459,33 @@ export async function postCertbotSslHandler(
   req: FastifyRequest<{ Body: CertbotBody }>,
   reply: FastifyReply
 ): Promise<void> {
-  const domain = (readEnvKeyFromFile("PUBLIC_DOMAIN") ?? "").trim().toLowerCase();
+  const bodyDomainRaw =
+    typeof req.body?.publicDomain === "string" ? req.body.publicDomain.trim().toLowerCase() : "";
+  let domain = (readEnvKeyFromFile("PUBLIC_DOMAIN") ?? "").trim().toLowerCase();
+
+  if (bodyDomainRaw) {
+    if (!isValidHostname(bodyDomainRaw)) {
+      return reply.code(400).send({
+        error: "BadRequest",
+        message: "publicDomain must be a valid DNS hostname (subdomains allowed).",
+      });
+    }
+    domain = bodyDomainRaw;
+    try {
+      const next = mergeIntoDotenv({ PUBLIC_DOMAIN: domain });
+      writeEnvWithBackup(next);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      logger.error({ err }, "postCertbotSsl: could not persist PUBLIC_DOMAIN");
+      return reply.code(500).send({ error: "WriteError", message: msg });
+    }
+  }
+
   if (!domain || !isValidHostname(domain)) {
     return reply.code(400).send({
       error: "BadRequest",
       message:
-        "PUBLIC_DOMAIN must be a DNS hostname (not a raw IP) for Let's Encrypt. Save it under Public URL first, then update DNS.",
+        "PUBLIC_DOMAIN must be a DNS hostname (not a raw IP) for Let's Encrypt. Enter the hostname in Settings (or save it to .env), then update DNS.",
     });
   }
 


### PR DESCRIPTION
## Summary

This branch delivers **GitHub App integration** for the dashboard, a full **Settings** experience for **public hostname, URL path, nginx, and Let’s Encrypt (Certbot)**, routing fixes, and clearer **“where VersionGate is served”** UX on Overview and Settings.

---

## Dashboard

### Routing
- **`/settings` route** is registered in `main.tsx` so the Settings nav item no longer falls through to the catch-all redirect to `/`.

### Settings — instance & environment
- Instance metadata, health donut, `.env` patching (non-secret keys), and self-update controls.
- **Dashboard URL & hostname** (anchor `#dashboard-url`): edit `PUBLIC_DOMAIN`, `PUBLIC_BASE_PATH`, and `CERTBOT_EMAIL`; DNS guidance; **Save to .env**, **Write nginx config & reload**, **Obtain SSL (certbot --nginx)**.
- Loading no longer blocks indefinitely if the self-update API fails (fallback from instance flags).
- **Certbot** requests may include **`publicDomain`** so the hostname in the form is written to `.env` before Let’s Encrypt runs (avoids stale apex domain after switching to a subdomain). Error responses can include a **`detail`** string; the UI shows it in the toast description when present.

### Overview
- New **“Dashboard hostname & URL”** card: shows the configured public URL (from instance settings), hostname/path breakdown, and **Change domain & hostname** → `/settings#dashboard-url`.
- Fetches `getInstanceSettings()` alongside existing overview data (non-fatal on failure).

### Shared helpers
- `dashboard/src/lib/public-url.ts`: `normalizePublicBasePath`, `looksLikeIpv4`, `formatPublicDashboardUrl` — shared by Settings and Overview.

### Setup wizard
- Domain field label aligned with Settings: **Hostname (domain or IP)**.

---

## Backend

### Settings / nginx / SSL
- **`GET /settings/instance`** exposes `publicDomain`, `publicBasePath`, `certbotEmail` (from `.env`).
- **`PATCH /settings/env`** allows `PUBLIC_DOMAIN`, `PUBLIC_BASE_PATH`, `CERTBOT_EMAIL` with validation.
- **`POST /settings/nginx/apply`**: writes generated nginx reverse-proxy config (supports path prefix), reloads nginx, persists `PUBLIC_*` to `.env` when possible.
- **`POST /settings/ssl/certbot`**: non-interactive `certbot --nginx`; optional **`publicDomain`** in JSON body persists to `.env` before the run; **`email`** optional in body.
- Shared **`domain-validation`** and **`nginx-versiongate-site`** utilities; setup wizard uses the nginx generator for consistency.

### GitHub App (earlier commits on this branch)
- Install flow, repos API, signed webhooks, dashboard **Integrations** page, repo picker, and create-project GitHub flow (see commits `94e25c0`, `73c755a`, `49e7d24`).

---

## How to verify

From repo root and `dashboard/`:

```bash
bunx tsc --noEmit
cd dashboard && bunx tsc --noEmit && bun run build
```

Manually:
1. Open **Overview** — confirm **Dashboard hostname & URL** card and link to Settings.
2. Open **Settings** — confirm **Dashboard URL & hostname** section, save/apply/nginx/certbot flows as appropriate on a test host.
3. Confirm **Settings** in the sidebar navigates to `/settings` (no bounce to `/`).

---

## Operational notes

- **DNS**: Let’s Encrypt validates the **exact** hostname; a subdomain needs its own **A**/**AAAA**/**CNAME**, not only apex records.
- **Order when changing hostname**: update hostname in UI → **Write nginx** (so `server_name` matches) → DNS propagated → **Certbot**. Ports **80** (and **443** after TLS) must reach nginx where applicable.
- **Certbot / nginx** require the binaries and sufficient privileges on the host (implementation may use `sudo -n` as fallback).
- **Subpath** (`PUBLIC_BASE_PATH` ≠ `/`) still requires a dashboard build whose Vite `base` matches; UI warns about this.

---

## Files touched (latest commit)

| Area | Files |
|------|--------|
| Dashboard | `dashboard/src/lib/public-url.ts` (new), `Overview.tsx`, `Settings.tsx`, `Setup.tsx`, `api.ts` |
| API | `src/controllers/settings.controller.ts` |

Full branch diff vs `main` includes additional backend/dashboard files from GitHub integration and the initial Settings/nginx feature commit.
