### PR TITLE
GitHub App integration, Settings TLS/nginx, preflight SSL, install redirect fix

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,8 @@ NODE_ENV=development
 LOG_LEVEL=info
 # Set true when the dashboard is only served over HTTPS (session cookie Secure flag)
 # COOKIE_SECURE=false
+# Full browser origin for redirects (GitHub App callback → dashboard). If unset, inferred from Host / PUBLIC_DOMAIN.
+# PUBLIC_APP_URL="https://versiongate.example.com"
 
 # ── Docker ─────────────────────────────────────────────────────────────────────
 DOCKER_NETWORK="versiongate-net"

--- a/dashboard/src/pages/Integrations.tsx
+++ b/dashboard/src/pages/Integrations.tsx
@@ -16,6 +16,7 @@ import {
 import { Separator } from "@/components/ui/separator";
 import { buttonVariants } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 
 const MANAGE_APP_HREF = "https://github.com/apps/VersionGate-App/installations";
 const INSTALL_HREF = "/api/auth/github/install";
@@ -81,6 +82,11 @@ export function Integrations() {
     return g ? g.trim().toLowerCase() : null;
   }, [searchParams]);
 
+  const githubCallbackUrl = useMemo(
+    () => (typeof window !== "undefined" ? `${window.location.origin}/api/auth/github/callback` : ""),
+    []
+  );
+
   useEffect(() => {
     if (!githubQuery) return;
     const messages: Record<string, { type: "success" | "error"; text: string }> = {
@@ -109,6 +115,28 @@ export function Integrations() {
         title="Integrations"
         description="Connect external services to streamline project setup and automation."
       />
+
+      <Alert className="border-border/80 bg-muted/20">
+        <AlertTitle>Return to VersionGate after GitHub install</AlertTitle>
+        <AlertDescription className="space-y-2 text-muted-foreground [&_p]:text-sm">
+          <p>
+            If you finish install on GitHub but stay on <span className="font-mono text-xs">github.com/settings/installations</span>, your GitHub App{" "}
+            <strong className="text-foreground">Callback URL</strong> is not pointing at this server. In GitHub →{" "}
+            <strong className="text-foreground">Settings → Applications → VersionGate-App</strong> (or the org app settings), set{" "}
+            <strong className="text-foreground">Callback URL</strong> to exactly:
+          </p>
+          {githubCallbackUrl ? (
+            <code className="block max-w-full overflow-x-auto break-all rounded-md bg-background px-2 py-1.5 font-mono text-xs text-foreground">
+              {githubCallbackUrl}
+            </code>
+          ) : null}
+          <p>
+            Optionally set the same value as <strong className="text-foreground">Setup URL</strong> so GitHub sends users back here automatically. Use{" "}
+            <strong className="text-foreground">Connect GitHub</strong> below so your session is linked. If the API is reached on a different host than this page, set{" "}
+            <span className="font-mono text-xs">PUBLIC_APP_URL</span> in <span className="font-mono text-xs">.env</span> and register that callback URL in the GitHub App.
+          </p>
+        </AlertDescription>
+      </Alert>
 
       <Card>
         <CardHeader>

--- a/src/controllers/github-app.controller.ts
+++ b/src/controllers/github-app.controller.ts
@@ -14,13 +14,12 @@ import { createInstallState, parseInstallState } from "../utils/github-install-s
 import { getInstallationAccessToken } from "../utils/github-installation-token";
 import { normalizeGithubRepoUrl } from "../utils/github-repo-url";
 import { verifyGithubWebhookSignature } from "../utils/github-webhook-signature";
+import { dashboardIntegrationsAbsoluteUrl } from "../utils/public-app-origin";
 
 const projectRepo = new ProjectRepository();
 const envRepo = new EnvironmentRepository();
 
 const INSTALL_APP_URL = "https://github.com/apps/VersionGate-App/installations/new";
-/** Dashboard Integrations page (SPA). */
-const INTEGRATIONS_PATH = "/dashboard/integrations";
 
 function githubAppReady(): boolean {
   const appId = Number(config.githubAppId);
@@ -56,6 +55,14 @@ export async function githubInstallHandler(req: FastifyRequest, reply: FastifyRe
     url.searchParams.set("state", createInstallState(user.id, secret));
   }
 
+  logger.info(
+    {
+      userId: user.id,
+      redirectAfterInstall: dashboardIntegrationsAbsoluteUrl(req, { github: "connected" }),
+    },
+    "githubInstall: redirecting user to GitHub App install"
+  );
+
   reply.redirect(302, url.toString());
 }
 
@@ -64,15 +71,25 @@ export async function githubCallbackHandler(
   reply: FastifyReply
 ): Promise<void> {
   if (!githubAppReady()) {
-    reply.redirect(302, `${INTEGRATIONS_PATH}?github=config`);
+    reply.redirect(302, dashboardIntegrationsAbsoluteUrl(req, { github: "config" }));
     return;
   }
 
   const installationIdStr = req.query.installation_id ?? "";
   const setupAction = req.query.setup_action ?? "";
 
+  logger.info(
+    {
+      installationId: installationIdStr || undefined,
+      setupAction: setupAction || undefined,
+      host: req.headers.host,
+      origin: dashboardIntegrationsAbsoluteUrl(req, {}),
+    },
+    "githubCallback: received redirect from GitHub"
+  );
+
   if (!installationIdStr || !/^\d+$/.test(installationIdStr)) {
-    reply.redirect(302, `${INTEGRATIONS_PATH}?github=missing_installation`);
+    reply.redirect(302, dashboardIntegrationsAbsoluteUrl(req, { github: "missing_installation" }));
     return;
   }
 
@@ -84,12 +101,12 @@ export async function githubCallbackHandler(
     userId = user?.id ?? null;
   }
   if (!userId) {
-    reply.redirect(302, `${INTEGRATIONS_PATH}?github=auth_required`);
+    reply.redirect(302, dashboardIntegrationsAbsoluteUrl(req, { github: "auth_required" }));
     return;
   }
 
   if (setupAction === "request") {
-    reply.redirect(302, INTEGRATIONS_PATH);
+    reply.redirect(302, dashboardIntegrationsAbsoluteUrl(req, {}));
     return;
   }
 
@@ -105,7 +122,7 @@ export async function githubCallbackHandler(
 
   const account = installation.account;
   if (!account || typeof account !== "object") {
-    reply.redirect(302, `${INTEGRATIONS_PATH}?github=bad_installation`);
+    reply.redirect(302, dashboardIntegrationsAbsoluteUrl(req, { github: "bad_installation" }));
     return;
   }
   const login = "login" in account ? account.login : "";
@@ -127,7 +144,7 @@ export async function githubCallbackHandler(
     },
   });
 
-  reply.redirect(302, `${INTEGRATIONS_PATH}?github=connected`);
+  reply.redirect(302, dashboardIntegrationsAbsoluteUrl(req, { github: "connected" }));
 }
 
 async function resolveInstallationForUser(

--- a/src/utils/public-app-origin.ts
+++ b/src/utils/public-app-origin.ts
@@ -1,0 +1,52 @@
+import type { FastifyRequest } from "fastify";
+import { config } from "../config/env";
+import { isValidHostname, isValidIpv4Address } from "./domain-validation";
+
+function firstHeader(req: FastifyRequest, name: string): string {
+  const v = req.headers[name];
+  if (Array.isArray(v)) return (v[0] ?? "").trim();
+  return String(v ?? "").trim();
+}
+
+/**
+ * Public browser origin for this deployment (scheme + host, no path).
+ * Used for HTTP redirects (e.g. GitHub App install callback → dashboard).
+ */
+export function inferOriginFromRequest(req: FastifyRequest): string {
+  const xfHost = firstHeader(req, "x-forwarded-host") || firstHeader(req, "host");
+  if (!xfHost) return "";
+  const xfProtoRaw = firstHeader(req, "x-forwarded-proto");
+  const proto = (xfProtoRaw.split(",")[0]?.trim() || (req as { protocol?: string }).protocol || "https").replace(
+    /:$/,
+    ""
+  );
+  return `${proto}://${xfHost.split(",")[0].trim()}`;
+}
+
+/**
+ * Canonical public origin: `PUBLIC_APP_URL` → request Host → `https://` + `PUBLIC_DOMAIN`.
+ */
+export function resolvePublicAppOrigin(req: FastifyRequest): string {
+  const fromEnv = (process.env.PUBLIC_APP_URL ?? "").trim().replace(/\/+$/, "");
+  if (fromEnv) return fromEnv;
+
+  const inferred = inferOriginFromRequest(req);
+  if (inferred) return inferred;
+
+  const d = (process.env.PUBLIC_DOMAIN ?? "").trim().toLowerCase();
+  if (d && isValidHostname(d)) return `https://${d}`;
+  if (d && isValidIpv4Address(d)) {
+    const port = config.port;
+    return `http://${d}:${port}`;
+  }
+  return "";
+}
+
+/** Absolute URL to the dashboard Integrations page (or relative path if origin unknown). */
+export function dashboardIntegrationsAbsoluteUrl(req: FastifyRequest, search: Record<string, string>): string {
+  const base = resolvePublicAppOrigin(req);
+  const q = new URLSearchParams(search).toString();
+  const path = `/dashboard/integrations${q ? `?${q}` : ""}`;
+  if (!base) return path;
+  return `${base}${path}`;
+}


### PR DESCRIPTION
## Summary

Branch **`cursor/github-app-integration`** delivers GitHub App integration, dashboard Settings (public URL / nginx / Certbot), preflight SSL checks, routing fixes, and **GitHub install redirects** that return users to the correct hosted origin.

## Latest: GitHub install redirect (this commit)

- **`PUBLIC_APP_URL`** optional in `.env` — canonical browser origin for HTTP redirects.
- **`resolvePublicAppOrigin` / `dashboardIntegrationsAbsoluteUrl`** — callback redirects use absolute URLs (Host / `X-Forwarded-*` / `PUBLIC_DOMAIN` fallback) so users land on Integrations on the right host after GitHub.
- **Integrations** alert shows the exact **Callback URL** to paste in GitHub App settings (`…/api/auth/github/callback`).
- Install/callback logging for debugging.

## Earlier commits on this branch (vs `main`)

- GitHub App: webhooks, repos API, Integrations UI, repo picker, create-project flow.
- Settings: nginx + Certbot APIs, `PUBLIC_DOMAIN` / path / email, Certbot `publicDomain` body, DNS logging, certbot path util.
- **`/settings`** route; Overview hostname card; **`public-url.ts`** dashboard helper.
- Preflight: certbot, nginx config path, DNS A for `PUBLIC_DOMAIN`, `CERTBOT_EMAIL`, `COOKIE_SECURE`.

## Verify

```bash
bunx tsc --noEmit
cd dashboard && bunx tsc --noEmit && bun run build
```

## Ops

- Register **Callback URL** (and optional **Setup URL**) in the GitHub App to match your deployment, e.g. `https://<host>/api/auth/github/callback`.
- Set **`PUBLIC_APP_URL`** if the API is reached on a different host than the SPA.
