### PR TITLE
fix(dashboard): enable Vite CORS credentials for Safari local API

### DIFF
--- a/dashboard/vite.config.ts
+++ b/dashboard/vite.config.ts
@@ -21,8 +21,17 @@ export default defineConfig({
     emptyOutDir: true,
   },
   server: {
+    // Safari blocks credentialed same-origin /api fetches when Vite's default CORS
+    // reflects Origin without Access-Control-Allow-Credentials.
+    cors: {
+      origin: true,
+      credentials: true,
+    },
     proxy: {
-      "/api": "http://localhost:9090",
+      "/api": {
+        target: "http://localhost:9090",
+        changeOrigin: true,
+      },
     },
   },
 });


### PR DESCRIPTION
## Summary
- Safari was blocking credentialed `/api` fetches from the Vite dashboard when the proxy reflected `Origin` without `Access-Control-Allow-Credentials`.
- Set `server.cors.credentials: true` and use an explicit `/api` proxy target so local auth works in Safari.

## Test plan
- [x] `curl -H 'Origin: http://localhost:5173' http://localhost:5173/api/v1/auth/status` returns `Access-Control-Allow-Credentials: true`
- [ ] Hard-refresh dashboard in Safari and confirm Overview loads without access-control errors

Made with [Cursor](https://cursor.com)