### PR TITLE
docs(readme): update README and marketing website docs to reflect Drizzle ORM, Redis, and setup wizard

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ Built for single-server (KVM/VPS) setups where you want Vercel-style deployments
 | --------------- | ------------------------------------------------- |
 | Runtime         | Bun 1.x + TypeScript                              |
 | API server      | Fastify                                           |
-| Database        | PostgreSQL via Prisma (Neon serverless supported) |
+| Database        | PostgreSQL via Drizzle ORM                        |
+| Queue & Locks   | Redis (ioredis) pub/sub + atomic locking          |
 | Containers      | Docker CLI                                        |
 | Proxy           | Nginx upstream config management                  |
 | Process manager | PM2 (recommended)                                 |
@@ -98,13 +99,12 @@ The setup wizard will then:
 - Write the `.env` file
 - Set `PROJECTS_ROOT_PATH`
 - Generate and persist `ENCRYPTION_KEY`
-- Run `bunx prisma generate`
-- Run `bunx prisma migrate deploy` (falls back to `db push` only if the database has no migration history)
+- Execute Drizzle ORM schema migrations (`runDrizzleSchemaSync`)
 - Write and reload Nginx config when permissions allow
 
 After setup finishes, open the dashboard and start adding projects.
 
-No manual `.env` edits or Prisma commands are required after opening `/setup`.
+No manual `.env` edits or Prisma commands are required after running `bun run setup` or opening `/setup`.
 
 ### GitHub App (Integrations)
 

--- a/website/src/app/docs/architecture/page.tsx
+++ b/website/src/app/docs/architecture/page.tsx
@@ -25,7 +25,7 @@ export default function Architecture() {
       <Breadcrumb page="Architecture" />
       <PageTitle>Architecture</PageTitle>
       <Lead>
-        VersionGate is a Fastify API plus a background worker, backed by PostgreSQL via Prisma. It
+        VersionGate is a Fastify API plus a background worker, backed by PostgreSQL via Drizzle ORM and Redis event pub/sub. It
         orchestrates the Docker CLI and rewrites Nginx upstreams to switch traffic atomically.
       </Lead>
 
@@ -54,7 +54,7 @@ export default function Architecture() {
       </P>
 
       <Callout title="Component overview">
-        HTTP request → Fastify router → controller → service layer → Prisma (state) + Docker CLI
+        HTTP request → Fastify router → controller → service layer → Drizzle ORM + Redis (state/queue) + Docker CLI
         (build/run/stop) → Nginx (traffic switch). A job queue with a dedicated worker handles
         long-running deploys and streams logs to the dashboard over WebSockets.
       </Callout>


### PR DESCRIPTION
## Summary
Updates the root README.md and marketing site documentation (website/) to accurately reflect VersionGate's modernized Drizzle ORM, Redis event queuing, and unified CLI setup wizard (bun run setup).

## Key Updates
- README.md Modernization:
  - Updated Tech Stack table to list Drizzle ORM (PostgreSQL) and Redis (ioredis) distributed lock/queue manager.
  - Removed outdated Prisma references in favor of Drizzle schema synchronization (runDrizzleSchemaSync) and bun run setup.
- Marketing Site Documentation (website/src/app/docs/architecture/page.tsx):
  - Updated Architecture overview Lead and Callout sections to reflect Drizzle ORM and Redis event pub/sub.

## Verification
- bun run typecheck — clean pass with 0 errors.
- cd website && bun run build — compiled Next.js static and dynamic pages with 0 errors.