### PR TITLE
fix(ui): prefer production live URLs and cut noisy copy

### DIFF
--- a/dashboard/src/components/BlueGreenTrafficCard.tsx
+++ b/dashboard/src/components/BlueGreenTrafficCard.tsx
@@ -69,18 +69,16 @@ export function BlueGreenTrafficCard({
   const latestBlue = latestDeploymentForColor(deployments, "BLUE");
   const latestGreen = latestDeploymentForColor(deployments, "GREEN");
 
-  const nginxNote =
-    "Nginx upstream points at the live slot’s host port. Direct links below hit each slot even when idle.";
+  const nginxNote = "Open the live URL after promote — development can stay running on its own ports.";
 
   return (
     <Card className="border-border bg-card">
       <CardHeader className="space-y-3">
         <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
           <div>
-            <CardTitle>Blue / green slots</CardTitle>
-            <CardDescription className="mt-1 max-w-2xl">
-              Two fixed host ports per project. A deploy builds into the <span className="font-medium text-foreground">idle</span> slot;
-              after the health check passes, traffic switches and the old container is stopped.
+            <CardTitle>Blue / green</CardTitle>
+            <CardDescription className="mt-1">
+              Production slots. Live traffic uses the active port below.
             </CardDescription>
           </div>
         </div>

--- a/dashboard/src/components/EnvironmentChain.tsx
+++ b/dashboard/src/components/EnvironmentChain.tsx
@@ -1,13 +1,14 @@
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { toast } from "sonner";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { StatusBadge } from "@/components/StatusBadge";
 import {
   promoteEnvironment,
   type EnvironmentSummary,
 } from "@/lib/api";
+import { publicServiceUrl } from "@/lib/deployment-display";
 
 function ChainArrow() {
   return (
@@ -67,8 +68,7 @@ export function EnvironmentChain({
   return (
     <div className="space-y-3">
       <p className="text-xs text-muted-foreground">
-        <strong className="text-foreground/80">Promote</strong> reuses the upstream Docker image (no rebuild).{" "}
-        <span className="font-mono text-[0.7rem] opacity-80">POST /projects/…/environments/:id/promote</span>
+        Deploy builds once on the first stage. Promote copies that image forward (no rebuild).
       </p>
       <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-stretch">
         {sorted.map((env, index) => {
@@ -77,6 +77,10 @@ export function EnvironmentChain({
           const active = env.activeDeployment;
           const showPromote = index > 0;
           const promoteDisabled = !upstreamActive || promotingId !== null;
+          const openUrl =
+            active?.status === "ACTIVE" || active?.status === "DEPLOYING"
+              ? publicServiceUrl(active.port)
+              : null;
 
           return (
             <div key={env.id} className="flex flex-1 min-w-[200px] flex-col gap-3 sm:flex-row sm:items-stretch">
@@ -87,20 +91,25 @@ export function EnvironmentChain({
                     <CardTitle className="font-mono text-xs uppercase tracking-wider">{env.name}</CardTitle>
                     {active ? <StatusBadge status={active.status} /> : <StatusBadge status="PENDING" />}
                   </div>
-                  <CardDescription className="font-mono text-xs">
-                    Branch {env.branch} · host ports {env.basePort}–{env.basePort + 1}
-                  </CardDescription>
                 </CardHeader>
-                <CardContent className="space-y-3 pt-0">
+                <CardContent className="space-y-3 pt-3">
                   {active ? (
                     <div className="space-y-1 text-xs text-muted-foreground">
                       <p>
-                        <span className="text-foreground/80">Version</span>{" "}
-                        <span className="font-mono tabular-nums">v{active.version}</span>
+                        <span className="text-foreground/80">v{active.version}</span>
+                        <span className="mx-1.5 text-border">·</span>
+                        <span className="font-mono">:{active.port}</span>
                       </p>
-                      <p className="truncate font-mono" title={active.imageTag}>
-                        {active.imageTag}
-                      </p>
+                      {openUrl ? (
+                        <a
+                          href={openUrl}
+                          target="_blank"
+                          rel="noreferrer"
+                          className="block truncate font-mono text-primary underline-offset-2 hover:underline"
+                        >
+                          Open {env.name}
+                        </a>
+                      ) : null}
                     </div>
                   ) : (
                     <p className="text-xs text-muted-foreground">No deployment yet.</p>
@@ -113,7 +122,7 @@ export function EnvironmentChain({
                         variant="secondary"
                         onClick={() => void onDeployToEnvironment(env.id)}
                       >
-                        Deploy to {env.name}
+                        Deploy
                       </Button>
                     ) : null}
                     {showPromote ? (
@@ -123,8 +132,8 @@ export function EnvironmentChain({
                         onClick={() => upstream && void onPromote(env.id, upstream.id)}
                         title={
                           !upstreamActive
-                            ? `Wait until ${upstream?.name ?? "upstream"} has an ACTIVE deployment`
-                            : undefined
+                            ? `Need an ACTIVE deploy on ${upstream?.name ?? "upstream"} first`
+                            : `Promote ${upstream?.name} → ${env.name}`
                         }
                       >
                         {promotingId === env.id ? (
@@ -133,7 +142,7 @@ export function EnvironmentChain({
                             Promoting…
                           </>
                         ) : (
-                          "Promote"
+                          `→ ${env.name}`
                         )}
                       </Button>
                     ) : null}

--- a/dashboard/src/components/Layout.tsx
+++ b/dashboard/src/components/Layout.tsx
@@ -29,7 +29,8 @@ import { Separator } from "@/components/ui/separator";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { Toaster } from "@/components/ui/sonner";
 import { useEffect, useState } from "react";
-import { authLogout, getAuthStatus, getProjects, getServerStats, getSetupStatus, type Project } from "@/lib/api";
+import { authLogout, getAuthStatus, getInstanceSettings, getProjects, getServerStats, getSetupStatus, type Project } from "@/lib/api";
+import { setConfiguredPublicHost } from "@/lib/deployment-display";
 import { cn } from "@/lib/utils";
 import { GlobalSearchDialog } from "@/components/GlobalSearchDialog";
 import { CreateProjectModal } from "@/components/CreateProjectModal";
@@ -72,6 +73,20 @@ export function Layout() {
   const [searchOpen, setSearchOpen] = useState(false);
   const [projects, setProjects] = useState<Project[]>([]);
   const [headerUserEmail, setHeaderUserEmail] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    void getInstanceSettings()
+      .then((s) => {
+        if (!cancelled) setConfiguredPublicHost(s.publicDomain);
+      })
+      .catch(() => {
+        /* settings may be unavailable before auth */
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   useEffect(() => {
     let cancelled = false;

--- a/dashboard/src/lib/deployment-display.ts
+++ b/dashboard/src/lib/deployment-display.ts
@@ -2,6 +2,24 @@ import type { Deployment, Project } from "@/lib/api";
 
 export type DeploymentColor = "BLUE" | "GREEN";
 
+/** Hostname from Settings / setup (`PUBLIC_DOMAIN`), used for Open / Live links. */
+let configuredPublicHost: string | null = null;
+
+export function isLoopbackHostname(host: string): boolean {
+  const h = host.trim().toLowerCase();
+  return h === "localhost" || h === "127.0.0.1" || h === "::1" || h === "0.0.0.0";
+}
+
+/** Call when instance settings load so app links use the public IP/domain, not an SSH-tunnel host. */
+export function setConfiguredPublicHost(host: string | null | undefined): void {
+  const h = (host ?? "").trim();
+  configuredPublicHost = h && !isLoopbackHostname(h) ? h : null;
+}
+
+export function getConfiguredPublicHost(): string | null {
+  return configuredPublicHost;
+}
+
 export function isDeploymentColor(c: string): c is DeploymentColor {
   return c === "BLUE" || c === "GREEN";
 }
@@ -35,29 +53,64 @@ export function slotLabel(color: string): string {
   return color;
 }
 
+/**
+ * Prefer PUBLIC_DOMAIN (non-loopback), then an explicit hostname, then the browser host
+ * when it is not loopback (so SSH tunnels at 127.0.0.1 do not poison Open links).
+ */
+export function resolvePublicHostname(hostname?: string): string {
+  const explicit = hostname?.trim();
+  if (explicit && !isLoopbackHostname(explicit)) return explicit;
+  if (configuredPublicHost) return configuredPublicHost;
+  const fromWindow = typeof window !== "undefined" ? window.location.hostname : "";
+  if (fromWindow && !isLoopbackHostname(fromWindow)) return fromWindow;
+  if (explicit) return explicit;
+  return fromWindow || "localhost";
+}
+
 export function publicServiceUrl(port: number, hostname?: string): string {
-  const host = hostname ?? (typeof window !== "undefined" ? window.location.hostname : "localhost");
-  const proto = typeof window !== "undefined" && window.location.protocol === "https:" ? "https" : "http";
+  const host = resolvePublicHostname(hostname);
+  const windowProto =
+    typeof window !== "undefined" && window.location.protocol === "https:" ? "https" : "http";
+  // IPv4 public hosts are almost always plain HTTP on the published Docker port.
+  const proto = /^\d{1,3}(\.\d{1,3}){3}$/.test(host) ? "http" : windowProto;
   if (port === 80 && proto === "http") return `${proto}://${host}`;
   if (port === 443 && proto === "https") return `${proto}://${host}`;
   return `${proto}://${host}:${port}`;
+}
+
+/** production = project.basePort; staging +200; development +400 (see project.repository). */
+export function guessEnvironmentLabel(project: Project, deployment: Deployment): string {
+  const p = deployment.port;
+  const base = project.basePort;
+  if (p === base || p === base + 1) return "production";
+  if (p === base + 200 || p === base + 201) return "staging";
+  if (p === base + 400 || p === base + 401) return "development";
+  return "—";
+}
+
+/** Prefer production when several envs are ACTIVE (lowest published port). */
+function preferProductionSlot(rows: Deployment[]): Deployment | undefined {
+  if (rows.length === 0) return undefined;
+  return rows.reduce((a, b) => (a.port <= b.port ? a : b));
 }
 
 export function getDeployingDeployment(
   projectId: string,
   deployments: Deployment[]
 ): Deployment | undefined {
-  return deployments.find((d) => d.projectId === projectId && d.status === "DEPLOYING");
+  const rows = deployments.filter((d) => d.projectId === projectId && d.status === "DEPLOYING");
+  return preferProductionSlot(rows);
 }
 
 export function getActiveDeployment(
   projectId: string,
   deployments: Deployment[]
 ): Deployment | undefined {
-  return deployments.find((d) => d.projectId === projectId && d.status === "ACTIVE");
+  const rows = deployments.filter((d) => d.projectId === projectId && d.status === "ACTIVE");
+  return preferProductionSlot(rows);
 }
 
-/** Prefer in-flight deploy row for slot/port; else live active. */
+/** Prefer in-flight deploy row for slot/port; else live active (production preferred). */
 export function getDisplayDeployment(
   projectId: string,
   deployments: Deployment[]

--- a/dashboard/src/lib/project-deployment-status.ts
+++ b/dashboard/src/lib/project-deployment-status.ts
@@ -1,11 +1,11 @@
 import type { Deployment } from "@/lib/api";
+import { getActiveDeployment, getDeployingDeployment } from "@/lib/deployment-display";
 
 /** Derives a single rollout state for a project from its deployment rows. */
 export function projectDeploymentStatus(projectId: string, deployments: Deployment[]): string {
   const mine = deployments.filter((d) => d.projectId === projectId);
-  const active = mine.find((d) => d.status === "ACTIVE");
-  if (mine.some((d) => d.status === "DEPLOYING")) return "DEPLOYING";
-  if (active) return "ACTIVE";
+  if (getDeployingDeployment(projectId, deployments)) return "DEPLOYING";
+  if (getActiveDeployment(projectId, deployments)) return "ACTIVE";
   const last = mine.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())[0];
   if (last?.status === "FAILED") return "FAILED";
   if (last?.status === "ROLLED_BACK") return "ROLLED_BACK";

--- a/dashboard/src/pages/DeployLog.tsx
+++ b/dashboard/src/pages/DeployLog.tsx
@@ -278,11 +278,9 @@ export function DeployLog() {
 
       {showWorkerHint && (
         <Alert className="border-amber-500/40 bg-amber-50">
-          <AlertTitle>Job still queued</AlertTitle>
+          <AlertTitle>Queued</AlertTitle>
           <AlertDescription>
-            Nothing has started yet. On the server run{" "}
-            <code className="rounded bg-muted px-1 py-0.5 text-xs">pm2 list</code> and ensure{" "}
-            <code className="rounded bg-muted px-1 py-0.5 text-xs">versiongate-worker</code> is online.
+            Worker idle — run <code className="rounded bg-muted px-1 text-xs">pm2 restart versiongate-worker</code>
           </AlertDescription>
         </Alert>
       )}
@@ -425,12 +423,8 @@ export function DeployLog() {
             </CardHeader>
             <CardContent className="space-y-2 text-xs">
               <div className="flex justify-between gap-2">
-                <span className="text-muted-foreground">Internal</span>
-                <span className="font-mono text-[11px]">127.0.0.1</span>
-              </div>
-              <div className="flex justify-between gap-2">
-                <span className="text-muted-foreground">Node</span>
-                <span className="truncate font-mono text-[11px]">{typeof window !== "undefined" ? window.location.hostname : "—"}</span>
+                <span className="text-muted-foreground">Dashboard</span>
+                <span className="truncate font-mono text-[11px]">{typeof window !== "undefined" ? window.location.host : "—"}</span>
               </div>
               {hostStats ? (
                 <div className="flex justify-between gap-2">

--- a/dashboard/src/pages/Overview.tsx
+++ b/dashboard/src/pages/Overview.tsx
@@ -25,11 +25,13 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Badge } from "@/components/ui/badge";
 import { useLaunchCreateProject } from "@/create-project-launch";
 import {
+  getActiveDeployment,
   getDeployingDeployment,
   getDisplayDeployment,
-  hostPortForSlot,
+  guessEnvironmentLabel,
   latestDeploymentForColor,
   publicServiceUrl,
+  setConfiguredPublicHost,
 } from "@/lib/deployment-display";
 import { projectDeploymentStatus } from "@/lib/project-deployment-status";
 import { DeleteProjectDialog } from "@/components/DeleteProjectDialog";
@@ -84,6 +86,7 @@ export function Overview() {
       setDeployments(d.deployments);
       setRecentJobs(allJobs.jobs);
       setInstanceSettings(inst);
+      setConfiguredPublicHost(inst?.publicDomain);
 
       const jobEntries = await Promise.all(
         p.projects.map(async (proj) => {
@@ -213,11 +216,9 @@ export function Overview() {
         <CardHeader className="pb-3">
           <CardTitle className="flex items-center gap-2 text-base">
             <Globe className="size-5 text-muted-foreground" aria-hidden />
-            Dashboard hostname &amp; URL
+            Public hostname
           </CardTitle>
-          <CardDescription>
-            Where this VersionGate UI is meant to be reached (DNS hostname and optional path). Change these when you move to a new domain or subdomain.
-          </CardDescription>
+          <CardDescription>Used for Live / Open links (set your VM IP or domain here).</CardDescription>
         </CardHeader>
         <CardContent className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
           <div className="min-w-0 flex-1 space-y-2">
@@ -245,7 +246,7 @@ export function Overview() {
               </>
             ) : (
               <p className="text-sm text-muted-foreground">
-                No public hostname configured yet. Set the domain or subdomain where operators should open VersionGate, then point DNS and nginx at this server.
+                Set your public IP or domain so Open links are not 127.0.0.1.
               </p>
             )}
           </div>
@@ -253,7 +254,7 @@ export function Overview() {
             to="/settings#dashboard-url"
             className={buttonVariants({ variant: "default", size: "sm", className: "w-full shrink-0 sm:w-auto" })}
           >
-            Change domain &amp; hostname
+            Change hostname
           </Link>
         </CardContent>
       </Card>
@@ -378,14 +379,16 @@ export function Overview() {
                 const row = getDisplayDeployment(p.id, deployments);
                 const st = projectDeploymentStatus(p.id, deployments);
                 const job = latestJobs[p.id];
-                const hostPort = row ? hostPortForSlot(p, row.color) : null;
+                const hostPort = row?.port ?? null;
                 const hostUrl = hostPort != null ? publicServiceUrl(hostPort) : null;
-                const active = mine.find((d) => d.status === "ACTIVE");
+                const envLabel = row ? guessEnvironmentLabel(p, row) : null;
+                const active = getActiveDeployment(p.id, deployments);
                 const deploying = getDeployingDeployment(p.id, deployments);
                 const bluePort = p.basePort;
                 const greenPort = p.basePort + 1;
-                const blueLatest = latestDeploymentForColor(mine, "BLUE");
-                const greenLatest = latestDeploymentForColor(mine, "GREEN");
+                const prodMine = mine.filter((d) => d.port === p.basePort || d.port === p.basePort + 1);
+                const blueLatest = latestDeploymentForColor(prodMine, "BLUE");
+                const greenLatest = latestDeploymentForColor(prodMine, "GREEN");
                 const lastDeploy = mine.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())[0];
 
                 return (
@@ -448,6 +451,11 @@ export function Overview() {
                       <div className="space-y-2">
                         <div className="flex flex-wrap items-center gap-2">
                           {row && <SlotBadge color={row.color} />}
+                          {envLabel && envLabel !== "—" ? (
+                            <Badge variant="outline" className="font-mono text-[9px] uppercase">
+                              {envLabel}
+                            </Badge>
+                          ) : null}
                           {hostUrl ? (
                             <a
                               href={hostUrl}

--- a/dashboard/src/pages/ProjectDetail.tsx
+++ b/dashboard/src/pages/ProjectDetail.tsx
@@ -247,9 +247,9 @@ export function ProjectDetail() {
         </div>
         <div className="flex flex-wrap gap-2">
           <Button variant="outline" className="border-destructive/50 text-destructive" onClick={() => void onRollback()}>
-            Emergency Rollback
+            Rollback
           </Button>
-          <Button onClick={() => void onDeploy()}>Force Deployment</Button>
+          <Button onClick={() => void onDeploy()}>Deploy production</Button>
           <Button type="button" variant="ghost" className="text-destructive" onClick={() => setDeleteOpen(true)}>
             Delete
           </Button>
@@ -260,11 +260,9 @@ export function ProjectDetail() {
         <div className="space-y-6 min-w-0">
       <Card className="border-border bg-card">
         <CardHeader>
-          <CardTitle className="font-mono text-sm uppercase tracking-wider">Promotion Pipeline</CardTitle>
+          <CardTitle className="font-mono text-sm uppercase tracking-wider">Environments</CardTitle>
           <CardDescription>
-            Stages run on different host port ranges. Use <strong>Deploy to …</strong> on the first stage for a fresh build, then{" "}
-            <strong>Promote</strong> to reuse the upstream image on the next stage. The top <strong>Deploy</strong> button targets{" "}
-            <strong>production</strong> only.
+            Deploy on development, then promote to staging and production.
           </CardDescription>
         </CardHeader>
         <CardContent className="space-y-4">
@@ -278,20 +276,13 @@ export function ProjectDetail() {
             </div>
           ) : null}
           {!environmentsError && environments.length === 0 ? (
-            <div className="space-y-2 text-sm text-muted-foreground">
-              <p>No environments were returned for this project.</p>
-              <p>
-                New projects get <span className="font-medium text-foreground">development</span>,{" "}
-                <span className="font-medium text-foreground">staging</span>, and{" "}
-                <span className="font-medium text-foreground">production</span>. If this project was created on an older release, upgrade the
-                engine and apply migrations, or create a new project to get the full chain.
-              </p>
-            </div>
+            <p className="text-sm text-muted-foreground">
+              No environments yet. Create a new project to get development → staging → production.
+            </p>
           ) : null}
           {!environmentsError && environments.length === 1 && environments[0]?.name === "production" ? (
             <p className="text-xs text-muted-foreground">
-              Only <strong className="font-medium">production</strong> is present. The dev → staging → production chain appears when all three
-              environment rows exist.
+              Only production exists on this project (legacy). New projects include the full chain.
             </p>
           ) : null}
           {!environmentsError && environments.length > 0 ? (

--- a/dashboard/src/pages/Projects.tsx
+++ b/dashboard/src/pages/Projects.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useMemo, useState } from "react";
 import { Link } from "react-router-dom";
-import { getAllDeployments, getProjects, getServerStats, listAllJobs, type Deployment, type JobRecord, type Project, type ServerStats } from "@/lib/api";
+import { getAllDeployments, getInstanceSettings, getProjects, getServerStats, listAllJobs, type Deployment, type JobRecord, type Project, type ServerStats } from "@/lib/api";
 import { projectDeploymentStatus } from "@/lib/project-deployment-status";
-import { getDisplayDeployment, publicServiceUrl } from "@/lib/deployment-display";
+import { getActiveDeployment, getDisplayDeployment, guessEnvironmentLabel, publicServiceUrl, setConfiguredPublicHost } from "@/lib/deployment-display";
 import { PageHeader } from "@/components/PageHeader";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { StatusBadge } from "@/components/StatusBadge";
@@ -19,7 +19,7 @@ import { Progress } from "@/components/ui/progress";
 const PAGE_SIZE = 6;
 
 function formatUptime(projectId: string, deployments: Deployment[]): string {
-  const active = deployments.find((d) => d.projectId === projectId && d.status === "ACTIVE");
+  const active = getActiveDeployment(projectId, deployments);
   if (!active) return "—";
   const sec = Math.max(0, (Date.now() - new Date(active.updatedAt).getTime()) / 1000);
   const d = Math.floor(sec / 86400);
@@ -43,11 +43,13 @@ export function Projects() {
   const load = async () => {
     setLoading(true);
     try {
-      const [p, d, jobs] = await Promise.all([
+      const [p, d, jobs, inst] = await Promise.all([
         getProjects(),
         getAllDeployments(),
         listAllJobs({ limit: 120 }).catch(() => ({ jobs: [] as JobRecord[], total: 0 })),
+        getInstanceSettings().catch(() => null),
       ]);
+      setConfiguredPublicHost(inst?.publicDomain);
       setProjects(p.projects);
       setDeployments(d.deployments);
       const m = new Map<string, string>();
@@ -150,6 +152,7 @@ export function Projects() {
                       disp && (disp.status === "ACTIVE" || disp.status === "DEPLOYING")
                         ? publicServiceUrl(disp.port)
                         : null;
+                    const envLabel = disp ? guessEnvironmentLabel(proj, disp) : "—";
                     const jobId = latestJobByProject.get(proj.id);
                     return (
                       <TableRow key={proj.id}>
@@ -162,8 +165,9 @@ export function Projects() {
                         <TableCell>
                           <StatusBadge status={state} />
                         </TableCell>
-                        <TableCell className="font-mono text-xs text-muted-foreground">
-                          {disp ? `v${disp.version}` : "—"}
+                        <TableCell className="font-mono text-xs uppercase text-muted-foreground">
+                          {envLabel}
+                          {disp ? <span className="ml-1 normal-case text-muted-foreground/70">v{disp.version}</span> : null}
                         </TableCell>
                         <TableCell className="text-sm tabular-nums text-muted-foreground">
                           {formatUptime(proj.id, deployments)}

--- a/dashboard/src/pages/Settings.tsx
+++ b/dashboard/src/pages/Settings.tsx
@@ -27,6 +27,7 @@ import { DonutChart } from "@/components/charts/DonutChart";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Globe } from "lucide-react";
 import { formatPublicDashboardUrl, looksLikeIpv4, normalizePublicBasePath } from "@/lib/public-url";
+import { setConfiguredPublicHost } from "@/lib/deployment-display";
 
 function Row({ label, value }: { label: string; value: ReactNode }) {
   return (
@@ -76,6 +77,7 @@ export function Settings() {
         if (cancelled) return;
         setInstance(i);
         setSetup(s);
+        setConfiguredPublicHost(i.publicDomain);
         setPublicDomainDraft(i.publicDomain ?? "");
         setPublicBasePathDraft(i.publicBasePath ?? "/");
         setCertbotEmailDraft(i.certbotEmail ?? "");
@@ -295,6 +297,7 @@ export function Settings() {
       toast.success(r.message);
       const i = await getInstanceSettings();
       setInstance(i);
+      setConfiguredPublicHost(i.publicDomain);
       setPublicDomainDraft(i.publicDomain ?? "");
       setPublicBasePathDraft(i.publicBasePath ?? "/");
       setCertbotEmailDraft(i.certbotEmail ?? "");

--- a/dashboard/src/pages/Setup.tsx
+++ b/dashboard/src/pages/Setup.tsx
@@ -9,7 +9,10 @@ import { Toaster } from "@/components/ui/sonner";
 
 function defaultDomain(): string {
   if (typeof window === "undefined") return "";
-  return window.location.hostname || "";
+  const host = window.location.hostname || "";
+  // SSH tunnels / local browser hosts must not become PUBLIC_DOMAIN (breaks Open links).
+  if (host === "localhost" || host === "127.0.0.1" || host === "::1") return "";
+  return host;
 }
 
 export function Setup() {
@@ -134,10 +137,13 @@ export function Setup() {
                   id="vg-domain"
                   value={domain}
                   onChange={(e) => setDomain(e.target.value)}
-                  placeholder="example.com or 203.0.113.10"
+                  placeholder="4.240.101.7 or app.example.com"
                   autoComplete="off"
                   required
                 />
+                <p className="text-xs text-muted-foreground">
+                  Use the VM public IP or domain — not 127.0.0.1 (that breaks Open / Live links).
+                </p>
               </div>
               <div className="space-y-2">
                 <label htmlFor="vg-db" className="text-sm font-medium">

--- a/src/controllers/setup.controller.ts
+++ b/src/controllers/setup.controller.ts
@@ -29,7 +29,10 @@ interface SetupApplyBody {
   geminiApiKey?: string;
 }
 
-const NGINX_CONF_PATH = "/etc/nginx/conf.d/versiongate.conf";
+/** Dashboard reverse-proxy site (must not be overwritten by traffic switch). */
+const NGINX_SITE_CONF_PATH = "/etc/nginx/conf.d/versiongate.conf";
+/** App blue/green upstream rewritten by TrafficService on production promote/deploy. */
+const NGINX_UPSTREAM_CONF_PATH = "/etc/nginx/conf.d/upstream.conf";
 const DB_URL_REGEX = /^DATABASE_URL\s*=\s*"?([^"\n\r]+)"?\s*$/m;
 const ENCRYPTION_KEY_REGEX = /^ENCRYPTION_KEY\s*=\s*"?([0-9a-fA-F]{64})"?\s*$/m;
 
@@ -179,7 +182,7 @@ export async function applySetupHandler(
 PORT=9090
 NODE_ENV=production
 DOCKER_NETWORK="versiongate-net"
-NGINX_CONFIG_PATH="${NGINX_CONF_PATH}"
+NGINX_CONFIG_PATH="${NGINX_UPSTREAM_CONF_PATH}"
 PROJECTS_ROOT_PATH="${escapeEnvValue(projectsRootPath)}"
 PUBLIC_DOMAIN="${escapeEnvValue(normalizedDomain)}"
 PUBLIC_BASE_PATH="/"
@@ -269,7 +272,14 @@ ENCRYPTION_KEY="${encryptionKey}"
       upstreamPort: 9090,
       basePath: "/",
     });
-    writeFileSync(NGINX_CONF_PATH, nginxConf, "utf-8");
+    writeFileSync(NGINX_SITE_CONF_PATH, nginxConf, "utf-8");
+    if (!existsSync(NGINX_UPSTREAM_CONF_PATH)) {
+      writeFileSync(
+        NGINX_UPSTREAM_CONF_PATH,
+        "# Written by VersionGate on production deploy/promote\n",
+        "utf-8"
+      );
+    }
 
     try {
       execSync("nginx -t && nginx -s reload", { stdio: "pipe", timeout: 10_000 });


### PR DESCRIPTION
## Summary
- Live/Open links resolve via `PUBLIC_DOMAIN` (not browser `127.0.0.1` from SSH tunnels)
- “Live” prefers the production ACTIVE deployment (lowest port) so promote no longer looks stuck on development
- Setup writes `NGINX_CONFIG_PATH` to `upstream.conf` and keeps the dashboard site on `versiongate.conf`
- Shorter copy on environments, blue/green, job queued hint, overview hostname card

## Test plan
- [ ] Settings → set PUBLIC_DOMAIN to VM public IP → Live links use that host
- [ ] Deploy development → promote to staging → promote to production → Live badge/URL shows production port
- [ ] Environment cards show Open per stage
- [ ] After setup on a fresh install, `.env` has `NGINX_CONFIG_PATH=/etc/nginx/conf.d/upstream.conf`


Made with [Cursor](https://cursor.com)