### PR TITLE
fix(dashboard): remove full-card Link overlay in Overview page that intercepted live port links

### DIFF
--- a/dashboard/src/pages/Overview.tsx
+++ b/dashboard/src/pages/Overview.tsx
@@ -15,6 +15,7 @@ import {
   type Project,
 } from "@/lib/api";
 import { Button, buttonVariants } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
 import { StatusBadge } from "@/components/badges/StatusBadge";
 import { SlotBadge } from "@/components/badges/SlotBadge";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -394,14 +395,13 @@ export function Overview() {
                 return (
                   <Card
                     key={p.id}
-                    className="group relative border-border/50 bg-card/60 shadow-none ring-1 ring-border/30 transition-all hover:ring-primary/30 hover:shadow-md hover:shadow-primary/5"
+                    className="border-border/50 bg-card/60 shadow-none ring-1 ring-border/30 transition-all hover:ring-primary/30 hover:shadow-md hover:shadow-primary/5"
                   >
-                    <Link to={`/projects/${p.id}`} className="absolute inset-0 z-10" />
                     <CardHeader className="pb-3">
                       <div className="flex items-start justify-between gap-3">
                         <div className="min-w-0 flex-1">
-                          <CardTitle className="truncate text-base font-semibold transition-colors group-hover:text-primary">
-                            {p.name}
+                          <CardTitle className="truncate text-base font-semibold transition-colors hover:text-primary">
+                            <Link to={`/projects/${p.id}`}>{p.name}</Link>
                           </CardTitle>
                           <CardDescription className="mt-1 space-y-0.5 font-mono text-xs">
                             <div className="truncate">Branch: {p.branch}</div>
@@ -461,10 +461,12 @@ export function Overview() {
                               href={hostUrl}
                               target="_blank"
                               rel="noreferrer"
-                              onClick={(e) => e.stopPropagation()}
-                              className="relative z-20 truncate font-mono text-xs text-primary underline-offset-2 hover:underline"
+                              className={cn(
+                                buttonVariants({ variant: "default", size: "xs" }),
+                                "bg-emerald-600 hover:bg-emerald-700 text-white font-medium border-emerald-500/30 text-[10px]"
+                              )}
                             >
-                              Live {hostUrl.replace(/^https?:\/\//, "")}
+                              Open App ({hostUrl.replace(/^https?:\/\//, "")})
                             </a>
                           ) : (
                             <span className="text-xs text-muted-foreground/50">Not deployed</span>


### PR DESCRIPTION
### Root Cause Discovered

In `Overview.tsx`, project cards rendered an invisible link overlay stretched across the entire card component:
```tsx
<Link to={`/projects/${p.id}`} className="absolute inset-0 z-10" />
```
Because this invisible overlay sat on top of the card at `z-10`, clicking **anywhere** on the card—including the `Open App (:3100)`, `:9001`, `:3100`, or `Live` hyperlinks—triggered the `<Link to={`/projects/${p.id}`}>` overlay! As a result, React Router intercepted every click and navigated to `http://4.240.101.7:9090/projects/cmrx1rezi0004qm2uzeadmt1w` (the dashboard page).

### Fix

- Removed the full-card `absolute inset-0` invisible overlay from `Overview.tsx`.
- Made the Project Title link directly to `/projects/${p.id}`.
- Styled the **Open App (:3100)** link as a distinct green button that opens `http://<IP>:<PORT>` directly in a new tab without overlay interception.

### Empirical Test & Verification

- **Dashboard Build**: `bun run build:dashboard` -> **PASSED** (Built in 347ms with 0 errors)
- **Backend Typecheck**: `bun run typecheck` -> **PASSED** (0 errors)