### PR TITLE
feat(github): shared App webhook fan-out via versiongate.tech relay

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,21 +26,23 @@ PROJECTS_ROOT_PATH="/var/versiongate/projects"
 # Personal access token for private repositories (optional)
 GIT_TOKEN=""
 
-# ── GitHub App (VersionGate-App) ───────────────────────────────────────────────
-# Register on GitHub → App → General:
-#   Callback URL (fixed relay): https://versiongate.tech/api/github/callback
-#   Webhook URL (your instance): {PUBLIC_URL}/api/webhooks/github  (same host users use for VersionGate)
+# ── GitHub App (official VersionGate-App — shared) ─────────────────────────────
+# Users do NOT create their own App. Paste the official shared credentials once.
 #
-# From GitHub → App settings: App ID, Client ID, Private key, Webhook secret.
+# Official App settings (ops — versiongate.tech):
+#   Callback URL: https://versiongate.tech/api/github/callback
+#   Webhook URL:  https://versiongate.tech/api/webhooks/github
+#
+# From the official App: App ID, Client ID, Private key, Webhook secret.
 GITHUB_APP_ID="3587447"
 GITHUB_APP_CLIENT_ID="Iv23liAp0wg0PPIDLvZ0"
 # PEM for signing JWTs (single line with \n escapes, or multiline in quoted string)
 GITHUB_APP_PRIVATE_KEY=""
-# Verifies POST /api/webhooks/github (X-Hub-Signature-256)
+# Same webhook secret as the official App (also used by the relay to verify GitHub)
 GITHUB_WEBHOOK_SECRET=""
-# Public base URL of this instance (no trailing slash). Required for GitHub install relay + webhook URL hint.
+# Public base URL of THIS instance (no trailing slash). Required for install + fan-out routing.
 # PUBLIC_URL="https://my-vps.example.com"
-# Shared with versiongate.tech relay (RELAY_SECRET there). Signs install state; must match relay.
+# Shared with versiongate.tech RELAY_SECRET. Signs install state + relay hop signatures.
 # GITHUB_STATE_SECRET=""
 
 # ── Security ───────────────────────────────────────────────────────────────────

--- a/README.md
+++ b/README.md
@@ -103,16 +103,31 @@ No manual `.env` edits or Prisma commands are required after opening `/setup`.
 
 ### GitHub App (Integrations)
 
-Self-hosted instances use a **fixed callback** on the public relay: register **Callback URL** `https://versiongate.tech/api/github/callback` in the GitHub App settings (same for every deployment).
+VersionGate uses **one official GitHub App** (`VersionGate-App`). Self-hosted users only click **Connect GitHub** — they do not create their own App.
 
-- Set **`PUBLIC_URL`** in `.env` to this instance’s public base URL (no trailing slash) and **`GITHUB_STATE_SECRET`** to the same value as the relay’s `RELAY_SECRET` (used to sign the install `state`).
-- Set the app’s **Webhook URL** to `{PUBLIC_URL}/api/webhooks/github` (push events, etc. go to your server). **POST** `/api/webhooks/github` is unchanged and still verified with **`GITHUB_WEBHOOK_SECRET`**.
+**Official App URLs (ops-owned, fixed for everyone):**
 
+| Setting | URL |
+|---------|-----|
+| Callback URL | `https://versiongate.tech/api/github/callback` |
+| Webhook URL | `https://versiongate.tech/api/webhooks/github` |
+
+**On each VPS `.env` (shared App credentials + instance identity):**
+
+- `GITHUB_APP_ID`, `GITHUB_APP_PRIVATE_KEY`, `GITHUB_WEBHOOK_SECRET` — same values as the official App
+- `PUBLIC_URL` — this instance’s public base URL (no trailing slash)
+- `GITHUB_STATE_SECRET` — same value as the website relay’s `RELAY_SECRET`
+
+Flow: Connect → install App → relay stores `installation_id → PUBLIC_URL` → push events hit versiongate.tech → fan-out to `POST {PUBLIC_URL}/api/webhooks/github/relay` → deploy.
+
+Legacy per-project webhooks (`POST /api/v1/webhooks/:secret`) still work without the App.
 ---
 
 ## Docs
 
 - [Setup & API](docs/SETUP.md) — detailed setup, environment variables, full API reference
 - [Architecture](docs/ARCHITECTURE.md) — deployment pipeline, blue-green state diagrams, rollback flow, crash recovery
-- [Website](website/) — marketing site + GitHub App relay (deployed to versiongate.tech)
+- [Website](website/) — marketing site + GitHub App install/webhook relay (versiongate.tech)
+- [GitHub App advanced (Phase 2)](docs/github-app-advanced.md) — future per-instance App Manifest (not shipped yet)
+- [Ops: App webhook URL](docs/github-app-ops-webhook.md) — point official App webhook at versiongate.tech
 

--- a/dashboard/src/pages/Integrations.tsx
+++ b/dashboard/src/pages/Integrations.tsx
@@ -84,10 +84,7 @@ export function Integrations() {
     return g ? g.trim().toLowerCase() : null;
   }, [searchParams]);
 
-  const webhookUrlHint = useMemo(
-    () => (typeof window !== "undefined" ? `${window.location.origin}/api/webhooks/github` : ""),
-    []
-  );
+  const webhookUrlHint = "https://versiongate.tech/api/webhooks/github";
 
   useEffect(() => {
     if (!githubQuery) return;
@@ -123,26 +120,26 @@ export function Integrations() {
         mono
       />
 
-      <Alert className="border-border/80 bg-muted/20">
-        <AlertTitle>GitHub App URLs (self-hosted)</AlertTitle>
+      <Alert className="border-border bg-muted">
+        <AlertTitle className="font-mono text-xs uppercase tracking-wider">Connect only — one official App</AlertTitle>
         <AlertDescription className="space-y-2 text-muted-foreground [&_p]:text-sm">
           <p>
-            The GitHub App <strong className="text-foreground">Callback URL</strong> is fixed for every instance — register this relay on GitHub → App → General:
+            Install the shared <strong className="text-foreground">VersionGate</strong> GitHub App on your account or org.
+            You do <strong className="text-foreground">not</strong> create your own App. Push webhooks go to the public relay,
+            which routes deploys to this instance.
           </p>
-          <code className="block max-w-full overflow-x-auto break-all rounded-md bg-background px-2 py-1.5 font-mono text-xs text-foreground">
+          <p className="font-mono text-[10px] uppercase tracking-wider text-muted-foreground">Webhook (fixed)</p>
+          <code className="block max-w-full overflow-x-auto break-all border border-border bg-background px-2 py-1.5 font-mono text-xs text-foreground">
+            {webhookUrlHint}
+          </code>
+          <p className="font-mono text-[10px] uppercase tracking-wider text-muted-foreground">Install callback (fixed)</p>
+          <code className="block max-w-full overflow-x-auto break-all border border-border bg-background px-2 py-1.5 font-mono text-xs text-foreground">
             {GITHUB_APP_RELAY_CALLBACK}
           </code>
           <p>
-            Set <strong className="text-foreground">Webhook URL</strong> to your instance (same host as{" "}
-            <span className="font-mono text-xs">PUBLIC_URL</span> in <span className="font-mono text-xs">.env</span>), for example:
-          </p>
-          {webhookUrlHint ? (
-            <code className="block max-w-full overflow-x-auto break-all rounded-md bg-background px-2 py-1.5 font-mono text-xs text-foreground">
-              {webhookUrlHint}
-            </code>
-          ) : null}
-          <p>
-            Use <strong className="text-foreground">Connect GitHub</strong> below while signed in so the installation is linked to your account when GitHub sends you back via the relay.
+            This server needs <span className="font-mono text-xs">PUBLIC_URL</span>, shared App credentials, and{" "}
+            <span className="font-mono text-xs">GITHUB_STATE_SECRET</span> matching the relay. Then use{" "}
+            <strong className="text-foreground">Connect GitHub</strong> while signed in.
           </p>
         </AlertDescription>
       </Alert>

--- a/docs/github-app-advanced.md
+++ b/docs/github-app-advanced.md
@@ -1,0 +1,23 @@
+# Advanced: per-instance GitHub App (Phase 2)
+
+> **Status:** Not implemented. Phase 1 uses the **official shared** VersionGate GitHub App with a webhook fan-out relay on [versiongate.tech](https://versiongate.tech).
+
+## Goal
+
+Allow operators who want a fully self-contained VPS (no dependency on versiongate.tech for webhooks) to create their **own** GitHub App from the dashboard.
+
+## Planned approach (Coolify-style)
+
+1. Dashboard → Integrations → **Create my own GitHub App**
+2. App Manifest flow (`POST` to GitHub with prefilled permissions + `{PUBLIC_URL}/api/webhooks/github`)
+3. Exchange temporary `code` → store App ID, PEM, webhook secret encrypted in DB (`ENCRYPTION_KEY`)
+4. Webhooks hit the VPS directly — no fan-out relay
+5. Toggle: “Use official VersionGate App” (default) vs “Use my own App”
+
+## Why Phase 1 first
+
+- One App = simpler UX for new users (Connect only)
+- Shared webhook URL requires a central relay; that is what Phase 1 ships
+- Manifest flow is the right escape hatch for air-gapped / privacy-sensitive installs
+
+See [website/README.md](../website/README.md) for the Phase 1 relay architecture.

--- a/docs/github-app-ops-webhook.md
+++ b/docs/github-app-ops-webhook.md
@@ -1,0 +1,25 @@
+# Ops: flip official GitHub App webhook to the relay
+
+After deploying the website with Redis + `GITHUB_WEBHOOK_SECRET` + `RELAY_SECRET`:
+
+1. Open **VersionGate-App** → General → Webhook
+2. Set **Webhook URL** to:
+   ```
+   https://versiongate.tech/api/webhooks/github
+   ```
+3. Ensure webhook secret matches website `GITHUB_WEBHOOK_SECRET` and each VPS `GITHUB_WEBHOOK_SECRET`
+4. Deliveries → Recent deliveries → confirm `ping` / `push` return 200
+5. E2E: Connect GitHub on a VPS → push to a linked project branch → confirm fan-out in Vercel logs and deploy job on the VPS
+
+Local relay smoke (without GitHub):
+
+```bash
+# After register mapping exists in Redis for installation 12345:
+curl -sS -X POST http://localhost:3000/api/webhooks/github \
+  -H "Content-Type: application/json" \
+  -H "X-GitHub-Event: ping" \
+  -H "X-Hub-Signature-256: sha256=$(...)" \
+  -d '{"zen":"test"}'
+```
+
+Signature must be computed with the real webhook secret over the raw body.

--- a/src/controllers/github-app.controller.ts
+++ b/src/controllers/github-app.controller.ts
@@ -14,6 +14,7 @@ import { createRelayInstallState, parseRelayInstallState } from "../utils/github
 import { getInstallationAccessToken } from "../utils/github-installation-token";
 import { normalizeGithubRepoUrl } from "../utils/github-repo-url";
 import { verifyGithubWebhookSignature } from "../utils/github-webhook-signature";
+import { registerInstallationWithRelay, verifyRelayHopSignature } from "../utils/github-relay";
 import { dashboardIntegrationsAbsoluteUrl } from "../utils/public-app-origin";
 
 const projectRepo = new ProjectRepository();
@@ -163,6 +164,22 @@ export async function githubCallbackHandler(
       githubAccountType: accountType,
     },
   });
+
+  if (config.publicUrl && config.githubStateSecret) {
+    try {
+      await registerInstallationWithRelay({
+        installationId: installationIdStr,
+        userId,
+        instanceUrl: config.publicUrl,
+        relaySecret: config.githubStateSecret,
+      });
+    } catch (err) {
+      logger.warn(
+        { err: err instanceof Error ? err.message : String(err), installationId: installationIdStr },
+        "githubCallback: failed to register installation with versiongate.tech relay"
+      );
+    }
+  }
 
   reply.redirect(302, dashboardIntegrationsAbsoluteUrl(req, { github: "connected" }));
 }
@@ -409,6 +426,55 @@ export async function githubReposHandler(req: FastifyRequest, reply: FastifyRepl
   });
 }
 
+async function handleGithubPushDeploy(
+  payload: GitHubPushPayload,
+  logPrefix: string
+): Promise<{ triggered: boolean; projects: string[]; skipped?: string }> {
+  const ref = payload.ref ?? "";
+  const pushedBranch = ref.replace("refs/heads/", "");
+  const cloneUrl = payload.repository?.clone_url ?? "";
+  const htmlUrl = payload.repository?.html_url ?? "";
+  const normalized = normalizeGithubRepoUrl(cloneUrl || htmlUrl);
+
+  if (!normalized) {
+    return { triggered: false, projects: [], skipped: "Could not determine repository URL" };
+  }
+
+  const projects = await projectRepo.findAll();
+  const matches = projects.filter((p) => normalizeGithubRepoUrl(p.repoUrl) === normalized);
+
+  if (matches.length === 0) {
+    logger.info({ normalized }, `${logPrefix}: no VersionGate project matches repository`);
+    return { triggered: false, projects: [], skipped: "No matching project for repository" };
+  }
+
+  const triggered: string[] = [];
+  for (const project of matches) {
+    const defaultEnv = await envRepo.findDefaultForProject(project.id);
+    if (!defaultEnv) {
+      logger.error({ projectId: project.id }, `${logPrefix}: no default environment — skipping deploy`);
+      continue;
+    }
+    if (pushedBranch && pushedBranch !== defaultEnv.branch) {
+      logger.info(
+        { projectId: project.id, pushedBranch, configuredBranch: defaultEnv.branch },
+        `${logPrefix}: branch mismatch — skipping`
+      );
+      continue;
+    }
+
+    logger.info(
+      { projectId: project.id, projectName: project.name, environmentId: defaultEnv.id, ref },
+      `${logPrefix}: triggering auto-deploy`
+    );
+
+    await enqueueJob("DEPLOY", project.id, {}, defaultEnv.id);
+    triggered.push(project.name);
+  }
+
+  return { triggered: triggered.length > 0, projects: triggered };
+}
+
 export async function githubAppWebhookHandler(req: ReqWithRaw, reply: FastifyReply): Promise<void> {
   const secret = config.githubWebhookSecret;
   if (!secret) {
@@ -453,50 +519,73 @@ export async function githubAppWebhookHandler(req: ReqWithRaw, reply: FastifyRep
     return;
   }
 
-  const payload = body as GitHubPushPayload;
-  const ref = payload.ref ?? "";
-  const pushedBranch = ref.replace("refs/heads/", "");
-  const cloneUrl = payload.repository?.clone_url ?? "";
-  const htmlUrl = payload.repository?.html_url ?? "";
-  const normalized = normalizeGithubRepoUrl(cloneUrl || htmlUrl);
+  const result = await handleGithubPushDeploy(body as GitHubPushPayload, "GitHub App webhook");
+  if (result.skipped && !result.triggered) {
+    reply.code(200).send({ skipped: true, reason: result.skipped });
+    return;
+  }
+  reply.code(200).send({ triggered: result.triggered, projects: result.projects });
+}
 
-  if (!normalized) {
-    reply.code(200).send({ skipped: true, reason: "Could not determine repository URL" });
+/**
+ * Fan-out ingest from versiongate.tech (official App webhook → relay → this instance).
+ * Verified with X-VG-Relay-Signature (GITHUB_STATE_SECRET), not GitHub's signature.
+ */
+export async function githubAppRelayWebhookHandler(req: ReqWithRaw, reply: FastifyReply): Promise<void> {
+  const secret = config.githubStateSecret;
+  if (!secret) {
+    reply.code(503).send({
+      error: "ServiceUnavailable",
+      message: "GITHUB_STATE_SECRET is not configured (required for relay fan-out).",
+    });
     return;
   }
 
-  const projects = await projectRepo.findAll();
-  const matches = projects.filter((p) => normalizeGithubRepoUrl(p.repoUrl) === normalized);
-
-  if (matches.length === 0) {
-    logger.info({ normalized }, "GitHub App webhook: no VersionGate project matches repository");
-    reply.code(200).send({ skipped: true, reason: "No matching project for repository" });
+  const rawBody = req.rawBody;
+  if (!rawBody?.length) {
+    reply.code(400).send({ error: "BadRequest", message: "Missing raw body for signature verification" });
     return;
   }
 
-  const triggered: string[] = [];
-  for (const project of matches) {
-    const defaultEnv = await envRepo.findDefaultForProject(project.id);
-    if (!defaultEnv) {
-      logger.error({ projectId: project.id }, "GitHub App webhook: no default environment — skipping deploy");
-      continue;
-    }
-    if (pushedBranch && pushedBranch !== defaultEnv.branch) {
-      logger.info(
-        { projectId: project.id, pushedBranch, configuredBranch: defaultEnv.branch },
-        "GitHub App webhook: branch mismatch — skipping"
-      );
-      continue;
-    }
-
-    logger.info(
-      { projectId: project.id, projectName: project.name, environmentId: defaultEnv.id, ref },
-      "GitHub App webhook: triggering auto-deploy"
-    );
-
-    await enqueueJob("DEPLOY", project.id, {}, defaultEnv.id);
-    triggered.push(project.name);
+  const installationHeader = req.headers["x-vg-installation-id"];
+  const installationId = (Array.isArray(installationHeader) ? installationHeader[0] : installationHeader) ?? "";
+  if (!installationId || !/^\d+$/.test(installationId)) {
+    reply.code(400).send({ error: "BadRequest", message: "Missing X-VG-Installation-Id" });
+    return;
   }
 
-  reply.code(200).send({ triggered: triggered.length > 0, projects: triggered });
+  const hop = req.headers["x-vg-relay-signature"];
+  const hopStr = Array.isArray(hop) ? hop[0] : hop;
+  if (!verifyRelayHopSignature(rawBody, installationId, hopStr, secret)) {
+    reply.code(401).send({ error: "Unauthorized", message: "Invalid relay signature" });
+    return;
+  }
+
+  let body: unknown;
+  try {
+    body = JSON.parse(rawBody.toString("utf8"));
+  } catch {
+    reply.code(400).send({ error: "BadRequest", message: "Invalid JSON body" });
+    return;
+  }
+
+  const event = req.headers["x-github-event"];
+  const eventStr = (Array.isArray(event) ? event[0] : event)?.toLowerCase() ?? "";
+
+  if (eventStr === "ping") {
+    reply.code(200).send({ ok: true, ping: true });
+    return;
+  }
+
+  if (eventStr !== "push") {
+    reply.code(200).send({ skipped: true, reason: `Ignoring event: ${eventStr || "unknown"}` });
+    return;
+  }
+
+  const result = await handleGithubPushDeploy(body as GitHubPushPayload, "GitHub relay webhook");
+  if (result.skipped && !result.triggered) {
+    reply.code(200).send({ skipped: true, reason: result.skipped, installationId });
+    return;
+  }
+  reply.code(200).send({ triggered: result.triggered, projects: result.projects, installationId });
 }

--- a/src/routes/github-app.routes.ts
+++ b/src/routes/github-app.routes.ts
@@ -1,6 +1,7 @@
 import type { FastifyInstance } from "fastify";
 import { requireDatabaseConfigured } from "../middleware/require-database";
 import {
+  githubAppRelayWebhookHandler,
   githubAppWebhookHandler,
   githubCallbackHandler,
   githubInstallationRecordHandler,
@@ -19,4 +20,5 @@ export async function githubAppRoutes(app: FastifyInstance): Promise<void> {
   app.get("/github/repos/:owner/:repo/branches", githubRepoBranchesHandler);
   app.get("/github/repos", githubReposHandler);
   app.post("/webhooks/github", githubAppWebhookHandler);
+  app.post("/webhooks/github/relay", githubAppRelayWebhookHandler);
 }

--- a/src/utils/github-relay.ts
+++ b/src/utils/github-relay.ts
@@ -1,0 +1,82 @@
+import { createHmac, timingSafeEqual } from "crypto";
+
+/**
+ * Hop signature from versiongate.tech fan-out.
+ * HMAC-SHA256 of `${installationId}.` + rawBody, header `X-VG-Relay-Signature: sha256=<hex>`.
+ * Secret must match website RELAY_SECRET / engine GITHUB_STATE_SECRET.
+ */
+export function verifyRelayHopSignature(
+  rawBody: Buffer,
+  installationId: string,
+  signatureHeader: string | undefined,
+  secret: string
+): boolean {
+  if (!signatureHeader?.startsWith("sha256=")) return false;
+  const expectedHex = createHmac("sha256", secret)
+    .update(`${installationId}.`, "utf8")
+    .update(rawBody)
+    .digest("hex");
+  const expected = `sha256=${expectedHex}`;
+  try {
+    const a = Buffer.from(signatureHeader, "utf8");
+    const b = Buffer.from(expected, "utf8");
+    if (a.length !== b.length) return false;
+    return timingSafeEqual(a, b);
+  } catch {
+    return false;
+  }
+}
+
+export interface RegisterPayload {
+  instanceUrl: string;
+  installationId: string;
+  userId?: string;
+  ts: number;
+}
+
+function canonicalRegisterJson(p: RegisterPayload): string {
+  return JSON.stringify({
+    instanceUrl: p.instanceUrl,
+    installationId: p.installationId,
+    userId: p.userId ?? "",
+    ts: p.ts,
+  });
+}
+
+export function signRegisterPayload(p: RegisterPayload, secret: string): string {
+  const body = canonicalRegisterJson(p);
+  const sig = createHmac("sha256", secret).update(body, "utf8").digest("hex");
+  return Buffer.from(JSON.stringify({ p, sig }), "utf8").toString("base64url");
+}
+
+const DEFAULT_RELAY_ORIGIN = "https://versiongate.tech";
+
+/** Notify the central relay of installation → this instance mapping. */
+export async function registerInstallationWithRelay(opts: {
+  installationId: string;
+  userId: string;
+  instanceUrl: string;
+  relaySecret: string;
+  relayOrigin?: string;
+}): Promise<void> {
+  const token = signRegisterPayload(
+    {
+      instanceUrl: opts.instanceUrl.trim().replace(/\/+$/, ""),
+      installationId: opts.installationId,
+      userId: opts.userId,
+      ts: Date.now(),
+    },
+    opts.relaySecret
+  );
+  const origin = (opts.relayOrigin ?? DEFAULT_RELAY_ORIGIN).replace(/\/+$/, "");
+  const res = await fetch(`${origin}/api/github/register`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ token }),
+    signal: AbortSignal.timeout(10_000),
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(`Relay register failed (${res.status}): ${text.slice(0, 200)}`);
+  }
+}

--- a/website/.env.example
+++ b/website/.env.example
@@ -1,3 +1,10 @@
-# Shared secret for HMAC verification of the `state` query param on GET /api/github/callback.
-# Must match the VersionGate server value of GITHUB_STATE_SECRET (same string in both places).
+# Shared secret for HMAC verification of the `state` query param on GET /api/github/callback
+# and hop signatures on webhook fan-out. Must match each VersionGate instance's GITHUB_STATE_SECRET.
 RELAY_SECRET=
+
+# Same webhook secret as the official VersionGate GitHub App (verifies X-Hub-Signature-256).
+GITHUB_WEBHOOK_SECRET=
+
+# Upstash Redis (Vercel Marketplace) — installation_id → instanceUrl registry
+UPSTASH_REDIS_REST_URL=
+UPSTASH_REDIS_REST_TOKEN=

--- a/website/README.md
+++ b/website/README.md
@@ -1,6 +1,6 @@
 # VersionGate marketing site
 
-Public landing page and GitHub App install relay for [versiongate.tech](https://versiongate.tech).
+Public landing page and GitHub App **install + webhook fan-out relay** for [versiongate.tech](https://versiongate.tech).
 
 Lives in the same repo as the deployment engine so marketing copy stays in sync with dashboard features.
 
@@ -8,9 +8,13 @@ Lives in the same repo as the deployment engine so marketing copy stays in sync 
 
 | Path | Purpose |
 |------|---------|
-| `src/app/page.tsx` | Landing page (features, install steps, dashboard preview) |
-| `src/app/api/github/callback/route.ts` | GitHub App OAuth relay → self-hosted instances |
-| `src/lib/github-install-state.ts` | State parser (must match engine `src/utils/github-install-state.ts`) |
+| `src/app/page.tsx` | Landing page |
+| `src/app/api/github/callback/route.ts` | Install callback → persist mapping → redirect to VPS |
+| `src/app/api/github/register/route.ts` | Signed backup registration from VPS after install |
+| `src/app/api/webhooks/github/route.ts` | Official App webhook → fan-out to `POST {instance}/api/webhooks/github/relay` |
+| `src/lib/install-registry.ts` | Upstash Redis: `installation_id → instanceUrl` |
+| `src/lib/github-install-state.ts` | Install `state` parser (must match engine) |
+| `src/lib/relay-crypto.ts` | GitHub sig verify + hop signatures + register tokens |
 
 ## Development
 
@@ -26,20 +30,40 @@ Open [http://localhost:3000](http://localhost:3000).
 
 Deploy the `website/` directory as the project root on Vercel.
 
-Environment variable:
+Add an **Upstash Redis** store from the Vercel Marketplace and set:
 
 | Variable | Description |
 |----------|-------------|
-| `RELAY_SECRET` | Same value as `GITHUB_STATE_SECRET` on self-hosted engine instances |
+| `RELAY_SECRET` | Same value as `GITHUB_STATE_SECRET` on every self-hosted engine |
+| `GITHUB_WEBHOOK_SECRET` | Same webhook secret as the official VersionGate GitHub App |
+| `UPSTASH_REDIS_REST_URL` | From Upstash / Vercel Redis integration |
+| `UPSTASH_REDIS_REST_TOKEN` | From Upstash / Vercel Redis integration |
 
-## GitHub App relay
+## Official GitHub App (ops checklist)
 
-Self-hosted instances use a **fixed** GitHub App callback URL:
+On [github.com/apps/VersionGate-App](https://github.com/apps/VersionGate-App) → settings:
+
+1. **Callback URL:** `https://versiongate.tech/api/github/callback`
+2. **Webhook URL:** `https://versiongate.tech/api/webhooks/github` (not per-VPS)
+3. Subscribe to: `push`, `installation`, `installation_repositories`, `ping`
+4. Permissions: Contents (read), Metadata (read) — plus any already required for repo listing
+
+### E2E smoke test
+
+1. Set `PUBLIC_URL` + shared App env + `GITHUB_STATE_SECRET` on a VPS
+2. Dashboard → Integrations → Connect GitHub → install on a test repo
+3. Confirm Redis key `vg:install:{id}` exists
+4. Push to the project branch → relay logs fan-out → VPS enqueues deploy
+
+## GitHub App relay flow
 
 ```
-https://versiongate.tech/api/github/callback
+Install:  GitHub → /api/github/callback → Redis SET → redirect to VPS
+Push:     GitHub → /api/webhooks/github → lookup → POST VPS /api/webhooks/github/relay
 ```
 
-Flow: user installs app → GitHub redirects here → relay verifies signed `state` → redirects to `{PUBLIC_URL}/api/auth/github/callback` on the user's instance.
+## Phase 2 (not implemented yet)
+
+Advanced users may later create a **per-instance** GitHub App via the App Manifest flow (Coolify-style), with webhook URL `{PUBLIC_URL}/api/webhooks/github` and no dependency on this relay. Tracked as a follow-up; Phase 1 is shared App only.
 
 The engine repo is at [github.com/dinexh/VersionGate](https://github.com/dinexh/VersionGate).

--- a/website/bun.lock
+++ b/website/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "my-app",
       "dependencies": {
-        "lucide-react": "^1.25.0",
+        "@upstash/redis": "^1.38.0",
         "next": "16.1.6",
         "react": "19.2.3",
         "react-dom": "19.2.3",
@@ -288,6 +288,8 @@
     "@unrs/resolver-binding-win32-ia32-msvc": ["@unrs/resolver-binding-win32-ia32-msvc@1.11.1", "", { "os": "win32", "cpu": "ia32" }, "sha512-DCEI6t5i1NmAZp6pFonpD5m7i6aFrpofcp4LA2i8IIq60Jyo28hamKBxNrZcyOwVOZkgsRp9O2sXWBWP8MnvIQ=="],
 
     "@unrs/resolver-binding-win32-x64-msvc": ["@unrs/resolver-binding-win32-x64-msvc@1.11.1", "", { "os": "win32", "cpu": "x64" }, "sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g=="],
+
+    "@upstash/redis": ["@upstash/redis@1.38.0", "", { "dependencies": { "uncrypto": "^0.1.3" } }, "sha512-wu+dZBptlLy0+MCUEoHmzrY/TnmgDey3+c7EbIGwrLqAvkP8yi5MWZHYGIFtAygmL4Bkz2TdFu+eU0vFPncIcg=="],
 
     "acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
 
@@ -637,8 +639,6 @@
 
     "lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
 
-    "lucide-react": ["lucide-react@1.25.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-/mdJTRbiwcLOQ1NZZK1amZF9rIZyvO18D6r9TngE6TG1NmqHgFuT4eE7Xrkm9UsXMbBJD1NlfwHVltCDWHrOTw=="],
-
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
@@ -820,6 +820,8 @@
     "typescript-eslint": ["typescript-eslint@8.56.1", "", { "dependencies": { "@typescript-eslint/eslint-plugin": "8.56.1", "@typescript-eslint/parser": "8.56.1", "@typescript-eslint/typescript-estree": "8.56.1", "@typescript-eslint/utils": "8.56.1" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-U4lM6pjmBX7J5wk4szltF7I1cGBHXZopnAXCMXb3+fZ3B/0Z3hq3wS/CCUB2NZBNAExK92mCU2tEohWuwVMsDQ=="],
 
     "unbox-primitive": ["unbox-primitive@1.1.0", "", { "dependencies": { "call-bound": "^1.0.3", "has-bigints": "^1.0.2", "has-symbols": "^1.1.0", "which-boxed-primitive": "^1.1.1" } }, "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw=="],
+
+    "uncrypto": ["uncrypto@0.1.3", "", {}, "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q=="],
 
     "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 

--- a/website/package.json
+++ b/website/package.json
@@ -9,6 +9,7 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "@upstash/redis": "^1.38.0",
     "next": "16.1.6",
     "react": "19.2.3",
     "react-dom": "19.2.3"

--- a/website/src/app/api/github/callback/route.ts
+++ b/website/src/app/api/github/callback/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { parseRelayInstallState } from "@/lib/github-install-state";
+import { isValidInstanceUrl, setInstallMapping } from "@/lib/install-registry";
 
 function badRequest(message: string) {
   const body = `<!DOCTYPE html><html lang="en"><head><meta charset="utf-8"/><title>GitHub relay error</title></head><body><p>${escapeHtml(message)}</p></body></html>`;
@@ -17,22 +18,11 @@ function escapeHtml(s: string) {
     .replace(/"/g, "&quot;");
 }
 
-function isValidInstanceUrl(instanceUrl: string): boolean {
-  const t = instanceUrl.trim();
-  if (!t) return false;
-  try {
-    const u = new URL(t);
-    if (u.protocol !== "http:" && u.protocol !== "https:") return false;
-    if (!u.hostname) return false;
-    return true;
-  } catch {
-    return false;
-  }
-}
-
 /**
  * GitHub App install relay for self-hosted VersionGate instances.
  * GitHub App callback URL (fixed): https://versiongate.tech/api/github/callback
+ *
+ * Persists installation_id → instanceUrl in Redis so push webhooks can fan out.
  */
 export async function GET(request: NextRequest) {
   const secret = process.env.RELAY_SECRET;
@@ -58,6 +48,18 @@ export async function GET(request: NextRequest) {
 
   if (!isValidInstanceUrl(decoded.instanceUrl)) {
     return badRequest("Invalid instance URL in state.");
+  }
+
+  if (installationId && /^\d+$/.test(installationId)) {
+    try {
+      await setInstallMapping(installationId, {
+        instanceUrl: decoded.instanceUrl,
+        userId: decoded.userId,
+      });
+    } catch (err) {
+      console.error("[github/callback] failed to persist install mapping", err);
+      // Still redirect — engine register API is a backup
+    }
   }
 
   const target = new URL("/api/auth/github/callback", decoded.instanceUrl.trim().replace(/\/+$/, ""));

--- a/website/src/app/api/github/register/route.ts
+++ b/website/src/app/api/github/register/route.ts
@@ -1,0 +1,52 @@
+import { NextRequest, NextResponse } from "next/server";
+import { isValidInstanceUrl, setInstallMapping } from "@/lib/install-registry";
+import { parseRegisterPayload } from "@/lib/relay-crypto";
+
+/**
+ * Backup registration from a VersionGate instance after GitHub App install.
+ * Body: { token: base64url signed RegisterPayload }
+ * Auth: RELAY_SECRET HMAC inside token.
+ */
+export async function POST(request: NextRequest) {
+  const secret = process.env.RELAY_SECRET;
+  if (!secret) {
+    return NextResponse.json({ error: "RELAY_SECRET is not configured" }, { status: 500 });
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  const token =
+    body && typeof body === "object" && "token" in body && typeof (body as { token: unknown }).token === "string"
+      ? (body as { token: string }).token
+      : null;
+
+  if (!token) {
+    return NextResponse.json({ error: "Missing token" }, { status: 400 });
+  }
+
+  const parsed = parseRegisterPayload(token, secret);
+  if (!parsed) {
+    return NextResponse.json({ error: "Invalid or expired token" }, { status: 401 });
+  }
+
+  if (!isValidInstanceUrl(parsed.instanceUrl)) {
+    return NextResponse.json({ error: "Invalid instanceUrl" }, { status: 400 });
+  }
+
+  try {
+    await setInstallMapping(parsed.installationId, {
+      instanceUrl: parsed.instanceUrl,
+      userId: parsed.userId,
+    });
+  } catch (err) {
+    console.error("[github/register] redis error", err);
+    return NextResponse.json({ error: "Registry unavailable" }, { status: 503 });
+  }
+
+  return NextResponse.json({ ok: true, installationId: parsed.installationId });
+}

--- a/website/src/app/api/webhooks/github/route.ts
+++ b/website/src/app/api/webhooks/github/route.ts
@@ -1,0 +1,162 @@
+import { NextRequest, NextResponse } from "next/server";
+import { deleteInstallMapping, getInstallMapping, setInstallMapping } from "@/lib/install-registry";
+import { createRelayHopSignature, verifyGithubWebhookSignature } from "@/lib/relay-crypto";
+
+const RELAY_FORWARD_ATTEMPTS = 3;
+const RELAY_BACKOFF_MS = [200, 800, 2000];
+
+async function sleep(ms: number) {
+  await new Promise((r) => setTimeout(r, ms));
+}
+
+async function forwardToInstance(
+  instanceUrl: string,
+  installationId: string,
+  rawBody: Buffer,
+  githubEvent: string,
+  relaySecret: string
+): Promise<{ ok: boolean; status?: number; error?: string }> {
+  const target = new URL("/api/webhooks/github/relay", instanceUrl.replace(/\/+$/, ""));
+  const hop = createRelayHopSignature(rawBody, installationId, relaySecret);
+
+  for (let i = 0; i < RELAY_FORWARD_ATTEMPTS; i++) {
+    try {
+      const res = await fetch(target.toString(), {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-GitHub-Event": githubEvent,
+          "X-VG-Installation-Id": installationId,
+          "X-VG-Relay-Signature": hop,
+        },
+        body: new Uint8Array(rawBody),
+        signal: AbortSignal.timeout(15_000),
+      });
+      if (res.ok) return { ok: true, status: res.status };
+      if (res.status >= 500 && i < RELAY_FORWARD_ATTEMPTS - 1) {
+        await sleep(RELAY_BACKOFF_MS[i] ?? 1000);
+        continue;
+      }
+      return { ok: false, status: res.status, error: await res.text().catch(() => "") };
+    } catch (err) {
+      if (i < RELAY_FORWARD_ATTEMPTS - 1) {
+        await sleep(RELAY_BACKOFF_MS[i] ?? 1000);
+        continue;
+      }
+      return { ok: false, error: err instanceof Error ? err.message : String(err) };
+    }
+  }
+  return { ok: false, error: "exhausted retries" };
+}
+
+/**
+ * Official VersionGate GitHub App webhook URL:
+ *   https://versiongate.tech/api/webhooks/github
+ *
+ * Verifies GitHub signature, looks up installation → instance, fans out to VPS.
+ */
+export async function POST(request: NextRequest) {
+  const webhookSecret = process.env.GITHUB_WEBHOOK_SECRET;
+  const relaySecret = process.env.RELAY_SECRET;
+
+  if (!webhookSecret || !relaySecret) {
+    return NextResponse.json(
+      { error: "GITHUB_WEBHOOK_SECRET and RELAY_SECRET must be configured" },
+      { status: 500 }
+    );
+  }
+
+  const rawBody = Buffer.from(await request.arrayBuffer());
+  const sig = request.headers.get("x-hub-signature-256") ?? undefined;
+
+  if (!verifyGithubWebhookSignature(rawBody, sig, webhookSecret)) {
+    return NextResponse.json({ error: "Invalid signature" }, { status: 401 });
+  }
+
+  const event = (request.headers.get("x-github-event") ?? "").toLowerCase();
+
+  let payload: Record<string, unknown>;
+  try {
+    payload = JSON.parse(rawBody.toString("utf8")) as Record<string, unknown>;
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  if (event === "ping") {
+    return NextResponse.json({ ok: true, ping: true });
+  }
+
+  const installation = payload.installation as { id?: number } | undefined;
+  const installationId = installation?.id != null ? String(installation.id) : null;
+
+  if (event === "installation") {
+    const action = typeof payload.action === "string" ? payload.action : "";
+    if (action === "deleted" && installationId) {
+      await deleteInstallMapping(installationId);
+      return NextResponse.json({ ok: true, deleted: installationId });
+    }
+    // created / suspend / unsuspend — mapping should already exist from callback/register
+    if (installationId) {
+      const existing = await getInstallMapping(installationId);
+      if (!existing) {
+        console.warn("[webhooks/github] installation event without registry mapping", {
+          installationId,
+          action,
+        });
+      }
+    }
+    return NextResponse.json({ ok: true, event: "installation", action });
+  }
+
+  if (!installationId) {
+    // No installation context — acknowledge to avoid GitHub retries
+    console.warn("[webhooks/github] missing installation.id", { event });
+    return NextResponse.json({ ok: true, skipped: true, reason: "no_installation" });
+  }
+
+  const mapping = await getInstallMapping(installationId);
+  if (!mapping?.instanceUrl) {
+    console.warn("[webhooks/github] no instance mapping", { installationId, event });
+    return NextResponse.json({ ok: true, skipped: true, reason: "unmapped_installation" });
+  }
+
+  // Refresh TTL/touch by re-setting (keeps registry warm)
+  try {
+    await setInstallMapping(installationId, {
+      instanceUrl: mapping.instanceUrl,
+      userId: mapping.userId,
+    });
+  } catch {
+    /* ignore */
+  }
+
+  if (event !== "push") {
+    return NextResponse.json({ ok: true, skipped: true, reason: `Ignoring event: ${event || "unknown"}` });
+  }
+
+  const result = await forwardToInstance(
+    mapping.instanceUrl,
+    installationId,
+    rawBody,
+    event,
+    relaySecret
+  );
+
+  if (!result.ok) {
+    console.error("[webhooks/github] fan-out failed", {
+      installationId,
+      instanceUrl: mapping.instanceUrl,
+      status: result.status,
+      error: result.error,
+    });
+    // Return 200 so GitHub does not retry forever for a down VPS;
+    // operators can redeploy manually. Transient failures may still retry from GitHub if we return 5xx —
+    // prefer 502 when instance is unreachable so GitHub retries briefly.
+    if (result.status && result.status >= 400 && result.status < 500) {
+      return NextResponse.json({ ok: false, forwarded: false, status: result.status }, { status: 200 });
+    }
+    return NextResponse.json({ ok: false, forwarded: false, error: result.error }, { status: 502 });
+  }
+
+  return NextResponse.json({ ok: true, forwarded: true, instanceUrl: mapping.instanceUrl });
+}

--- a/website/src/app/docs/api-reference/page.tsx
+++ b/website/src/app/docs/api-reference/page.tsx
@@ -41,14 +41,19 @@ export default function ApiReference() {
       <Table
         head={["Method", "Path", "Description"]}
         rows={[
-          ["GET", "/api/auth/github/install", "Start GitHub App install (redirects to GitHub)"],
+          ["GET", "/api/auth/github/install", "Start official App install (redirects to GitHub)"],
           ["GET", "/api/auth/github/callback", "Install callback (via versiongate.tech relay)"],
           ["GET", "/api/github/repos", "List repositories for the installation"],
           ["GET", "/api/github/repos/:owner/:repo/branches", "List branches"],
-          ["POST", "/api/webhooks/github", "Signed push webhook (auto-deploy)"],
+          ["POST", "/api/webhooks/github", "Direct GitHub signature webhook (dev / advanced)"],
+          ["POST", "/api/webhooks/github/relay", "Fan-out from versiongate.tech (hop-signed)"],
         ]}
       />
-
+      <P>
+        Public relay routes on versiongate.tech:{" "}
+        <InlineCode>GET /api/github/callback</InlineCode>, <InlineCode>POST /api/github/register</InlineCode>,{" "}
+        <InlineCode>POST /api/webhooks/github</InlineCode>.
+      </P>
       <H2>System</H2>
       <Table
         head={["Method", "Path", "Description"]}

--- a/website/src/app/docs/networking/page.tsx
+++ b/website/src/app/docs/networking/page.tsx
@@ -43,9 +43,14 @@ export default function Networking() {
 
       <H2>Webhook endpoints</H2>
       <P>
-        GitHub App webhooks arrive at <InlineCode>{`{PUBLIC_URL}`}/api/webhooks/github</InlineCode>{" "}
-        and are verified with <InlineCode>GITHUB_WEBHOOK_SECRET</InlineCode>. Legacy per-project
-        webhooks (<InlineCode>/api/v1/webhooks/:secret</InlineCode>) continue to work.
+        The official VersionGate GitHub App sends webhooks to{" "}
+        <InlineCode>https://versiongate.tech/api/webhooks/github</InlineCode>. The public relay
+        looks up your installation and forwards the event to{" "}
+        <InlineCode>{`{PUBLIC_URL}`}/api/webhooks/github/relay</InlineCode> on your VPS (verified with{" "}
+        <InlineCode>GITHUB_STATE_SECRET</InlineCode>). Direct{" "}
+        <InlineCode>{`{PUBLIC_URL}`}/api/webhooks/github</InlineCode> remains available for local
+        testing. Legacy per-project webhooks (<InlineCode>/api/v1/webhooks/:secret</InlineCode>) continue
+        to work without the App.
       </P>
 
       <Callout title="Behind PM2 with a minimal PATH?">

--- a/website/src/app/docs/quick-start/page.tsx
+++ b/website/src/app/docs/quick-start/page.tsx
@@ -46,14 +46,19 @@ pm2 save   # persist across reboots`}</Code>
 
       <H2>5. Connect GitHub &amp; deploy</H2>
       <P>
-        In the dashboard, open <InlineCode>Integrations → Connect GitHub</InlineCode> to install the
-        GitHub App. Then create a project, pick a repository and branch, and push — every commit to
-        the configured branch triggers a zero-downtime deploy.
+        Paste the official shared GitHub App credentials into <InlineCode>.env</InlineCode> once (
+        <InlineCode>GITHUB_APP_ID</InlineCode>, <InlineCode>GITHUB_APP_PRIVATE_KEY</InlineCode>,{" "}
+        <InlineCode>GITHUB_WEBHOOK_SECRET</InlineCode>, <InlineCode>PUBLIC_URL</InlineCode>,{" "}
+        <InlineCode>GITHUB_STATE_SECRET</InlineCode>), restart the engine, then open{" "}
+        <InlineCode>Integrations → Connect GitHub</InlineCode>. You install the official VersionGate
+        App — you do not create your own App. Create a project, pick a repository and branch, and
+        push to auto-deploy.
       </P>
 
-      <Callout title="No manual .env editing required">
-        After the setup wizard finishes, everything else — projects, environments, secrets, HTTPS —
-        is managed from the dashboard.
+      <Callout title="Shared App credentials">
+        After the setup wizard finishes, add the official App env vars (same for every self-hosted
+        instance) and <InlineCode>PUBLIC_URL</InlineCode>. Projects, environments, secrets, and HTTPS
+        are then managed from the dashboard.
       </Callout>
 
       <NextLinks

--- a/website/src/lib/install-registry.ts
+++ b/website/src/lib/install-registry.ts
@@ -1,0 +1,89 @@
+import { createHash } from "node:crypto";
+import { Redis } from "@upstash/redis";
+
+export interface InstallMapping {
+  instanceUrl: string;
+  userId?: string;
+  registeredAt: string;
+}
+
+function normalizeInstanceUrl(url: string): string {
+  return url.trim().replace(/\/+$/, "");
+}
+
+function instanceKeyHash(instanceUrl: string): string {
+  return createHash("sha256").update(normalizeInstanceUrl(instanceUrl), "utf8").digest("hex").slice(0, 32);
+}
+
+export function getRedis(): Redis | null {
+  const url = process.env.UPSTASH_REDIS_REST_URL ?? process.env.KV_REST_API_URL;
+  const token = process.env.UPSTASH_REDIS_REST_TOKEN ?? process.env.KV_REST_API_TOKEN;
+  if (!url || !token) return null;
+  return new Redis({ url, token });
+}
+
+function installKey(installationId: string | number): string {
+  return `vg:install:${installationId}`;
+}
+
+function instanceIndexKey(instanceUrl: string): string {
+  return `vg:instance:${instanceKeyHash(instanceUrl)}:installs`;
+}
+
+export async function setInstallMapping(
+  installationId: string | number,
+  mapping: { instanceUrl: string; userId?: string }
+): Promise<void> {
+  const redis = getRedis();
+  if (!redis) {
+    throw new Error("Redis is not configured (UPSTASH_REDIS_REST_URL / UPSTASH_REDIS_REST_TOKEN).");
+  }
+  const instanceUrl = normalizeInstanceUrl(mapping.instanceUrl);
+  const payload: InstallMapping = {
+    instanceUrl,
+    userId: mapping.userId,
+    registeredAt: new Date().toISOString(),
+  };
+  const id = String(installationId);
+  await redis.set(installKey(id), payload);
+  await redis.sadd(instanceIndexKey(instanceUrl), id);
+}
+
+export async function getInstallMapping(installationId: string | number): Promise<InstallMapping | null> {
+  const redis = getRedis();
+  if (!redis) return null;
+  const raw = await redis.get<InstallMapping | string>(installKey(String(installationId)));
+  if (!raw) return null;
+  if (typeof raw === "string") {
+    try {
+      return JSON.parse(raw) as InstallMapping;
+    } catch {
+      return null;
+    }
+  }
+  return raw;
+}
+
+export async function deleteInstallMapping(installationId: string | number): Promise<void> {
+  const redis = getRedis();
+  if (!redis) return;
+  const id = String(installationId);
+  const existing = await getInstallMapping(id);
+  await redis.del(installKey(id));
+  if (existing?.instanceUrl) {
+    await redis.srem(instanceIndexKey(existing.instanceUrl), id);
+  }
+}
+
+export function isValidInstanceUrl(instanceUrl: string): boolean {
+  const t = instanceUrl.trim();
+  if (!t) return false;
+  try {
+    const u = new URL(t);
+    if (u.protocol !== "http:" && u.protocol !== "https:") return false;
+    if (!u.hostname) return false;
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/website/src/lib/relay-crypto.ts
+++ b/website/src/lib/relay-crypto.ts
@@ -1,0 +1,93 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
+
+/**
+ * Verifies GitHub `X-Hub-Signature-256` (HMAC SHA256 of raw body).
+ */
+export function verifyGithubWebhookSignature(
+  rawBody: Buffer,
+  signatureHeader: string | undefined,
+  secret: string
+): boolean {
+  if (!signatureHeader?.startsWith("sha256=")) return false;
+  const receivedHex = signatureHeader.slice("sha256=".length);
+  const expectedHex = createHmac("sha256", secret).update(rawBody).digest("hex");
+  try {
+    const a = Buffer.from(receivedHex, "hex");
+    const b = Buffer.from(expectedHex, "hex");
+    if (a.length !== b.length) return false;
+    return timingSafeEqual(a, b);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Hop signature for fan-out: HMAC-SHA256 hex of `${installationId}.${rawBody}`.
+ * Header: `X-VG-Relay-Signature: sha256=<hex>`
+ */
+export function createRelayHopSignature(rawBody: Buffer, installationId: string, secret: string): string {
+  const hex = createHmac("sha256", secret).update(`${installationId}.`, "utf8").update(rawBody).digest("hex");
+  return `sha256=${hex}`;
+}
+
+export function verifyRelayHopSignature(
+  rawBody: Buffer,
+  installationId: string,
+  signatureHeader: string | undefined,
+  secret: string
+): boolean {
+  if (!signatureHeader?.startsWith("sha256=")) return false;
+  const expected = createRelayHopSignature(rawBody, installationId, secret);
+  try {
+    const a = Buffer.from(signatureHeader, "utf8");
+    const b = Buffer.from(expected, "utf8");
+    if (a.length !== b.length) return false;
+    return timingSafeEqual(a, b);
+  } catch {
+    return false;
+  }
+}
+
+/** Signed register body for POST /api/github/register */
+export interface RegisterPayload {
+  instanceUrl: string;
+  installationId: string;
+  userId?: string;
+  ts: number;
+}
+
+function canonicalRegisterJson(p: RegisterPayload): string {
+  return JSON.stringify({
+    instanceUrl: p.instanceUrl,
+    installationId: p.installationId,
+    userId: p.userId ?? "",
+    ts: p.ts,
+  });
+}
+
+export function signRegisterPayload(p: RegisterPayload, secret: string): string {
+  const body = canonicalRegisterJson(p);
+  const sig = createHmac("sha256", secret).update(body, "utf8").digest("hex");
+  return Buffer.from(JSON.stringify({ p, sig }), "utf8").toString("base64url");
+}
+
+const REGISTER_MAX_AGE_MS = 5 * 60 * 1000;
+
+export function parseRegisterPayload(token: string, secret: string): RegisterPayload | null {
+  if (!token || !secret) return null;
+  try {
+    const raw = Buffer.from(token, "base64url").toString("utf8");
+    const o = JSON.parse(raw) as { p?: RegisterPayload; sig?: string };
+    if (!o.p || typeof o.sig !== "string") return null;
+    const body = canonicalRegisterJson(o.p);
+    const expected = createHmac("sha256", secret).update(body, "utf8").digest("hex");
+    const a = Buffer.from(o.sig, "hex");
+    const b = Buffer.from(expected, "hex");
+    if (a.length !== b.length || !timingSafeEqual(a, b)) return null;
+    if (Date.now() - o.p.ts > REGISTER_MAX_AGE_MS) return null;
+    if (!/^\d+$/.test(o.p.installationId)) return null;
+    return o.p;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- One official VersionGate GitHub App: users only **Connect GitHub** (no per-user App creation).
- versiongate.tech stores `installation_id → PUBLIC_URL` in Upstash Redis and fans out push webhooks to `POST {PUBLIC_URL}/api/webhooks/github/relay`.
- Engine registers installs with the relay and verifies hop signatures with `GITHUB_STATE_SECRET`.

## Test plan
- [ ] Deploy website with `RELAY_SECRET`, `GITHUB_WEBHOOK_SECRET`, `UPSTASH_REDIS_REST_URL`, `UPSTASH_REDIS_REST_TOKEN`
- [ ] Point official App webhook URL at `https://versiongate.tech/api/webhooks/github`
- [ ] On a VPS: set shared App env + `PUBLIC_URL` + `GITHUB_STATE_SECRET` → Integrations → Connect GitHub
- [ ] Confirm Redis key `vg:install:{id}` exists after install
- [ ] Push to a linked project branch → deploy job enqueued on VPS
- [ ] Unmapped installation / down VPS does not cause endless GitHub retry storms

## Ops
See `docs/github-app-ops-webhook.md` and the PR comment / chat for full App creation steps.


Made with [Cursor](https://cursor.com)