### PR TITLE
fix(db): auto-heal failed Prisma migrations on self-update

### DIFF
--- a/docs/database-migrations.md
+++ b/docs/database-migrations.md
@@ -8,7 +8,7 @@ On startup (when `DATABASE_URL` is set), the engine runs schema sync from [`src/
 
 | `PRISMA_SCHEMA_SYNC` | Behavior |
 | -------------------- | -------- |
-| `migrate` (default) | Runs `bunx prisma migrate deploy`. Uses **`DIRECT_DATABASE_URL`** as `DATABASE_URL` for that subprocess when set; if unset but **`DATABASE_URL`** is a Neon **`-pooler.`** host, VersionGate **infers** the usual direct host for migrate only (see [`prisma-schema-sync.ts`](../src/utils/prisma-schema-sync.ts)). On some failures it falls back to `db push`. **No fallback** on P3005 / P3009 / P1001 / P1002 / baseline / advisory-lock errors. |
+| `migrate` (default) | Runs `bunx prisma migrate deploy`. Uses **`DIRECT_DATABASE_URL`** as `DATABASE_URL` for that subprocess when set; if unset but **`DATABASE_URL`** is a Neon **`-pooler.`** host, VersionGate **infers** the usual direct host for migrate only (see [`prisma-schema-sync.ts`](../src/utils/prisma-schema-sync.ts)). **Auto-heals P3009** (failed migration rows) and falls back to `db push` on stubborn advisory-lock (**P1002**) timeouts. **No** push fallback for **P3005** (needs baseline). |
 | `push` | Runs **only** `bunx prisma db push --accept-data-loss` — no migration history required. Use only when you accept push-only discipline for that install. |
 
 Set in `.env`:
@@ -40,9 +40,22 @@ If you intentionally do not use migration history (e.g. ephemeral dev), set `PRI
 
 Prisma records each migration in `_prisma_migrations`. If a migration **started** but did not finish cleanly, Prisma marks it as **failed** and refuses to apply newer migrations until you **resolve** that record ([production troubleshooting](https://www.prisma.io/docs/guides/migrate/production-troubleshooting)).
 
+### Automatic heal (VersionGate)
+
+On startup and self-update, [`runPrismaSchemaSync`](../src/utils/prisma-schema-sync.ts) **auto-heals** P3009 when possible:
+
+1. Parse the failed migration name(s) from the error
+2. Run `prisma migrate resolve --applied <name>`
+3. Retry `migrate deploy`
+4. If still blocked (or Neon **P1002** advisory-lock timeout), sync with `db push` and continue so upgrades are not stuck behind SSH
+
+Operators should **not** need to run `migrate resolve` by hand for the common “setup used push fallback, then self-update hits P3009” path. Manual steps below remain for unusual / half-applied production DBs.
+
+Setup also writes **`DIRECT_DATABASE_URL`** when `DATABASE_URL` is a Neon `-pooler.` host, so migrate uses a session-capable endpoint.
+
 **Always use the migration name printed in the current P3009 message** — after you fix one failure, the next `migrate deploy` may report a **different** migration in failed state (see *VersionGate: common chain* below).
 
-**You must not blindly “resolve” without checking the live schema** — choose the branch that matches reality.
+**You must not blindly “resolve” without checking the live schema** — choose the branch that matches reality (auto-heal assumes the live schema already matches or will be synced via `db push`).
 
 ### Error P3008 — “migration is already recorded as applied”
 
@@ -52,20 +65,21 @@ You see this when you run `prisma migrate resolve --applied <name>` but Prisma a
 
 Older copies of this migration selected unqualified `"lockedAt"` while inserting into `"Environment"`. PostgreSQL errors with **42703** / “column lockedAt does not exist” even though `Environment.lockedAt` was just created. Setup may have recovered with **`db push`**, leaving a **failed** row in `_prisma_migrations` — later self-update then hits **P3009**.
 
-**On an install that already has environments / schema (typical after setup + push fallback):**
+**Preferred:** pull latest `main` and run self-update / restart — auto-heal marks the failed migration applied.
+
+**Manual (only if auto-heal is not on the box yet):**
 
 ```bash
 cd ~/VersionGate
+# Prefer Neon *direct* host (no `-pooler.`) to avoid P1002 advisory-lock timeouts
 bunx prisma migrate resolve --applied 20260419120000_environment_model
 bunx prisma migrate deploy
 pm2 restart all
 ```
 
-Then retry **Settings → Self-update → Apply**.
+**Fresh empty Neon database:** pull latest `main` (migration SQL uses `NULL` for `lockedAt`) and run setup again.
 
-**Fresh empty Neon database:** pull latest `main` (migration SQL uses `NULL` for `lockedAt`) and run setup again — do not reuse a DB with a failed migration row unless you `resolve` first.
-
-Redis / a separate queue does **not** fix Prisma migration history; keep Neon Postgres and clear `_prisma_migrations` failures with `migrate resolve`.
+Redis does **not** fix Prisma migration history; keep Neon Postgres.
 
 ### 1. Inspect the database
 

--- a/src/controllers/setup.controller.ts
+++ b/src/controllers/setup.controller.ts
@@ -7,7 +7,7 @@ import { PrismaClient } from "@prisma/client";
 import { logger } from "../utils/logger";
 import { config } from "../config/env";
 import { envFilePath, projectRoot } from "../utils/paths";
-import { runPrismaSchemaSync } from "../utils/prisma-schema-sync";
+import { runPrismaSchemaSync, tryInferNeonDirectDatabaseUrl } from "../utils/prisma-schema-sync";
 import { reconnectPrismaAfterSetup } from "../prisma/client";
 import { notifySetupApplied } from "../services/post-setup-hooks";
 import {
@@ -188,6 +188,11 @@ PUBLIC_DOMAIN="${escapeEnvValue(normalizedDomain)}"
 PUBLIC_BASE_PATH="/"
 ENCRYPTION_KEY="${encryptionKey}"
 `;
+
+  const inferredDirect = tryInferNeonDirectDatabaseUrl(databaseUrl);
+  if (inferredDirect) {
+    envContent += `DIRECT_DATABASE_URL="${escapeEnvValue(inferredDirect)}"\n`;
+  }
 
   if (geminiApiKey && geminiApiKey.trim().length > 0) {
     envContent += `GEMINI_API_KEY="${escapeEnvValue(geminiApiKey.trim())}"\n`;

--- a/src/utils/prisma-schema-sync.ts
+++ b/src/utils/prisma-schema-sync.ts
@@ -4,9 +4,19 @@ import { logger } from "./logger";
 
 export type PrismaSchemaSyncMode = "migrate" | "push";
 
-const DEFAULT_TIMEOUT_MS = 120_000;
+const DEFAULT_TIMEOUT_MS = 180_000;
+const MAX_P3009_HEAL_ROUNDS = 5;
 
 type ExecSyncError = Error & { status?: number; stderr?: string; stdout?: string };
+
+function errorText(e: unknown): string {
+  if (!(e instanceof Error)) return String(e);
+  const x = e as ExecSyncError;
+  const parts = [e.message];
+  if (typeof x.stderr === "string" && x.stderr.trim()) parts.push(x.stderr);
+  if (typeof x.stdout === "string" && x.stdout.trim()) parts.push(x.stdout);
+  return parts.join("\n");
+}
 
 function execSyncWithLogs(command: string, opts: { cwd: string; env: NodeJS.ProcessEnv; timeout: number }): void {
   try {
@@ -58,7 +68,7 @@ export function tryInferNeonDirectDatabaseUrl(poolerDatabaseUrl: string): string
 }
 
 /** Prisma Migrate needs a real DB session for advisory locks — Neon pooler URLs often hit P1002. */
-function envForMigrateDeploy(base: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+export function envForMigrateDeploy(base: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
   const explicitDirect = base.DIRECT_DATABASE_URL?.trim();
   if (explicitDirect) {
     return { ...base, DATABASE_URL: explicitDirect };
@@ -70,16 +80,132 @@ function envForMigrateDeploy(base: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
   return { ...base, DATABASE_URL: inferred };
 }
 
+/** Migration folder names cited in P3009 / P3018 messages. */
+export function extractFailedMigrationNames(message: string): string[] {
+  const names = new Set<string>();
+  const re =
+    /(?:The\s+)?`([0-9]{14}_[A-Za-z0-9_]+)`\s+migration(?:\s+started|\s+failed|[\s\S]*?failed)?/gi;
+  for (const m of message.matchAll(re)) {
+    names.add(m[1]);
+  }
+  // Fallback: Migration name: foo
+  for (const m of message.matchAll(/Migration name:\s*([0-9]{14}_[A-Za-z0-9_]+)/gi)) {
+    names.add(m[1]);
+  }
+  return [...names];
+}
+
+function markMigrationsApplied(
+  names: string[],
+  opts: { cwd: string; env: NodeJS.ProcessEnv; timeout: number }
+): void {
+  for (const name of names) {
+    logger.warn(
+      { migration: name },
+      "Auto-healing failed Prisma migration — marking as applied (schema usually already synced via prior db push / partial apply)"
+    );
+    try {
+      execSyncWithLogs(`bunx prisma migrate resolve --applied ${name}`, opts);
+    } catch (e: unknown) {
+      const msg = errorText(e);
+      // Already applied is fine; keep going.
+      if (/\bP3008\b/i.test(msg) || /already recorded as applied/i.test(msg)) {
+        logger.info({ migration: name }, "Migration already marked applied — continuing");
+        continue;
+      }
+      throw e;
+    }
+  }
+}
+
+function healFailedMigrationsThenDeploy(opts: {
+  cwd: string;
+  migrateEnv: NodeJS.ProcessEnv;
+  appEnv: NodeJS.ProcessEnv;
+  timeout: number;
+  firstErr: unknown;
+}): void {
+  let lastErr: unknown = opts.firstErr;
+  for (let round = 0; round < MAX_P3009_HEAL_ROUNDS; round++) {
+    const msg = errorText(lastErr);
+    if (!/\bP3009\b/i.test(msg) && !/\bfailed migrations\b/i.test(msg)) {
+      break;
+    }
+    const names = extractFailedMigrationNames(msg);
+    if (names.length === 0) {
+      logger.error("P3009 without a parseable migration name — cannot auto-heal");
+      break;
+    }
+    markMigrationsApplied(names, {
+      cwd: opts.cwd,
+      env: opts.migrateEnv,
+      timeout: opts.timeout,
+    });
+    try {
+      execSyncWithLogs("bunx prisma migrate deploy", {
+        cwd: opts.cwd,
+        env: opts.migrateEnv,
+        timeout: opts.timeout,
+      });
+      logger.info("Database migrations applied after auto-heal (prisma migrate deploy)");
+      return;
+    } catch (e: unknown) {
+      lastErr = e;
+    }
+  }
+
+  // Schema may already match from an earlier push / partial apply — sync then baseline remaining history.
+  logger.warn(
+    { err: errorText(lastErr) },
+    "migrate deploy still blocked — syncing schema with db push, then resolving any remaining failed migrations"
+  );
+  execSyncWithLogs("bunx prisma db push --accept-data-loss", {
+    cwd: opts.cwd,
+    env: opts.appEnv,
+    timeout: opts.timeout,
+  });
+
+  try {
+    execSyncWithLogs("bunx prisma migrate deploy", {
+      cwd: opts.cwd,
+      env: opts.migrateEnv,
+      timeout: opts.timeout,
+    });
+    logger.info("Database migrations applied after db push heal");
+    return;
+  } catch (e: unknown) {
+    const msg = errorText(e);
+    if (/\bP3009\b/i.test(msg) || /\bfailed migrations\b/i.test(msg)) {
+      const names = extractFailedMigrationNames(msg);
+      if (names.length > 0) {
+        markMigrationsApplied(names, {
+          cwd: opts.cwd,
+          env: opts.migrateEnv,
+          timeout: opts.timeout,
+        });
+        execSyncWithLogs("bunx prisma migrate deploy", {
+          cwd: opts.cwd,
+          env: opts.migrateEnv,
+          timeout: opts.timeout,
+        });
+        logger.info("Database migrations applied after resolve + deploy following db push");
+        return;
+      }
+    }
+    throw e;
+  }
+}
+
 /**
  * Applies Prisma schema changes: prefer `migrate deploy` (versioned migrations in repo),
- * with optional fallback to `db push` for databases that predate migration history.
+ * with automatic heal for failed migration history (P3009) so self-update does not require SSH.
  */
 export function runPrismaSchemaSync(options: {
   cwd?: string;
   env?: NodeJS.ProcessEnv;
   mode?: PrismaSchemaSyncMode;
   timeoutMs?: number;
-  /** When true, do not fall back to db push if migrate deploy fails */
+  /** When true, do not fall back to db push / auto-heal if migrate deploy fails */
   strictMigrate?: boolean;
 }): void {
   const cwd = options.cwd ?? projectRoot;
@@ -114,28 +240,68 @@ export function runPrismaSchemaSync(options: {
       timeout,
     });
     logger.info("Database migrations applied (prisma migrate deploy)");
+    return;
   } catch (firstErr: unknown) {
-    const msg = firstErr instanceof Error ? firstErr.message : String(firstErr);
+    const msg = errorText(firstErr);
     if (strict) {
       throw firstErr;
     }
-    // P3005 = DB never baselined for Migrate; push would emit wrong one-shot DDL (e.g. NOT NULL
-    // without the backfill steps in versioned migrations). Do not fall back to db push.
-    // P1001/P1002 = connectivity / advisory lock (Neon pooler) — push is the wrong recovery; use DIRECT_DATABASE_URL.
-    const noPushFallback =
-      /\bP3005\b/i.test(msg) ||
-      /\bP3009\b/i.test(msg) ||
-      /\bP1001\b/i.test(msg) ||
-      /\bP1002\b/i.test(msg) ||
-      /baseline an existing production database/i.test(msg) ||
-      /advisory lock/i.test(msg);
-    if (noPushFallback) {
+
+    // P3009: failed row in _prisma_migrations — auto resolve + retry (common after setup push fallback).
+    if (/\bP3009\b/i.test(msg) || /\bfailed migrations\b/i.test(msg)) {
+      healFailedMigrationsThenDeploy({
+        cwd,
+        migrateEnv,
+        appEnv: env,
+        timeout,
+        firstErr,
+      });
+      return;
+    }
+
+    // P1002 on pooler: retry once on migrate env (direct); if still failing, push then continue.
+    if (/\bP1002\b/i.test(msg) || /advisory lock/i.test(msg)) {
+      logger.warn(
+        { err: msg },
+        "prisma migrate deploy hit advisory-lock timeout — retrying once on direct URL, then db push if needed"
+      );
+      try {
+        execSyncWithLogs("bunx prisma migrate deploy", {
+          cwd,
+          env: migrateEnv,
+          timeout: Math.max(timeout, 180_000),
+        });
+        logger.info("Database migrations applied on retry (prisma migrate deploy)");
+        return;
+      } catch (retryErr: unknown) {
+        logger.warn(
+          { err: errorText(retryErr) },
+          "migrate deploy still timing out — falling back to prisma db push so upgrades are not blocked"
+        );
+        execSyncWithLogs("bunx prisma db push --accept-data-loss", {
+          cwd,
+          env,
+          timeout,
+        });
+        logger.warn("Database schema synced via prisma db push fallback (advisory lock)");
+        return;
+      }
+    }
+
+    // P3005 = DB never baselined for Migrate; push would emit wrong one-shot DDL without backfills.
+    if (/\bP3005\b/i.test(msg) || /baseline an existing production database/i.test(msg)) {
       logger.error(
         { err: msg },
-        "prisma migrate deploy failed (baseline / migration history / DB reachability / advisory lock). Not using db push fallback — see docs/database-migrations.md (Neon: set DIRECT_DATABASE_URL or use a `-pooler.` pooler URL for automatic direct-host inference)."
+        "prisma migrate deploy failed (baseline required). Not using db push fallback — see docs/database-migrations.md"
       );
       throw firstErr;
     }
+
+    if (/\bP1001\b/i.test(msg)) {
+      logger.error({ err: msg }, "prisma migrate deploy failed (database unreachable)");
+      throw firstErr;
+    }
+
     logger.warn(
       { err: msg },
       "prisma migrate deploy failed — falling back to prisma db push (legacy or drifted database)"


### PR DESCRIPTION
## Summary
- Auto-heal **P3009** during startup/self-update: `migrate resolve --applied` + retry (then `db push` if still blocked)
- Soften **P1002** advisory-lock failures with retry + `db push` so Neon pooler timeouts do not brick upgrades
- Setup writes **`DIRECT_DATABASE_URL`** when `DATABASE_URL` is a Neon `-pooler.` host

## Why
Self-hosted users hit P3009 after setup’s push fallback and then P1002 on pooler `migrate deploy`. Manual `prisma migrate resolve` is not an acceptable product loop.

## Test plan
- [ ] DB with failed `20260419120000_environment_model` row: self-update/apply completes without SSH resolve
- [ ] Neon pooler-only `.env`: migrate uses inferred/direct URL; P1002 path falls back to push instead of hard-failing the whole update
- [ ] Fresh setup with pooler URL writes `DIRECT_DATABASE_URL` into `.env`


Made with [Cursor](https://cursor.com)