### PR TITLE
fix(dashboard): clean public hostnames and format deployed project URLs

### DIFF
--- a/dashboard/src/lib/deployment-display.ts
+++ b/dashboard/src/lib/deployment-display.ts
@@ -5,15 +5,42 @@ export type DeploymentColor = "BLUE" | "GREEN";
 /** Hostname from Settings / setup (`PUBLIC_DOMAIN`), used for Open / Live links. */
 let configuredPublicHost: string | null = null;
 
+/**
+ * Strips protocol, port, path, and whitespace from a raw host string.
+ * Examples:
+ *   "http://4.240.101.7:9090/projects/123" -> "4.240.101.7"
+ *   "4.240.101.7:9090" -> "4.240.101.7"
+ *   "https://app.domain.com:8443" -> "app.domain.com"
+ *   "[::1]:9090" -> "::1"
+ */
+export function cleanHostname(rawHost: string): string {
+  let h = (rawHost ?? "").trim();
+  if (!h) return "";
+  // Remove protocol (e.g. http://, https://)
+  h = h.replace(/^[a-zA-Z]+:\/\//, "");
+  // Remove path, query params, hash
+  h = h.split("/")[0].split("?")[0].split("#")[0];
+  // Remove port if present
+  if (h.startsWith("[")) {
+    const endBracket = h.indexOf("]");
+    if (endBracket !== -1) {
+      h = h.slice(1, endBracket);
+    }
+  } else {
+    h = h.split(":")[0];
+  }
+  return h.trim();
+}
+
 export function isLoopbackHostname(host: string): boolean {
-  const h = host.trim().toLowerCase();
+  const h = cleanHostname(host).toLowerCase();
   return h === "localhost" || h === "127.0.0.1" || h === "::1" || h === "0.0.0.0";
 }
 
 /** Call when instance settings load so app links use the public IP/domain, not an SSH-tunnel host. */
 export function setConfiguredPublicHost(host: string | null | undefined): void {
-  const h = (host ?? "").trim();
-  configuredPublicHost = h && !isLoopbackHostname(h) ? h : null;
+  const cleaned = cleanHostname(host ?? "");
+  configuredPublicHost = cleaned && !isLoopbackHostname(cleaned) ? cleaned : null;
 }
 
 export function getConfiguredPublicHost(): string | null {
@@ -37,6 +64,7 @@ export function latestDeploymentForColor(
 /** Full URL to hit the app health check on a host slot (browser / curl). */
 export function healthCheckUrl(project: Project, hostPort: number): string {
   const base = publicServiceUrl(hostPort).replace(/\/$/, "");
+  if (!base) return "";
   const path = project.healthPath.startsWith("/") ? project.healthPath : `/${project.healthPath}`;
   return `${base}${path}`;
 }
@@ -58,21 +86,23 @@ export function slotLabel(color: string): string {
  * when it is not loopback (so SSH tunnels at 127.0.0.1 do not poison Open links).
  */
 export function resolvePublicHostname(hostname?: string): string {
-  const explicit = hostname?.trim();
+  const explicit = hostname ? cleanHostname(hostname) : "";
   if (explicit && !isLoopbackHostname(explicit)) return explicit;
   if (configuredPublicHost) return configuredPublicHost;
-  const fromWindow = typeof window !== "undefined" ? window.location.hostname : "";
+  const fromWindow = typeof window !== "undefined" ? cleanHostname(window.location.hostname || window.location.host) : "";
   if (fromWindow && !isLoopbackHostname(fromWindow)) return fromWindow;
   if (explicit) return explicit;
   return fromWindow || "localhost";
 }
 
 export function publicServiceUrl(port: number, hostname?: string): string {
+  if (!port || port <= 0) return "";
   const host = resolvePublicHostname(hostname);
   const windowProto =
     typeof window !== "undefined" && window.location.protocol === "https:" ? "https" : "http";
   // IPv4 public hosts are almost always plain HTTP on the published Docker port.
-  const proto = /^\d{1,3}(\.\d{1,3}){3}$/.test(host) ? "http" : windowProto;
+  const isIpv4 = /^\d{1,3}(\.\d{1,3}){3}$/.test(host);
+  const proto = isIpv4 ? "http" : windowProto;
   if (port === 80 && proto === "http") return `${proto}://${host}`;
   if (port === 443 && proto === "https") return `${proto}://${host}`;
   return `${proto}://${host}:${port}`;

--- a/dashboard/src/lib/public-url.ts
+++ b/dashboard/src/lib/public-url.ts
@@ -1,3 +1,5 @@
+import { cleanHostname } from "@/lib/deployment-display";
+
 /** Matches backend `normalizePublicBasePath` (leading slash, no trailing slash except `/`). */
 export function normalizePublicBasePath(raw: string): string {
   let p = raw.trim();
@@ -8,15 +10,31 @@ export function normalizePublicBasePath(raw: string): string {
 }
 
 export function looksLikeIpv4(host: string): boolean {
-  return /^\d{1,3}(\.\d{1,3}){3}$/.test(host.trim());
+  const cleaned = cleanHostname(host);
+  return /^\d{1,3}(\.\d{1,3}){3}$/.test(cleaned);
 }
 
 /** Preview URL for the dashboard (scheme guessed: HTTP for raw IPv4, HTTPS for hostnames). */
 export function formatPublicDashboardUrl(publicDomain: string, publicBasePath: string): string | null {
-  const host = publicDomain.trim().toLowerCase();
+  const raw = publicDomain.trim();
+  if (!raw) return null;
+  
+  let proto = "http";
+  let host = raw;
+  if (/^https:\/\//i.test(raw)) {
+    proto = "https";
+    host = raw.replace(/^https:\/\//i, "");
+  } else if (/^http:\/\//i.test(raw)) {
+    proto = "http";
+    host = raw.replace(/^http:\/\//i, "");
+  } else {
+    proto = looksLikeIpv4(raw) ? "http" : "https";
+  }
+  
+  host = host.split("/")[0].split("?")[0].split("#")[0].trim();
   if (!host) return null;
+  
   const path = normalizePublicBasePath(publicBasePath || "/");
-  const proto = looksLikeIpv4(host) ? "http" : "https";
   const origin = `${proto}://${host}`;
   return path === "/" ? origin : `${origin}${path}`;
 }

--- a/dashboard/src/pages/Overview.tsx
+++ b/dashboard/src/pages/Overview.tsx
@@ -445,7 +445,15 @@ export function Overview() {
                         </div>
                       ) : null}
                       <div className="text-xs text-muted-foreground">
-                        <span className="font-mono">{p.repoUrl.replace(/^https?:\/\/(www\.)?/, "")}</span>
+                        <a
+                          href={/^https?:\/\//i.test(p.repoUrl) ? p.repoUrl : `https://${p.repoUrl}`}
+                          target="_blank"
+                          rel="noreferrer"
+                          onClick={(e) => e.stopPropagation()}
+                          className="font-mono hover:text-primary hover:underline"
+                        >
+                          {p.repoUrl.replace(/^https?:\/\/(www\.)?/, "")}
+                        </a>
                       </div>
 
                       <div className="space-y-2">

--- a/dashboard/src/pages/ProjectDetail.tsx
+++ b/dashboard/src/pages/ProjectDetail.tsx
@@ -217,8 +217,11 @@ export function ProjectDetail() {
           ? "ROLLED_BACK"
           : "PENDING";
 
-  const liveHostPort = active ? active.port : project.basePort;
-  const liveUrl = publicServiceUrl(liveHostPort);
+  const liveHostPort = active ? active.port : null;
+  const liveUrl = liveHostPort ? publicServiceUrl(liveHostPort) : null;
+  const repoHref = /^https?:\/\//i.test(project.repoUrl)
+    ? project.repoUrl
+    : `https://${project.repoUrl}`;
   const totalDeploys = productionDeployments.length;
 
   return (
@@ -238,7 +241,7 @@ export function ProjectDetail() {
             <StatusBadge status={displayStatus} />
           </div>
           <a
-            href={project.repoUrl}
+            href={repoHref}
             target="_blank"
             rel="noreferrer"
             className="block font-mono text-xs text-muted-foreground hover:text-foreground"

--- a/dashboard/src/pages/Projects.tsx
+++ b/dashboard/src/pages/Projects.tsx
@@ -148,8 +148,7 @@ export function Projects() {
                   {slice.map((proj) => {
                     const state = projectDeploymentStatus(proj.id, deployments);
                     const disp = getDisplayDeployment(proj.id, deployments);
-                    const port = disp ? disp.port : proj.basePort;
-                    const url = publicServiceUrl(port);
+                    const url = disp ? publicServiceUrl(disp.port) : null;
                     const envLabel = disp ? guessEnvironmentLabel(proj, disp) : "—";
                     const jobId = latestJobByProject.get(proj.id);
                     return (
@@ -186,7 +185,7 @@ export function Projects() {
                         </TableCell>
                         <TableCell className="pr-6 text-right">
                           <div className="flex justify-end gap-2">
-                            {url ? (
+                            {url && disp ? (
                               <a
                                 href={url}
                                 target="_blank"
@@ -197,7 +196,7 @@ export function Projects() {
                                 )}
                               >
                                 <span>Open App</span>
-                                <span className="font-mono text-[10px] opacity-80">(:{disp?.port})</span>
+                                <span className="font-mono text-[10px] opacity-80">(:{disp.port})</span>
                               </a>
                             ) : null}
                             {jobId ? (


### PR DESCRIPTION
## Summary of Changes

* **Host Name Sanitization ()**:
  * Strips protocols (`http://`, `https://`), existing port declarations (`:9090`), request paths (`/projects/...`), and trailing slashes from raw public host input strings.
  * Updated `isLoopbackHostname`, `setConfiguredPublicHost`, `resolvePublicHostname`, and `publicServiceUrl` in `dashboard/src/lib/deployment-display.ts` to ensure generated app links produce clean, clickable URLs (e.g. `http://4.240.101.7:8000`) rather than invalid stacked URLs (e.g. `http://http://4.240.101.7:9090:8000`).
* **Public Dashboard URL Parser ()**:
  * Updated `formatPublicDashboardUrl` and `looksLikeIpv4` to handle explicit schemes and host formatting cleanly.
* **External Repository Link Formatting ( & )**:
  * Added automatic `https://` scheme formatting to repository links so external git repo URLs open in a new tab without triggering SPA route fallbacks.
* **Guarded Service Link Rendering ()**:
  * Guaranteed that `Open App` and service port links are only rendered when an active or in-progress display deployment exists for a project.

## Empirical Test Results

- **Backend Typecheck**: `bun run typecheck` passed cleanly (exit code 0)
- **Dashboard Production Build**: `bun run build:dashboard` passed cleanly (exit code 0)
- **Unit Tests**: `bun test` passed 20/20 unit tests cleanly