### PR TITLE
feat(scripts): bootstrap-host + website install docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,13 @@ If Docker is installed but PM2 provides a minimal `PATH`, set `DOCKER_BIN=/usr/b
 ```bash
 git clone https://github.com/dinexh/VersionGate
 cd VersionGate
+# Fresh Ubuntu/Debian VM — installs Docker, network, /var/versiongate/projects, nginx, …
+sudo bash scripts/bootstrap-host.sh
+newgrp docker
+npm run check-deps
 bun install
 cd dashboard && bun install && bun run build && cd ..
+bun run preflight
 ```
 
 ### 2. Start the engine

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -9,6 +9,29 @@
 - PM2 — `npm i -g pm2`
 - Git
 
+### Check host deps (before install)
+
+After cloning, **before** `bun install`:
+
+```bash
+# On a fresh Ubuntu/Debian VM — install Docker, network, dirs, nginx, etc.:
+sudo bash scripts/bootstrap-host.sh
+# or: sudo npm run bootstrap-host
+# options: --minimal | --with-postgres | --skip-docker
+
+# Then verify (no sudo):
+newgrp docker          # or log out/in so docker group applies
+npm run check-deps
+```
+
+`check-deps` verifies git, curl, bun, and Docker. Recommended tools (nginx, pm2, certbot, psql) warn but do not fail.
+
+After packages are installed, run the full check:
+
+```bash
+bun run preflight
+```
+
 ---
 
 ## Setup
@@ -18,6 +41,8 @@
 ```bash
 git clone https://github.com/dinexh/VersionGate
 cd VersionGate
+npm run check-deps    # fix anything marked [NO] first — or run bootstrap below
+# Fresh VM (Ubuntu/Debian): sudo bash scripts/bootstrap-host.sh && newgrp docker
 bun install
 ```
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
     "prisma:studio": "prisma studio",
     "lint": "eslint src --ext .ts",
     "typecheck": "tsc --noEmit",
+    "check-deps": "bash scripts/check-host-deps.sh",
+    "bootstrap-host": "bash scripts/bootstrap-host.sh",
     "preflight": "bun run scripts/preflight.ts",
     "self-update": "bun run scripts/self-update.ts",
     "create-admin": "bun scripts/create-admin.ts"

--- a/scripts/bootstrap-host.sh
+++ b/scripts/bootstrap-host.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+# Bootstrap a Linux host for VersionGate (Ubuntu/Debian).
+#
+# Installs / configures:
+#   - git, curl, ca-certificates
+#   - Bun (if missing)
+#   - Docker Engine + compose plugin
+#   - docker network versiongate-net
+#   - /var/versiongate/projects (writable by current user)
+#   - nginx, certbot (+ nginx plugin), pm2 (recommended)
+#
+# Usage (from repo root, on the VM):
+#   sudo bash scripts/bootstrap-host.sh
+#   npm run bootstrap-host
+#   bun run bootstrap-host
+#
+# Options:
+#   --minimal     Skip nginx / certbot / pm2
+#   --with-postgres  Also apt-install postgresql (local DB)
+#   --skip-docker    Do not install Docker (if already present via snap/etc.)
+#
+set -euo pipefail
+
+MINIMAL=0
+WITH_POSTGRES=0
+SKIP_DOCKER=0
+DOCKER_NETWORK="${DOCKER_NETWORK:-versiongate-net}"
+PROJECTS_ROOT="${PROJECTS_ROOT_PATH:-/var/versiongate/projects}"
+
+for arg in "$@"; do
+  case "$arg" in
+    --minimal) MINIMAL=1 ;;
+    --with-postgres) WITH_POSTGRES=1 ;;
+    --skip-docker) SKIP_DOCKER=1 ;;
+    -h|--help)
+      sed -n '2,24p' "$0"
+      exit 0
+      ;;
+  esac
+done
+
+log()  { printf '\n==> %s\n' "$*"; }
+ok()   { printf '  [ok] %s\n' "$*"; }
+warn() { printf '  [!]  %s\n' "$*"; }
+die()  { printf '  [NO] %s\n' "$*" >&2; exit 1; }
+
+# Resolve the user who should own projects dir / docker group
+REAL_USER="${SUDO_USER:-${USER:-}}"
+if [[ -z "$REAL_USER" || "$REAL_USER" == "root" ]]; then
+  REAL_USER="$(logname 2>/dev/null || echo root)"
+fi
+REAL_HOME="$(getent passwd "$REAL_USER" 2>/dev/null | cut -d: -f6 || echo /root)"
+
+if [[ "$(id -u)" -ne 0 ]]; then
+  if command -v sudo >/dev/null 2>&1; then
+    exec sudo -E bash "$0" "$@"
+  fi
+  die "Run with sudo: sudo bash scripts/bootstrap-host.sh"
+fi
+
+if [[ ! -f /etc/os-release ]]; then
+  die "Unsupported OS (need /etc/os-release)"
+fi
+# shellcheck source=/dev/null
+. /etc/os-release
+case "${ID:-}" in
+  ubuntu|debian) ok "OS: $PRETTY_NAME" ;;
+  *)
+    warn "Untested OS: $PRETTY_NAME — continuing with apt-style packages"
+    ;;
+esac
+
+export DEBIAN_FRONTEND=noninteractive
+
+log "Base packages (git, curl, ca-certificates, gnupg)"
+apt-get update -y
+apt-get install -y --no-install-recommends \
+  ca-certificates curl git gnupg lsb-release apt-transport-https
+
+# ── Bun ───────────────────────────────────────────────────────────────────────
+log "Bun runtime"
+if command -v bun >/dev/null 2>&1; then
+  ok "bun already installed: $(bun --version)"
+elif [[ -x "$REAL_HOME/.bun/bin/bun" ]]; then
+  ok "bun found at $REAL_HOME/.bun/bin/bun"
+else
+  log "Installing Bun for user $REAL_USER"
+  sudo -u "$REAL_USER" -H bash -lc 'curl -fsSL https://bun.sh/install | bash'
+  ok "Bun installed — ensure PATH includes ~/.bun/bin (re-login or source ~/.bashrc)"
+fi
+
+# ── Docker ────────────────────────────────────────────────────────────────────
+if [[ "$SKIP_DOCKER" -eq 1 ]]; then
+  warn "Skipping Docker install (--skip-docker)"
+else
+  log "Docker Engine"
+  if command -v docker >/dev/null 2>&1 && docker info >/dev/null 2>&1; then
+    ok "Docker already working: $(docker version --format '{{.Server.Version}}' 2>/dev/null || echo ok)"
+  else
+    log "Installing Docker via get.docker.com"
+    curl -fsSL https://get.docker.com | sh
+    systemctl enable --now docker
+    ok "Docker installed and started"
+  fi
+
+  if id "$REAL_USER" >/dev/null 2>&1; then
+    usermod -aG docker "$REAL_USER"
+    ok "Added $REAL_USER to docker group (log out/in or: newgrp docker)"
+  fi
+fi
+
+# ── Docker network ────────────────────────────────────────────────────────────
+log "Docker network: $DOCKER_NETWORK"
+if docker network inspect "$DOCKER_NETWORK" >/dev/null 2>&1; then
+  ok "Network $DOCKER_NETWORK already exists"
+else
+  docker network create "$DOCKER_NETWORK"
+  ok "Created network $DOCKER_NETWORK"
+fi
+
+# ── Projects directory ────────────────────────────────────────────────────────
+log "Projects directory: $PROJECTS_ROOT"
+mkdir -p "$PROJECTS_ROOT"
+chown -R "$REAL_USER:$REAL_USER" "$(dirname "$PROJECTS_ROOT")" 2>/dev/null || chown -R "$REAL_USER:$REAL_USER" "$PROJECTS_ROOT"
+chmod 755 "$PROJECTS_ROOT"
+ok "Writable by $REAL_USER: $PROJECTS_ROOT"
+
+# ── Recommended stack ─────────────────────────────────────────────────────────
+if [[ "$MINIMAL" -eq 0 ]]; then
+  log "Recommended: nginx + certbot"
+  apt-get install -y --no-install-recommends nginx certbot python3-certbot-nginx || warn "nginx/certbot install had issues"
+
+  if command -v nginx >/dev/null 2>&1; then
+    systemctl enable --now nginx || true
+    ok "nginx: $(nginx -v 2>&1)"
+  fi
+
+  log "Recommended: PM2 (global via npm)"
+  if command -v npm >/dev/null 2>&1; then
+    npm install -g pm2
+    ok "pm2: $(pm2 --version 2>/dev/null || echo installed)"
+  elif command -v bun >/dev/null 2>&1; then
+    # PM2 prefers npm; try installing nodejs for npm
+    apt-get install -y --no-install-recommends nodejs npm || warn "Could not install nodejs/npm for PM2"
+    if command -v npm >/dev/null 2>&1; then
+      npm install -g pm2
+      ok "pm2 installed"
+    else
+      warn "PM2 skipped — install Node/npm later: sudo apt install -y nodejs npm && sudo npm i -g pm2"
+    fi
+  else
+    warn "PM2 skipped — no npm yet"
+  fi
+else
+  warn "Minimal mode — skipped nginx / certbot / pm2"
+fi
+
+if [[ "$WITH_POSTGRES" -eq 1 ]]; then
+  log "PostgreSQL (local)"
+  apt-get install -y postgresql postgresql-contrib
+  systemctl enable --now postgresql
+  ok "PostgreSQL installed — create DB/user for VersionGate (see docs/SETUP.md)"
+fi
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+echo ""
+echo "============================================"
+echo " Bootstrap complete"
+echo "============================================"
+echo ""
+echo "Next (as $REAL_USER):"
+echo "  1. Apply docker group:  newgrp docker   # or log out/in"
+echo "  2. cd ~/VersionGate   # (or your clone path)"
+echo "  3. npm run check-deps"
+echo "  4. bun install && cd dashboard && bun install && bun run build && cd .."
+echo "  5. bun run preflight"
+echo "  6. bun --watch src/server.ts   # or: pm2 start ecosystem.config.cjs"
+echo "  7. Open http://<this-vm>:9090/setup"
+echo ""
+echo "GitHub App later needs PUBLIC_URL=https://your-domain (HTTPS reachable)."
+echo ""
+
+# Non-fatal: print docker status for current shell (may fail until newgrp)
+if docker info >/dev/null 2>&1; then
+  ok "docker info OK in this root shell"
+else
+  warn "docker info failed here — after logout, verify: docker info"
+fi

--- a/scripts/check-host-deps.sh
+++ b/scripts/check-host-deps.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# Host dependency check — run BEFORE `bun install`.
+# Usage (from repo root):
+#   ./scripts/check-host-deps.sh
+#   bun run check-deps
+#   npm run check-deps
+#
+# Exit 0 if all *required* tools are present; 1 otherwise.
+# Recommended tools print warnings but do not fail the script.
+
+set -u
+
+REQUIRED_FAIL=0
+WARN=0
+
+ok()   { printf '[ok]  %s\n' "$*"; }
+fail() { printf '[NO]  %s\n' "$*"; REQUIRED_FAIL=1; }
+warn() { printf '[!]   %s\n' "$*"; WARN=1; }
+info() { printf '[--]  %s\n' "$*"; }
+
+need_cmd() {
+  local name="$1" install_hint="$2"
+  if command -v "$name" >/dev/null 2>&1; then
+    local ver
+    ver="$("$name" --version 2>&1 | head -n1 | tr -d '\r')"
+    ok "$name — $ver"
+  else
+    fail "$name — missing. $install_hint"
+  fi
+}
+
+want_cmd() {
+  local name="$1" install_hint="$2"
+  if command -v "$name" >/dev/null 2>&1; then
+    local ver
+    ver="$("$name" --version 2>&1 | head -n1 | tr -d '\r')"
+    ok "$name — $ver"
+  else
+    warn "$name — not found (recommended). $install_hint"
+  fi
+}
+
+echo "VersionGate host deps check (before install)"
+echo "============================================"
+echo ""
+
+# ── Required ─────────────────────────────────────────────────────────────────
+echo "Required"
+need_cmd git "Install: sudo apt install -y git"
+need_cmd curl "Install: sudo apt install -y curl"
+
+if command -v bun >/dev/null 2>&1; then
+  ok "bun — $(bun --version 2>&1 | head -n1)"
+else
+  fail "bun — missing. Install: curl -fsSL https://bun.sh/install | bash"
+fi
+
+DOCKER_BIN="${DOCKER_BIN:-docker}"
+if command -v "$DOCKER_BIN" >/dev/null 2>&1; then
+  ok "docker CLI — $($DOCKER_BIN version --format '{{.Client.Version}}' 2>/dev/null || $DOCKER_BIN --version 2>&1 | head -n1)"
+  if $DOCKER_BIN info >/dev/null 2>&1; then
+    ok "docker daemon — reachable"
+  else
+    fail "docker daemon — not reachable (start dockerd; add user to docker group: sudo usermod -aG docker \$USER)"
+  fi
+else
+  fail "docker — missing. Install: curl -fsSL https://get.docker.com | sudo sh"
+fi
+
+echo ""
+echo "Recommended"
+want_cmd node "Optional if you only use Bun"
+want_cmd npm "Optional; Bun can install packages"
+want_cmd nginx "Install: sudo apt install -y nginx (traffic switching)"
+want_cmd pm2 "Install: npm i -g pm2 (or use systemd)"
+want_cmd psql "Install: sudo apt install -y postgresql-client (or use remote DATABASE_URL)"
+want_cmd certbot "Install: sudo apt install -y certbot python3-certbot-nginx"
+
+echo ""
+echo "After this passes, install VersionGate:"
+echo "  bun install"
+echo "  cd dashboard && bun install && bun run build && cd .."
+echo "  docker network create versiongate-net"
+echo "  bun run preflight    # full host + network + paths check"
+echo ""
+
+if [[ "$REQUIRED_FAIL" -ne 0 ]]; then
+  echo "Result: FAILED — fix required tools above, then re-run."
+  echo ""
+  echo "On Ubuntu/Debian VM, install everything in one shot:"
+  echo "  sudo bash scripts/bootstrap-host.sh"
+  echo "  newgrp docker"
+  echo "  npm run check-deps"
+  exit 1
+fi
+
+if [[ "$WARN" -ne 0 ]]; then
+  echo "Result: OK (with recommended warnings)"
+else
+  echo "Result: OK"
+fi
+exit 0

--- a/website/src/app/docs/quick-start/page.tsx
+++ b/website/src/app/docs/quick-start/page.tsx
@@ -6,37 +6,52 @@ export default function QuickStart() {
       <Breadcrumb page="Quick Start" />
       <PageTitle>Quick Start</PageTitle>
       <Lead>
-        Get VersionGate running on a fresh VPS in under five minutes. You need Bun, Docker,
-        PostgreSQL (local or Neon), Nginx, and Git on the host.
+        Get VersionGate running on a fresh Ubuntu/Debian VPS. The bootstrap script installs Docker,
+        creates the deploy network, and sets up nginx — then you build, preflight, and open the setup
+        wizard.
       </Lead>
 
-      <H2>1. Clone and install</H2>
+      <H2>1. Clone the repo</H2>
       <Code title="terminal">{`git clone https://github.com/dinexh/VersionGate
-cd VersionGate
-bun install
+cd VersionGate`}</Code>
 
-# Build the dashboard (served by the engine)
-cd dashboard && bun install && bun run build && cd ..`}</Code>
-
-      <H2>2. Verify the host</H2>
+      <H2>2. Bootstrap the host (Ubuntu/Debian)</H2>
       <P>
-        The preflight check validates Docker, Git, the deployment network, writable project paths,
-        and optional Nginx/PM2/SSL readiness before you deploy anything.
+        On a clean VM this installs Docker, adds your user to the <InlineCode>docker</InlineCode>{" "}
+        group, creates <InlineCode>versiongate-net</InlineCode>, creates{" "}
+        <InlineCode>/var/versiongate/projects</InlineCode>, and installs nginx / certbot / PM2.
       </P>
-      <Code title="terminal">{`# Create the deployment network once
-docker network create versiongate-net
+      <Code title="terminal">{`sudo bash scripts/bootstrap-host.sh
+# or: sudo npm run bootstrap-host
+# options: --minimal | --with-postgres | --skip-docker
 
+newgrp docker          # apply docker group (or log out/in)
+npm run check-deps     # should pass required checks`}</Code>
+      <Callout title="Already have Docker?">
+        You can skip bootstrap and only run <InlineCode>npm run check-deps</InlineCode>, then fix
+        anything marked <InlineCode>[NO]</InlineCode>. Full host validation after install is{" "}
+        <InlineCode>bun run preflight</InlineCode>.
+      </Callout>
+
+      <H2>3. Install packages &amp; build the dashboard</H2>
+      <Code title="terminal">{`bun install
+cd dashboard && bun install && bun run build && cd ..
 bun run preflight`}</Code>
-
-      <H2>3. Start the engine</H2>
-      <Code title="terminal">{`npm i -g pm2
-pm2 start ecosystem.config.cjs
-pm2 save   # persist across reboots`}</Code>
       <P>
-        For development you can run <InlineCode>bun --watch src/server.ts</InlineCode> instead.
+        Preflight validates Bun, Docker, the deploy network, writable project paths, and optional
+        Nginx/PM2/SSL readiness. Fix any <InlineCode>[NO]</InlineCode> required items before
+        continuing.
       </P>
 
-      <H2>4. Complete the setup wizard</H2>
+      <H2>4. Start the engine</H2>
+      <Code title="terminal">{`# Production
+pm2 start ecosystem.config.cjs
+pm2 save
+
+# Development
+bun --watch src/server.ts`}</Code>
+
+      <H2>5. Complete the setup wizard</H2>
       <P>
         Open <InlineCode>http://your-server-ip:9090/setup</InlineCode> and enter your PostgreSQL
         connection string, domain (or server IP), and an optional Gemini API key. The wizard writes{" "}
@@ -44,7 +59,7 @@ pm2 save   # persist across reboots`}</Code>
         configures Nginx when permissions allow.
       </P>
 
-      <H2>5. Connect GitHub &amp; deploy</H2>
+      <H2>6. Connect GitHub &amp; deploy</H2>
       <P>
         Paste the official shared GitHub App credentials into <InlineCode>.env</InlineCode> once (
         <InlineCode>GITHUB_APP_ID</InlineCode>, <InlineCode>GITHUB_APP_PRIVATE_KEY</InlineCode>,{" "}
@@ -57,8 +72,8 @@ pm2 save   # persist across reboots`}</Code>
 
       <Callout title="Shared App credentials">
         After the setup wizard finishes, add the official App env vars (same for every self-hosted
-        instance) and <InlineCode>PUBLIC_URL</InlineCode>. Projects, environments, secrets, and HTTPS
-        are then managed from the dashboard.
+        instance) and a public <InlineCode>PUBLIC_URL</InlineCode> (HTTPS). Projects, environments,
+        secrets, and HTTPS are then managed from the dashboard.
       </Callout>
 
       <NextLinks

--- a/website/src/app/page.tsx
+++ b/website/src/app/page.tsx
@@ -69,23 +69,23 @@ const PIPELINE_STEPS = [
 const GET_STARTED_STEPS = [
   {
     step: "01",
-    title: "Clone & install",
-    code: "git clone https://github.com/dinexh/VersionGate\ncd VersionGate && bun install\ncd dashboard && bun run build && cd ..",
+    title: "Clone",
+    code: "git clone https://github.com/dinexh/VersionGate\ncd VersionGate",
   },
   {
     step: "02",
-    title: "Verify the host",
-    code: "docker network create versiongate-net\nbun run preflight",
+    title: "Bootstrap host (Ubuntu/Debian)",
+    code: "sudo bash scripts/bootstrap-host.sh\nnewgrp docker\nnpm run check-deps",
   },
   {
     step: "03",
-    title: "Start the engine",
-    code: "pm2 start ecosystem.config.cjs\npm2 save",
+    title: "Install & verify",
+    code: "bun install\ncd dashboard && bun run build && cd ..\nbun run preflight",
   },
   {
     step: "04",
-    title: "Run setup wizard",
-    code: "Open http://your-server:9090/setup\n→ PostgreSQL URL, domain, admin account",
+    title: "Start & setup wizard",
+    code: "pm2 start ecosystem.config.cjs\nOpen http://your-server:9090/setup",
   },
   {
     step: "05",
@@ -326,8 +326,11 @@ export default function Home() {
             <p className="mb-3 font-mono text-[10px] uppercase tracking-wider text-muted-foreground">Get Started</p>
             <h2 className="text-2xl font-bold uppercase tracking-tight">Running in Under 5 Minutes</h2>
             <p className="mt-4 text-sm leading-relaxed text-muted-foreground">
-              You need Bun, Docker, PostgreSQL, Nginx, and Git on a Linux VPS. The setup wizard handles database
-              migrations, encryption keys, and Nginx configuration — no manual <code className="border border-border bg-muted px-1 font-mono text-xs">.env</code> editing required.
+              On a fresh Ubuntu/Debian VPS, bootstrap installs Docker and host deps, then you build
+              and open the setup wizard. You need a public HTTPS URL for GitHub push deploys. The
+              wizard handles the database and admin account — no hand-edited{" "}
+              <code className="border border-border bg-muted px-1 font-mono text-xs">.env</code> for
+              core setup (GitHub App credentials are pasted once after).
             </p>
           </div>
 


### PR DESCRIPTION
## Summary
- Adds `scripts/bootstrap-host.sh` (and `npm run bootstrap-host` / `check-deps`) to install Docker, create `versiongate-net` and `/var/versiongate/projects`, and optionally nginx/certbot/pm2 on Ubuntu/Debian.
- Updates README, SETUP.md, website Quick Start, and landing Get Started to match the new VM flow.

## Test plan
- [ ] On a clean Ubuntu VM: `sudo bash scripts/bootstrap-host.sh` → `newgrp docker` → `npm run check-deps` → `bun install` → `bun run preflight`
- [ ] `cd website && bun run build`
- [ ] Skim `/docs/quick-start` and `/#get-started` for correct commands


Made with [Cursor](https://cursor.com)