### PR TITLE
fix(ops): harden VM bootstrap and setup SPA diagnostics

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -4,10 +4,10 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "vite",
-    "build": "tsc -b && vite build",
+    "dev": "bun --bun vite",
+    "build": "tsc -b && bun --bun vite build",
     "lint": "eslint .",
-    "preview": "vite preview",
+    "preview": "bun --bun vite preview",
     "preflight": "bun ../scripts/preflight.ts"
   },
   "dependencies": {

--- a/scripts/bootstrap-host.sh
+++ b/scripts/bootstrap-host.sh
@@ -135,21 +135,13 @@ if [[ "$MINIMAL" -eq 0 ]]; then
     ok "nginx: $(nginx -v 2>&1)"
   fi
 
-  log "Recommended: PM2 (global via npm)"
+  log "Recommended: Node.js + npm + PM2"
+  apt-get install -y --no-install-recommends nodejs npm || warn "nodejs/npm apt install had issues"
   if command -v npm >/dev/null 2>&1; then
     npm install -g pm2
     ok "pm2: $(pm2 --version 2>/dev/null || echo installed)"
-  elif command -v bun >/dev/null 2>&1; then
-    # PM2 prefers npm; try installing nodejs for npm
-    apt-get install -y --no-install-recommends nodejs npm || warn "Could not install nodejs/npm for PM2"
-    if command -v npm >/dev/null 2>&1; then
-      npm install -g pm2
-      ok "pm2 installed"
-    else
-      warn "PM2 skipped — install Node/npm later: sudo apt install -y nodejs npm && sudo npm i -g pm2"
-    fi
   else
-    warn "PM2 skipped — no npm yet"
+    warn "PM2 skipped — install later: sudo apt install -y nodejs npm && sudo npm i -g pm2"
   fi
 else
   warn "Minimal mode — skipped nginx / certbot / pm2"

--- a/src/app.ts
+++ b/src/app.ts
@@ -180,13 +180,17 @@ export async function buildApp(): Promise<FastifyInstance> {
   }
 
   // ── SPA fallback (Vite + React Router) ─────────────────────────────────────
+  // Allow GET and HEAD so `curl -I /setup` works the same as a browser GET.
   app.setNotFoundHandler(async (req, reply) => {
-    if (req.method !== "GET" || req.url.startsWith("/api/")) {
+    if ((req.method !== "GET" && req.method !== "HEAD") || req.url.startsWith("/api/")) {
       return reply.code(404).send({ error: "Not Found", message: `${req.method} ${req.url} not found` });
     }
 
     const indexPath = join(dashboardOutDir, "index.html");
     if (existsSync(indexPath)) {
+      if (req.method === "HEAD") {
+        return reply.type("text/html").code(200).send();
+      }
       return reply.type("text/html").sendFile("index.html");
     }
 


### PR DESCRIPTION
## Summary
- Always install Node.js/npm during host bootstrap so `pm2` is available on Bun-only VMs
- Force Vite scripts through Bun (`bun --bun`) so dashboard builds work when apt Node is too old for Vite
- Allow HEAD on the SPA fallback so `curl -I /setup` returns 200 like a browser GET

## Test plan
- [ ] On a fresh Ubuntu VM: `sudo bash scripts/bootstrap-host.sh` installs npm + pm2
- [ ] `cd dashboard && bun run build` succeeds without requiring Node 20+
- [ ] With API running and dashboard built: `curl -sI http://127.0.0.1:9090/setup` returns 200
- [ ] `curl -s http://127.0.0.1:9090/api/v1/setup/status` still returns setup JSON


Made with [Cursor](https://cursor.com)