### PR TITLE
fix(db): unblock environment_model migration lockedAt INSERT

### DIFF
--- a/docs/database-migrations.md
+++ b/docs/database-migrations.md
@@ -48,6 +48,25 @@ Prisma records each migration in `_prisma_migrations`. If a migration **started*
 
 You see this when you run `prisma migrate resolve --applied <name>` but Prisma already has that migration as **applied** (not failed). **Ignore that name** and run `bunx prisma migrate status` plus `bunx prisma migrate deploy` again; the real blocker is whatever migration P3009 names **next**.
 
+### VersionGate: `20260419120000_environment_model` + `lockedAt` (P3018 → P3009)
+
+Older copies of this migration selected unqualified `"lockedAt"` while inserting into `"Environment"`. PostgreSQL errors with **42703** / “column lockedAt does not exist” even though `Environment.lockedAt` was just created. Setup may have recovered with **`db push`**, leaving a **failed** row in `_prisma_migrations` — later self-update then hits **P3009**.
+
+**On an install that already has environments / schema (typical after setup + push fallback):**
+
+```bash
+cd ~/VersionGate
+bunx prisma migrate resolve --applied 20260419120000_environment_model
+bunx prisma migrate deploy
+pm2 restart all
+```
+
+Then retry **Settings → Self-update → Apply**.
+
+**Fresh empty Neon database:** pull latest `main` (migration SQL uses `NULL` for `lockedAt`) and run setup again — do not reuse a DB with a failed migration row unless you `resolve` first.
+
+Redis / a separate queue does **not** fix Prisma migration history; keep Neon Postgres and clear `_prisma_migrations` failures with `migrate resolve`.
+
 ### 1. Inspect the database
 
 From the server (or any host that can reach the DB), with the same URL VersionGate uses for migrations (prefer **`DIRECT_DATABASE_URL`** unpooled if you use Neon):

--- a/prisma/migrations/20260419120000_environment_model/migration.sql
+++ b/prisma/migrations/20260419120000_environment_model/migration.sql
@@ -19,6 +19,8 @@ CREATE INDEX "Environment_projectId_idx" ON "Environment"("projectId");
 ALTER TABLE "Environment" ADD CONSTRAINT "Environment_projectId_fkey" FOREIGN KEY ("projectId") REFERENCES "Project"("id") ON DELETE CASCADE ON UPDATE CASCADE;
 
 -- One default environment per project (production) — mirrors former project-level deploy target
+-- Use NULL for lockedAt: Project never had that column in prior migrations; an unqualified
+-- "lockedAt" is rejected by PostgreSQL once Environment.lockedAt exists (P3018 / 42703).
 INSERT INTO "Environment" ("id", "name", "projectId", "branch", "serverHost", "basePort", "appPort", "lockedAt", "createdAt", "updatedAt")
 SELECT
   'env_prod_' || "id",
@@ -28,7 +30,7 @@ SELECT
   'localhost',
   "basePort",
   "appPort",
-  "lockedAt",
+  NULL,
   CURRENT_TIMESTAMP,
   CURRENT_TIMESTAMP
 FROM "Project";


### PR DESCRIPTION
## Summary
- Fix `20260419120000_environment_model` INSERT to use `NULL` for `lockedAt` (unqualified column caused Postgres 42703 / P3018, then P3009 on self-update)
- Document `prisma migrate resolve --applied` recovery for Neon DBs that already got schema via setup `db push` fallback

## Test plan
- [ ] On stuck VM: `bunx prisma migrate resolve --applied 20260419120000_environment_model && bunx prisma migrate deploy` exits 0
- [ ] Fresh empty DB: `prisma migrate deploy` applies `environment_model` without lockedAt error
- [ ] Self-update Apply succeeds after resolve


Made with [Cursor](https://cursor.com)