### PR TITLE
feat(dashboard): add prominent Open App action button and clarify navigation labels

### DIFF
--- a/dashboard/src/pages/ProjectDetail.tsx
+++ b/dashboard/src/pages/ProjectDetail.tsx
@@ -17,6 +17,7 @@ import {
 import { EnvironmentChain } from "@/components/badges/EnvironmentChain";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button, buttonVariants } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { StatusBadge } from "@/components/badges/StatusBadge";
 import { SlotBadge } from "@/components/badges/SlotBadge";
@@ -246,6 +247,25 @@ export function ProjectDetail() {
           </a>
         </div>
         <div className="flex flex-wrap gap-2">
+          {liveUrl ? (
+            <a
+              href={liveUrl}
+              target="_blank"
+              rel="noreferrer"
+              className={cn(
+                buttonVariants({ variant: "default", size: "default" }),
+                "gap-1.5 bg-emerald-600 hover:bg-emerald-700 text-white font-medium border-emerald-500/30"
+              )}
+            >
+              <span>Open Live App</span>
+              <span className="font-mono text-xs opacity-80">(:{liveHostPort})</span>
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
+                <polyline points="15 3 21 3 21 9" />
+                <line x1="10" y1="14" x2="21" y2="3" />
+              </svg>
+            </a>
+          ) : null}
           <Button variant="outline" className="border-destructive/50 text-destructive" onClick={() => void onRollback()}>
             Rollback
           </Button>

--- a/dashboard/src/pages/Projects.tsx
+++ b/dashboard/src/pages/Projects.tsx
@@ -188,6 +188,20 @@ export function Projects() {
                         </TableCell>
                         <TableCell className="pr-6 text-right">
                           <div className="flex justify-end gap-2">
+                            {url ? (
+                              <a
+                                href={url}
+                                target="_blank"
+                                rel="noreferrer"
+                                className={cn(
+                                  buttonVariants({ variant: "default", size: "sm" }),
+                                  "bg-emerald-600 hover:bg-emerald-700 text-white font-medium border-emerald-500/30"
+                                )}
+                              >
+                                <span>Open App</span>
+                                <span className="font-mono text-[10px] opacity-80">(:{disp?.port})</span>
+                              </a>
+                            ) : null}
                             {jobId ? (
                               <Link
                                 to={`/projects/${proj.id}/deploy/${jobId}`}
@@ -197,7 +211,7 @@ export function Projects() {
                               </Link>
                             ) : null}
                             <Link to={`/projects/${proj.id}`} className={cn(buttonVariants({ variant: "outline", size: "sm" }))}>
-                              Open
+                              Details
                             </Link>
                             <Button type="button" variant="ghost" size="sm" className="text-destructive" onClick={() => setDeleteTarget(proj)}>
                               Delete


### PR DESCRIPTION
### Root Cause & UI Clarification

The Projects list table featured a button labeled `"Open"` on each row. However, this button navigated to `/projects/:id` (the VersionGate admin dashboard page at `http://4.240.101.7:9090/projects/...`), causing confusion as users expected it to open their deployed web application on its host port (e.g. `http://4.240.101.7:3100`).

### Enhancements Made

1. **Direct "Open App (:3100)" Action Button in Projects List**:
   - Added a prominent green `"Open App (:port)"` button in `Projects.tsx` whenever a project has an active or deploying port, opening `http://<IP>:<PORT>` directly in a new browser tab.
   - Renamed the internal dashboard page navigation link from `"Open"` to `"Details"` to avoid ambiguity.
2. **Prominent "Open Live App (:3100)" Header Action in Project Details**:
   - Added an `"Open Live App (:port)"` button in `ProjectDetail.tsx` header next to `"Deploy production"`, giving instant 1-click access to the running application port.

### Empirical Test & Verification

- **Dashboard Build**: `bun run build:dashboard` -> **PASSED** (Built in 337ms with 0 errors)
- **Backend Typecheck**: `bun run typecheck` -> **PASSED** (0 errors)