### PR TITLE
GitHub App, Settings (URL/HTTPS/nginx/Certbot), preflight SSL, dashboard hostname UX

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,10 @@ DOCKER_NETWORK="versiongate-net"
 
 # ── Nginx ──────────────────────────────────────────────────────────────────────
 NGINX_CONFIG_PATH="/etc/nginx/conf.d/upstream.conf"
+# Public dashboard URL (Settings → Dashboard URL & hostname writes these)
+# PUBLIC_DOMAIN="versiongate.example.com"
+# PUBLIC_BASE_PATH="/"
+# CERTBOT_EMAIL="ops@example.com"
 
 # ── Git ────────────────────────────────────────────────────────────────────────
 # Base directory where project source code is cloned

--- a/dashboard/src/pages/Settings.tsx
+++ b/dashboard/src/pages/Settings.tsx
@@ -554,7 +554,10 @@ export function Settings() {
               <code className="font-mono text-xs">versiongate.dineshkorukonda.online</code>) → add a DNS <strong>A</strong> or <strong>CNAME</strong> for that
               name to this server → <strong>Write nginx config &amp; reload</strong> (so <code className="font-mono text-xs">server_name</code> matches) →
               then <strong>Obtain SSL</strong>. Apex DNS alone does not cover a subdomain—you need a record for the subdomain itself. Running SSL writes the hostname to{" "}
-              <code className="rounded bg-muted px-1 font-mono">.env</code>. Requires <code className="rounded bg-muted px-1 font-mono">certbot</code>, nginx on port 80, and reload privileges (often sudo).
+              <code className="rounded bg-muted px-1 font-mono">.env</code>. The API process must be able to run{" "}
+              <code className="rounded bg-muted px-1 font-mono">certbot</code> (install{" "}
+              <code className="rounded bg-muted px-1 font-mono">certbot</code> and{" "}
+              <code className="rounded bg-muted px-1 font-mono">python3-certbot-nginx</code> on the host; check logs for DNS and certbot path). Requires nginx on port 80 and reload privileges (often sudo).
             </p>
           </form>
         </CardContent>

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -115,7 +115,7 @@ After success, open the dashboard from `/`. The wizard is intended for initial b
 | Method | Path | Description |
 |--------|------|-------------|
 | `POST` | `/api/v1/webhooks/:secret` | GitHub push webhook (auto-deploy) |
-| `GET` | `/api/v1/system/preflight` | Host compatibility (Docker, Git, network, paths; no DB required). Same as `bun run preflight`. |
+| `GET` | `/api/v1/system/preflight` | Host compatibility (Docker, Git, nginx, **certbot / SSL readiness**, `PUBLIC_DOMAIN` DNS, `CERTBOT_EMAIL`, `COOKIE_SECURE`; no DB required). Same as `bun run preflight`. |
 | `GET` | `/api/v1/system/server-stats` | Host CPU / memory / disk / network |
 | `GET` | `/api/v1/system/server-dashboard` | Full server dashboard data |
 | `POST` | `/api/v1/system/reconcile` | Manual crash recovery trigger |

--- a/src/controllers/settings.controller.ts
+++ b/src/controllers/settings.controller.ts
@@ -1,6 +1,7 @@
 import { randomBytes } from "crypto";
 import { readFileSync, existsSync, writeFileSync } from "fs";
 import { execFileSync } from "child_process";
+import { promises as dns } from "dns";
 import { join } from "path";
 import { FastifyRequest, FastifyReply } from "fastify";
 import {
@@ -17,6 +18,7 @@ import { applySelfUpdate, getSelfUpdateStatus } from "../services/self-update.se
 import { kickSelfUpdatePoll } from "../services/self-update-poll";
 import { isValidHostname, isValidIpv4Address } from "../utils/domain-validation";
 import { generateVersionGateNginxConf, normalizePublicBasePath } from "../utils/nginx-versiongate-site";
+import { CERTBOT_PATH_CANDIDATES, findCertbotExecutablePath } from "../utils/certbot-path";
 
 const DB_URL_REGEX = /^DATABASE_URL\s*=\s*"?([^"\n\r]+)"?\s*$/m;
 
@@ -364,6 +366,84 @@ function reloadNginxBestEffort(): void {
   execFileSync("sudo", ["-n", "/usr/sbin/nginx", "-s", "reload"], { stdio: "pipe" });
 }
 
+async function logDnsForPublicHostname(context: string, hostname: string): Promise<void> {
+  try {
+    const a = await dns.resolve4(hostname);
+    logger.info({ context, hostname, A: a }, `${context}: DNS A for hostname (as seen by this server)`);
+  } catch (err) {
+    logger.warn(
+      { context, hostname, err },
+      `${context}: DNS A lookup failed — add an A (or AAAA) record for this exact hostname, or wait for propagation`
+    );
+  }
+  try {
+    const aaaa = await dns.resolve6(hostname);
+    logger.info({ context, hostname, AAAA: aaaa }, `${context}: DNS AAAA for hostname`);
+  } catch {
+    /* no IPv6 — common */
+  }
+  try {
+    const cname = await dns.resolveCname(hostname);
+    if (cname.length) logger.info({ context, hostname, CNAME: cname }, `${context}: DNS CNAME for hostname`);
+  } catch {
+    /* not a CNAME leaf — normal for A-record setups */
+  }
+}
+
+function isCertbotMissingError(message: string): boolean {
+  const m = message.toLowerCase();
+  return (
+    (m.includes("certbot") && m.includes("command not found")) ||
+    m.includes("enoent") ||
+    (m.includes("no such file or directory") && m.includes("certbot"))
+  );
+}
+
+/** Runs certbot with full binary path when possible (avoids sudo PATH issues). */
+function runCertbotNginxPlugin(args: string[], domain: string): void {
+  const explicit = findCertbotExecutablePath();
+  if (explicit) {
+    logger.info({ certbotPath: explicit, domain }, "certbot: invoking binary");
+    try {
+      execFileSync(explicit, args, { stdio: "pipe", timeout: 240_000 });
+      logger.info({ certbotPath: explicit, domain }, "certbot: finished OK (current user)");
+      return;
+    } catch (directErr) {
+      const msg = directErr instanceof Error ? directErr.message : String(directErr);
+      logger.warn({ err: msg, certbotPath: explicit, domain }, "certbot: failed as current user — trying sudo -n with same path");
+      execFileSync("sudo", ["-n", explicit, ...args], { stdio: "pipe", timeout: 240_000 });
+      logger.info({ certbotPath: explicit, domain, via: "sudo" }, "certbot: finished OK (sudo)");
+      return;
+    }
+  }
+
+  logger.warn(
+    { checkedPaths: [...CERTBOT_PATH_CANDIDATES] },
+    "certbot: no binary at known paths — falling back to PATH name certbot (install certbot on the host)"
+  );
+  try {
+    execFileSync("certbot", args, { stdio: "pipe", timeout: 240_000 });
+    logger.info({ domain }, "certbot: finished OK (PATH certbot)");
+  } catch (pathErr) {
+    const msg1 = pathErr instanceof Error ? pathErr.message : String(pathErr);
+    try {
+      execFileSync("sudo", ["-n", "/usr/bin/certbot", ...args], { stdio: "pipe", timeout: 240_000 });
+      logger.info({ domain, via: "sudo", certbotPath: "/usr/bin/certbot" }, "certbot: finished OK");
+    } catch (sudoErr) {
+      const msg2 = sudoErr instanceof Error ? sudoErr.message : String(sudoErr);
+      if (isCertbotMissingError(msg1) && isCertbotMissingError(msg2)) {
+        throw new Error(
+          "CERTBOT_MISSING: certbot is not installed or not on PATH for this process or sudo. " +
+            "On Debian/Ubuntu run: sudo apt update && sudo apt install -y certbot python3-certbot-nginx. " +
+            "Snap: sudo snap install --classic certbot && sudo ln -sf /snap/bin/certbot /usr/bin/certbot. " +
+            `Checked paths: ${CERTBOT_PATH_CANDIDATES.join(", ")}.`
+        );
+      }
+      throw sudoErr instanceof Error ? sudoErr : pathErr;
+    }
+  }
+}
+
 interface ApplyNginxBody {
   publicDomain?: string;
   publicBasePath?: string;
@@ -397,6 +477,21 @@ export async function postNginxApplySiteHandler(
     return reply.code(400).send({ error: "BadRequest", message: "Invalid public hostname or IP address." });
   }
 
+  logger.info(
+    {
+      domain: domainRaw,
+      basePath,
+      serverName: domainIsIp ? "_" : domainRaw,
+      upstreamPort: config.port,
+      nginxConfigPath: config.nginxConfigPath,
+    },
+    "postNginxApplySite: preparing nginx vhost for VersionGate"
+  );
+
+  if (domainIsHostname) {
+    await logDnsForPublicHostname("postNginxApplySite", domainRaw);
+  }
+
   const conf = generateVersionGateNginxConf({
     serverName: domainIsIp ? "_" : domainRaw,
     defaultServer: domainIsIp,
@@ -408,6 +503,7 @@ export async function postNginxApplySiteHandler(
   const outPath = config.nginxConfigPath;
   try {
     writeFileSync(outPath, conf, "utf-8");
+    logger.info({ outPath, bytes: Buffer.byteLength(conf, "utf-8") }, "postNginxApplySite: wrote nginx config file");
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     logger.error({ err }, "postNginxApplySite: write failed");
@@ -416,6 +512,7 @@ export async function postNginxApplySiteHandler(
 
   try {
     reloadNginxBestEffort();
+    logger.info({ outPath }, "postNginxApplySite: nginx config tested and reloaded");
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     logger.error({ err }, "postNginxApplySite: nginx reload failed");
@@ -510,20 +607,35 @@ export async function postCertbotSslHandler(
     "--redirect",
   ];
 
+  logger.info(
+    {
+      domain,
+      certbotResolvedPath: findCertbotExecutablePath(),
+      nginxConfigPath: config.nginxConfigPath,
+    },
+    "postCertbotSsl: starting Let's Encrypt (check DNS logs above if nginx apply was recent)"
+  );
+
+  await logDnsForPublicHostname("postCertbotSsl", domain);
+
   try {
-    try {
-      execFileSync("certbot", args, { stdio: "pipe", timeout: 240_000 });
-    } catch (directErr) {
-      logger.debug({ err: directErr }, "certbot as current user failed — trying sudo -n");
-      execFileSync("sudo", ["-n", "certbot", ...args], { stdio: "pipe", timeout: 240_000 });
-    }
+    runCertbotNginxPlugin(args, domain);
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
-    logger.error({ err }, "certbot failed");
+    if (msg.startsWith("CERTBOT_MISSING:")) {
+      const human = msg.replace(/^CERTBOT_MISSING:\s*/, "").trim();
+      logger.error({ domain, detail: human }, "postCertbotSsl: certbot binary not available on host");
+      return reply.code(503).send({
+        error: "CertbotNotInstalled",
+        message: "Certbot is not installed on this server (or sudo cannot run it). Install certbot and the nginx plugin, then retry.",
+        detail: human.slice(0, 1200),
+      });
+    }
+    logger.error({ domain, detail: msg }, "postCertbotSsl: certbot run failed");
     return reply.code(500).send({
       error: "CertbotFailed",
       message:
-        "Certbot could not obtain or install a certificate. Ensure DNS points to this server, ports 80/443 are reachable, certbot is installed, and nginx is healthy.",
+        "Certbot could not obtain or install a certificate. Ensure DNS points to this server, ports 80/443 are reachable, certbot is installed, and nginx is healthy. Check API logs for DNS A/AAAA lines for this hostname.",
       detail: msg.slice(0, 1200),
     });
   }

--- a/src/services/preflight.service.ts
+++ b/src/services/preflight.service.ts
@@ -1,7 +1,10 @@
 import { constants, existsSync } from "fs";
 import { access } from "fs/promises";
+import { promises as dns } from "dns";
 import { config } from "../config/env";
 import { execFileAsync } from "../utils/exec";
+import { findCertbotExecutablePath } from "../utils/certbot-path";
+import { isValidHostname, isValidIpv4Address } from "../utils/domain-validation";
 
 export type PreflightSeverity = "required" | "recommended" | "informational";
 
@@ -164,6 +167,134 @@ export async function runPreflightChecks(): Promise<PreflightReport> {
     ok: nginx.ok,
     message: nginx.ok ? firstLine(nginx.out) : "`nginx` not in PATH (install for automatic upstream switching)",
     detail: nginx.ok ? firstLine(nginx.out) : undefined,
+  });
+
+  if (nginx.ok) {
+    const nginxConfExists = existsSync(config.nginxConfigPath);
+    checks.push({
+      id: "nginx_config_path",
+      label: "Nginx config path",
+      severity: "informational",
+      ok: nginxConfExists,
+      message: nginxConfExists
+        ? `File exists: ${config.nginxConfigPath}`
+        : `Not found yet: ${config.nginxConfigPath} — use Settings → Write nginx config after setting PUBLIC_DOMAIN`,
+      detail: config.nginxConfigPath,
+    });
+  }
+
+  // ── Certbot + nginx plugin (Settings → Obtain SSL) ─────────────────────────
+  const certbotBin = findCertbotExecutablePath();
+  const certbotCmd = certbotBin ?? "certbot";
+  const certbotVer = await tryExec(certbotCmd, ["--version"]);
+  checks.push({
+    id: "certbot",
+    label: "Certbot (Let's Encrypt)",
+    severity: "recommended",
+    ok: certbotVer.ok,
+    message: certbotVer.ok
+      ? `${firstLine(certbotVer.out)}${certbotBin ? ` · ${certbotBin}` : ""}`
+      : "Install certbot + python3-certbot-nginx (or snap certbot) for in-dashboard TLS; see docs/SETUP.md",
+    detail: certbotVer.ok ? undefined : certbotVer.err,
+  });
+
+  let certbotNginxPluginOk = false;
+  let certbotPluginsOut = "";
+  if (certbotVer.ok) {
+    const plugins = await tryExec(certbotCmd, ["plugins"]);
+    certbotPluginsOut = plugins.ok ? plugins.out.slice(0, 600) : plugins.err;
+    certbotNginxPluginOk = plugins.ok && /\bnginx\b/i.test(plugins.out);
+  }
+  checks.push({
+    id: "certbot_nginx_plugin",
+    label: "Certbot nginx plugin",
+    severity: "recommended",
+    ok: certbotVer.ok && certbotNginxPluginOk,
+    message:
+      !certbotVer.ok
+        ? "Skipped — install certbot first"
+        : certbotNginxPluginOk
+          ? "`certbot --nginx` installer available"
+          : "Install python3-certbot-nginx (Debian/Ubuntu) so Settings → Obtain SSL can use the nginx authenticator",
+    detail: certbotPluginsOut || undefined,
+  });
+
+  // ── Public URL / TLS alignment (PUBLIC_DOMAIN from env this process loaded) ─
+  const publicDomain = (process.env.PUBLIC_DOMAIN ?? "").trim().toLowerCase();
+  const certbotEmail = (process.env.CERTBOT_EMAIL ?? "").trim();
+  const emailOk = /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(certbotEmail);
+
+  if (publicDomain && isValidHostname(publicDomain)) {
+    try {
+      const a = await dns.resolve4(publicDomain);
+      checks.push({
+        id: "public_domain_dns_a",
+        label: `DNS A for ${publicDomain}`,
+        severity: "recommended",
+        ok: a.length > 0,
+        message:
+          a.length > 0
+            ? `Resolved: ${a.join(", ")} (from this host — Let's Encrypt must reach this server on port 80)`
+            : "No A records returned",
+        detail: publicDomain,
+      });
+    } catch (e) {
+      const err = e instanceof Error ? e.message : String(e);
+      checks.push({
+        id: "public_domain_dns_a",
+        label: `DNS A for ${publicDomain}`,
+        severity: "recommended",
+        ok: false,
+        message:
+          "No A record from this host — subdomain or propagation issue; HTTP-01 validation will fail until DNS points here",
+        detail: err.slice(0, 300),
+      });
+    }
+  } else if (publicDomain && isValidIpv4Address(publicDomain)) {
+    checks.push({
+      id: "public_domain_dns_a",
+      label: "PUBLIC_DOMAIN",
+      severity: "informational",
+      ok: true,
+      message: `Using IPv4 ${publicDomain} — browser access OK; Let's Encrypt needs a DNS hostname instead`,
+      detail: publicDomain,
+    });
+  } else {
+    checks.push({
+      id: "public_domain_dns_a",
+      label: "PUBLIC_DOMAIN (public URL)",
+      severity: "informational",
+      ok: true,
+      message: "Not set — configure Settings → Dashboard URL & hostname when exposing VersionGate on a domain",
+    });
+  }
+
+  const wantsHttpsCookies =
+    Boolean(publicDomain && isValidHostname(publicDomain)) && !isValidIpv4Address(publicDomain);
+  checks.push({
+    id: "certbot_email_env",
+    label: "CERTBOT_EMAIL",
+    severity: "recommended",
+    ok: !wantsHttpsCookies || emailOk,
+    message:
+      wantsHttpsCookies && !emailOk
+        ? "Set CERTBOT_EMAIL in .env (or in Settings) for non-interactive `certbot --nginx` contact"
+        : emailOk
+          ? "Let's Encrypt contact email is set"
+          : "Optional until you use Obtain SSL with a hostname",
+    detail: certbotEmail ? "[set]" : undefined,
+  });
+
+  checks.push({
+    id: "cookie_secure_https",
+    label: "COOKIE_SECURE (HTTPS sessions)",
+    severity: "recommended",
+    ok: !wantsHttpsCookies || config.cookieSecure,
+    message: wantsHttpsCookies && !config.cookieSecure
+      ? "Set COOKIE_SECURE=true when the dashboard is HTTPS-only so session cookies use the Secure flag"
+      : config.cookieSecure
+        ? "COOKIE_SECURE=true — session cookies are Secure (use with HTTPS reverse proxy)"
+        : "COOKIE_SECURE unset/false — fine for HTTP or local access behind plain IP",
   });
 
   const requiredOk = checks.filter((c) => c.severity === "required").every((c) => c.ok);

--- a/src/utils/certbot-path.ts
+++ b/src/utils/certbot-path.ts
@@ -1,0 +1,17 @@
+import { existsSync } from "fs";
+
+/** Sudo often uses a minimal PATH; prefer these absolute paths (same list as Settings → SSL). */
+export const CERTBOT_PATH_CANDIDATES = [
+  "/usr/bin/certbot",
+  "/snap/bin/certbot",
+  "/usr/local/bin/certbot",
+  "/opt/certbot/bin/certbot",
+  "/opt/homebrew/bin/certbot",
+] as const;
+
+export function findCertbotExecutablePath(): string | null {
+  for (const p of CERTBOT_PATH_CANDIDATES) {
+    if (existsSync(p)) return p;
+  }
+  return null;
+}


### PR DESCRIPTION
## Summary

Branch **`cursor/github-app-integration`** adds GitHub App integration, dashboard **Settings** (public URL, nginx, Certbot), routing and hostname UX, and **preflight SSL / TLS readiness** checks.

## Highlights

### GitHub App
- Install flow, repos API, signed webhooks, **Integrations** page, repo picker, create-project GitHub wiring.

### Dashboard
- **`/settings`** route registered.
- **Settings**: instance/env/self-update; **Dashboard URL & hostname**; nginx apply + Certbot; Certbot can persist `publicDomain` from the UI; error `detail` in toasts.
- **Overview**: card for configured public URL + link to Settings anchor.
- **`src/lib/public-url.ts`**: shared URL formatting / path normalization.

### Backend
- Settings: `PATCH` env keys for public URL; `POST` nginx apply + Certbot; DNS logging; certbot full-path resolution; `503` when certbot missing.
- Shared **`src/utils/certbot-path.ts`** for certbot binary discovery.

### Preflight & ops (latest)
- Preflight: nginx config path, **certbot** + **nginx plugin**, **DNS A** for `PUBLIC_DOMAIN`, **`CERTBOT_EMAIL`**, **`COOKIE_SECURE`** when using a hostname.
- **`.env.example`**: commented `PUBLIC_DOMAIN` / `PUBLIC_BASE_PATH` / `CERTBOT_EMAIL`.
- **`docs/SETUP.md`**: preflight row updated.

## Verify

```bash
bunx tsc --noEmit
cd dashboard && bunx tsc --noEmit && bun run build
bun run preflight
```

## Ops

Restart API after `.env` changes so preflight sees updated `PUBLIC_DOMAIN`. Install **certbot** + **python3-certbot-nginx** (or snap) for Settings SSL.
