### PR TITLE
GitHub App install relay (versiongate.tech)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,15 +16,17 @@ Built for single-server (KVM/VPS) setups where you want Vercel-style deployments
 
 ## Stack
 
-| Layer | Technology |
-|-------|-----------|
-| Runtime | Bun 1.x + TypeScript |
-| API server | Fastify |
-| Database | PostgreSQL via Prisma (Neon serverless supported) |
-| Containers | Docker CLI |
-| Proxy | Nginx upstream config management |
-| Process manager | PM2 (recommended) |
-| Dashboard | React / Vite (static build, served by Fastify) |
+
+| Layer           | Technology                                        |
+| --------------- | ------------------------------------------------- |
+| Runtime         | Bun 1.x + TypeScript                              |
+| API server      | Fastify                                           |
+| Database        | PostgreSQL via Prisma (Neon serverless supported) |
+| Containers      | Docker CLI                                        |
+| Proxy           | Nginx upstream config management                  |
+| Process manager | PM2 (recommended)                                 |
+| Dashboard       | React / Vite (static build, served by Fastify)    |
+
 
 ---
 
@@ -112,3 +114,4 @@ Self-hosted instances use a **fixed callback** on the public relay: register **C
 
 - [Setup & API](docs/SETUP.md) — detailed setup, environment variables, full API reference
 - [Architecture](docs/ARCHITECTURE.md) — deployment pipeline, blue-green state diagrams, rollback flow, crash recovery
+


### PR DESCRIPTION
## Summary
Routes GitHub App installation through a central OAuth relay at **versiongate.tech** so self-hosted instances use one fixed GitHub **Callback URL**.

## Changes
- **Env:** `PUBLIC_URL`, `GITHUB_STATE_SECRET` (shared with relay `RELAY_SECRET`) — see `.env.example` and `src/config/env.ts`.
- **Install:** `GET /api/auth/github/install` builds HMAC-signed relay `state` and redirects to the GitHub App install URL.
- **Callback:** `GET /api/auth/github/callback` links installation to the **session** user; optional validation when `state` is forwarded.
- **Docs:** README + Integrations page (relay callback + webhook URL hint).

## Server rollout (after merge)
1. **Pull** on the server and **rebuild** dashboard: `cd dashboard && bun run build`.
2. **Edit `.env`:**
   - `PUBLIC_URL=` your public base URL (HTTPS, no trailing slash), e.g. `https://vg.example.com`.
   - `GITHUB_STATE_SECRET=` same value as the relay’s secret on versiongate.tech.
3. **Restart** the API (e.g. `pm2 restart ecosystem.config.cjs` or your process manager).
4. In **GitHub → App settings:** **Callback URL** = `https://versiongate.tech/api/github/callback`; **Webhook URL** = `${PUBLIC_URL}/api/webhooks/github` (must reach your server).
5. **Integrations → Connect GitHub** while signed in to complete linking.

Webhook verification is unchanged: `GITHUB_WEBHOOK_SECRET` for `POST /api/webhooks/github`.

Made with [Cursor](https://cursor.com)