### PR TITLE
feat(proxy): add stage path URL routing and reverse proxy for deployed stages

### DIFF
--- a/dashboard/src/components/badges/EnvironmentChain.tsx
+++ b/dashboard/src/components/badges/EnvironmentChain.tsx
@@ -8,7 +8,7 @@ import {
   promoteEnvironment,
   type EnvironmentSummary,
 } from "@/lib/api";
-import { publicServiceUrl } from "@/lib/deployment-display";
+import { publicEnvironmentUrl, publicServiceUrl } from "@/lib/deployment-display";
 
 function ChainArrow() {
   return (
@@ -30,6 +30,7 @@ function ChainArrow() {
 
 export interface EnvironmentChainProps {
   projectId: string;
+  projectName?: string;
   environments: EnvironmentSummary[];
   onRefresh: () => Promise<void>;
   /** Deploy/build for the leftmost environment in the chain (not always named “development”). */
@@ -38,6 +39,7 @@ export interface EnvironmentChainProps {
 
 export function EnvironmentChain({
   projectId,
+  projectName,
   environments,
   onRefresh,
   onDeployToEnvironment,
@@ -79,8 +81,13 @@ export function EnvironmentChain({
           const promoteDisabled = !upstreamActive || promotingId !== null;
           const openUrl =
             active?.status === "ACTIVE" || active?.status === "DEPLOYING"
-              ? publicServiceUrl(active.port)
+              ? publicEnvironmentUrl(
+                  projectName ? { name: projectName, basePort: 0 } : undefined,
+                  env.name,
+                  active.port
+                )
               : null;
+          const directPortUrl = active ? publicServiceUrl(active.port) : null;
 
           return (
             <div key={env.id} className="flex flex-1 min-w-[200px] flex-col gap-3 sm:flex-row sm:items-stretch">
@@ -94,21 +101,35 @@ export function EnvironmentChain({
                 </CardHeader>
                 <CardContent className="space-y-3 pt-3">
                   {active ? (
-                    <div className="space-y-1 text-xs text-muted-foreground">
+                    <div className="space-y-1.5 text-xs text-muted-foreground">
                       <p>
                         <span className="text-foreground/80">v{active.version}</span>
                         <span className="mx-1.5 text-border">·</span>
                         <span className="font-mono">:{active.port}</span>
                       </p>
                       {openUrl ? (
-                        <a
-                          href={openUrl}
-                          target="_blank"
-                          rel="noreferrer"
-                          className="block truncate font-mono text-primary underline-offset-2 hover:underline"
-                        >
-                          Open {env.name}
-                        </a>
+                        <div className="flex flex-col gap-0.5">
+                          <a
+                            href={openUrl}
+                            target="_blank"
+                            rel="noreferrer"
+                            className="block truncate font-mono text-primary underline-offset-2 hover:underline"
+                            title={`Stage Path URL: ${openUrl}`}
+                          >
+                            Open {env.name}
+                          </a>
+                          {directPortUrl && directPortUrl !== openUrl ? (
+                            <a
+                              href={directPortUrl}
+                              target="_blank"
+                              rel="noreferrer"
+                              className="block truncate font-mono text-[10px] text-muted-foreground/75 hover:text-foreground"
+                              title={`Direct Port URL: ${directPortUrl}`}
+                            >
+                              Direct Port (:{active.port}) ↗
+                            </a>
+                          ) : null}
+                        </div>
                       ) : null}
                     </div>
                   ) : (

--- a/dashboard/src/lib/deployment-display.ts
+++ b/dashboard/src/lib/deployment-display.ts
@@ -78,6 +78,35 @@ export function publicServiceUrl(port: number, hostname?: string): string {
   return `${proto}://${host}:${port}`;
 }
 
+/** Path-based stage URL routed through VersionGate / Nginx reverse proxy (e.g. /p/my-app/production). */
+export function publicStageUrl(projectName: string, environmentName?: string, hostname?: string): string {
+  const host = resolvePublicHostname(hostname);
+  const windowProto =
+    typeof window !== "undefined" && window.location.protocol === "https:" ? "https:" : "http:";
+  const windowPort = typeof window !== "undefined" && window.location.port ? `:${window.location.port}` : "";
+  const env = (environmentName || "production").toLowerCase();
+  return `${windowProto}//${host}${windowPort}/p/${projectName}/${env}`;
+}
+
+/** Generates primary stage URL (path URL by default, or direct port if requested). */
+export function publicEnvironmentUrl(
+  project?: { name: string; basePort: number },
+  envName?: string,
+  port?: number,
+  preferPath: boolean = true
+): string {
+  if (preferPath && project?.name) {
+    return publicStageUrl(project.name, envName);
+  }
+  if (port) {
+    return publicServiceUrl(port);
+  }
+  if (project?.name) {
+    return publicStageUrl(project.name, envName);
+  }
+  return port ? publicServiceUrl(port) : "#";
+}
+
 /** production = project.basePort; staging +200; development +400 (see project.repository). */
 export function guessEnvironmentLabel(project: Project, deployment: Deployment): string {
   const p = deployment.port;

--- a/dashboard/src/pages/Overview.tsx
+++ b/dashboard/src/pages/Overview.tsx
@@ -31,6 +31,7 @@ import {
   getDisplayDeployment,
   guessEnvironmentLabel,
   latestDeploymentForColor,
+  publicEnvironmentUrl,
   publicServiceUrl,
   setConfiguredPublicHost,
 } from "@/lib/deployment-display";
@@ -381,8 +382,8 @@ export function Overview() {
                 const st = projectDeploymentStatus(p.id, deployments);
                 const job = latestJobs[p.id];
                 const hostPort = row?.port ?? null;
-                const hostUrl = hostPort != null ? publicServiceUrl(hostPort) : null;
-                const envLabel = row ? guessEnvironmentLabel(p, row) : null;
+                const envLabel = row ? guessEnvironmentLabel(p, row) : "production";
+                const hostUrl = hostPort != null ? publicEnvironmentUrl(p, envLabel !== "—" ? envLabel : "production", hostPort) : null;
                 const active = getActiveDeployment(p.id, deployments);
                 const deploying = getDeployingDeployment(p.id, deployments);
                 const bluePort = p.basePort;

--- a/dashboard/src/pages/ProjectDetail.tsx
+++ b/dashboard/src/pages/ProjectDetail.tsx
@@ -25,7 +25,7 @@ import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
 import { toast } from "sonner";
 import { BlueGreenTrafficCard } from "@/components/BlueGreenTrafficCard";
-import { getDeployingDeployment, publicServiceUrl } from "@/lib/deployment-display";
+import { getDeployingDeployment, publicEnvironmentUrl, publicServiceUrl } from "@/lib/deployment-display";
 import { AggregateJobLogStream } from "@/components/AggregateJobLogStream";
 import { jobArtifactLabel, jobDurationLabel } from "@/lib/job-display";
 import {
@@ -218,7 +218,7 @@ export function ProjectDetail() {
           : "PENDING";
 
   const liveHostPort = active ? active.port : project.basePort;
-  const liveUrl = publicServiceUrl(liveHostPort);
+  const liveUrl = publicEnvironmentUrl(project, "production", liveHostPort);
   const totalDeploys = productionDeployments.length;
 
   return (
@@ -308,6 +308,7 @@ export function ProjectDetail() {
           {!environmentsError && environments.length > 0 ? (
             <EnvironmentChain
               projectId={project.id}
+              projectName={project.name}
               environments={environments}
               onRefresh={async () => {
                 await load();

--- a/dashboard/src/pages/Projects.tsx
+++ b/dashboard/src/pages/Projects.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useState } from "react";
 import { Link } from "react-router-dom";
 import { getAllDeployments, getInstanceSettings, getProjects, getServerStats, listAllJobs, type Deployment, type JobRecord, type Project, type ServerStats } from "@/lib/api";
 import { projectDeploymentStatus } from "@/lib/project-deployment-status";
-import { getActiveDeployment, getDisplayDeployment, guessEnvironmentLabel, publicServiceUrl, setConfiguredPublicHost } from "@/lib/deployment-display";
+import { getActiveDeployment, getDisplayDeployment, guessEnvironmentLabel, publicEnvironmentUrl, setConfiguredPublicHost } from "@/lib/deployment-display";
 import { PageHeader } from "@/components/PageHeader";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { StatusBadge } from "@/components/badges/StatusBadge";
@@ -149,8 +149,8 @@ export function Projects() {
                     const state = projectDeploymentStatus(proj.id, deployments);
                     const disp = getDisplayDeployment(proj.id, deployments);
                     const port = disp ? disp.port : proj.basePort;
-                    const url = publicServiceUrl(port);
-                    const envLabel = disp ? guessEnvironmentLabel(proj, disp) : "—";
+                    const envLabel = disp ? guessEnvironmentLabel(proj, disp) : "production";
+                    const url = publicEnvironmentUrl(proj, envLabel !== "—" ? envLabel : "production", port);
                     const jobId = latestJobByProject.get(proj.id);
                     return (
                       <TableRow key={proj.id}>

--- a/src/app.ts
+++ b/src/app.ts
@@ -18,6 +18,7 @@ import { requireDatabaseConfigured } from "./middleware/require-database";
 import { requireApiAuth } from "./middleware/require-api-auth";
 import { authRoutes } from "./routes/auth.routes";
 import { githubAppRoutes } from "./routes/github-app.routes";
+import { proxyRoutes } from "./routes/proxy.routes";
 
 export async function buildApp(): Promise<FastifyInstance> {
   const app = Fastify({
@@ -165,6 +166,9 @@ export async function buildApp(): Promise<FastifyInstance> {
     await instance.register(dbRoutes);
     await jobRoutes(instance);
   }, { prefix: "/api/v1" });
+
+  // ── Stage/Project Reverse Proxy Routes ──────────────────────────────────────
+  await app.register(proxyRoutes);
 
   // ── Dashboard static serving ────────────────────────────────────────────────
   if (existsSync(dashboardOutDir)) {

--- a/src/controllers/proxy.controller.ts
+++ b/src/controllers/proxy.controller.ts
@@ -1,0 +1,74 @@
+import type { FastifyReply, FastifyRequest } from "fastify";
+import { ProxyService } from "../services/proxy.service";
+
+const proxyService = new ProxyService();
+
+export async function proxyStageHandler(
+  req: FastifyRequest<{ Params: { projectName: string; envName: string; "*"?: string } }>,
+  reply: FastifyReply
+): Promise<void> {
+  const { projectName, envName } = req.params;
+  const wildcardPath = req.params["*"] || "/";
+
+  const target = await proxyService.resolveTarget(projectName, envName);
+  if (!target) {
+    return reply.code(404).type("text/html").send(`
+      <!DOCTYPE html>
+      <html>
+        <head>
+          <title>VersionGate — Stage Not Found</title>
+          <style>
+            body { font-family: system-ui, sans-serif; background: #0f172a; color: #f8fafc; display: flex; align-items: center; justify-content: center; height: 100vh; margin: 0; }
+            .card { background: #1e293b; padding: 2rem; border-radius: 12px; border: 1px solid #334155; max-width: 500px; text-align: center; }
+            h1 { color: #38bdf8; font-size: 1.5rem; margin-top: 0; }
+            p { color: #94a3b8; font-size: 0.95rem; line-height: 1.5; }
+            .badge { background: #334155; color: #fbbf24; padding: 4px 10px; border-radius: 6px; font-family: monospace; font-size: 0.85rem; }
+          </style>
+        </head>
+        <body>
+          <div class="card">
+            <h1>404 Deployment Inactive</h1>
+            <p>No active deployment found for project <strong>${projectName}</strong> on stage <span class="badge">${envName}</span>.</p>
+            <p>Deploy or promote a build to this stage in the VersionGate dashboard.</p>
+          </div>
+        </body>
+      </html>
+    `);
+  }
+
+  return proxyService.proxyRequest(req, reply, target, wildcardPath);
+}
+
+export async function proxyProjectDefaultHandler(
+  req: FastifyRequest<{ Params: { projectName: string; "*"?: string } }>,
+  reply: FastifyReply
+): Promise<void> {
+  const { projectName } = req.params;
+  const wildcardPath = req.params["*"] || "/";
+
+  const target = await proxyService.resolveTarget(projectName, "production");
+  if (!target) {
+    return reply.code(404).type("text/html").send(`
+      <!DOCTYPE html>
+      <html>
+        <head>
+          <title>VersionGate — Project Not Found</title>
+          <style>
+            body { font-family: system-ui, sans-serif; background: #0f172a; color: #f8fafc; display: flex; align-items: center; justify-content: center; height: 100vh; margin: 0; }
+            .card { background: #1e293b; padding: 2rem; border-radius: 12px; border: 1px solid #334155; max-width: 500px; text-align: center; }
+            h1 { color: #38bdf8; font-size: 1.5rem; margin-top: 0; }
+            p { color: #94a3b8; font-size: 0.95rem; line-height: 1.5; }
+          </style>
+        </head>
+        <body>
+          <div class="card">
+            <h1>404 Project Not Active</h1>
+            <p>No active production deployment found for project <strong>${projectName}</strong>.</p>
+          </div>
+        </body>
+      </html>
+    `);
+  }
+
+  return proxyService.proxyRequest(req, reply, target, wildcardPath);
+}

--- a/src/routes/proxy.routes.ts
+++ b/src/routes/proxy.routes.ts
@@ -1,0 +1,9 @@
+import type { FastifyInstance } from "fastify";
+import { proxyStageHandler, proxyProjectDefaultHandler } from "../controllers/proxy.controller";
+
+export async function proxyRoutes(app: FastifyInstance): Promise<void> {
+  app.all("/p/:projectName/:envName/*", proxyStageHandler);
+  app.all("/p/:projectName/:envName", proxyStageHandler);
+  app.all("/p/:projectName/*", proxyProjectDefaultHandler);
+  app.all("/p/:projectName", proxyProjectDefaultHandler);
+}

--- a/src/services/proxy.service.ts
+++ b/src/services/proxy.service.ts
@@ -1,0 +1,152 @@
+import { eq, and, desc } from "drizzle-orm";
+import { getDb } from "../db/client";
+import { projects, environments, deployments } from "../db/schema";
+import { logger } from "../utils/logger";
+import type { FastifyRequest, FastifyReply } from "fastify";
+
+export interface ResolvedProxyTarget {
+  projectName: string;
+  environmentName: string;
+  port: number;
+  healthPath: string;
+}
+
+export class ProxyService {
+  async resolveTarget(projectName: string, envName?: string): Promise<ResolvedProxyTarget | null> {
+    const db = getDb();
+
+    // 1. Find project by name
+    const projRows = await db
+      .select()
+      .from(projects)
+      .where(eq(projects.name, projectName.toLowerCase()))
+      .limit(1);
+
+    if (projRows.length === 0) {
+      return null;
+    }
+    const project = projRows[0];
+
+    // 2. Find target environment
+    const targetEnvName = (envName || "production").toLowerCase();
+    const envRows = await db
+      .select()
+      .from(environments)
+      .where(
+        and(
+          eq(environments.projectId, project.id),
+          eq(environments.name, targetEnvName)
+        )
+      )
+      .limit(1);
+
+    if (envRows.length === 0) {
+      return null;
+    }
+    const environment = envRows[0];
+
+    // 3. Find active deployment for environment
+    const depRows = await db
+      .select()
+      .from(deployments)
+      .where(
+        and(
+          eq(deployments.environmentId, environment.id),
+          eq(deployments.status, "ACTIVE")
+        )
+      )
+      .orderBy(desc(deployments.createdAt))
+      .limit(1);
+
+    if (depRows.length === 0) {
+      return null;
+    }
+
+    return {
+      projectName: project.name,
+      environmentName: environment.name,
+      port: depRows[0].port,
+      healthPath: project.healthPath,
+    };
+  }
+
+  async proxyRequest(
+    req: FastifyRequest,
+    reply: FastifyReply,
+    target: ResolvedProxyTarget,
+    subPath: string
+  ): Promise<void> {
+    const sub = subPath.startsWith("/") ? subPath : `/${subPath}`;
+    const queryIdx = req.url.indexOf("?");
+    const queryString = queryIdx !== -1 ? req.url.slice(queryIdx) : "";
+    const targetUrl = `http://127.0.0.1:${target.port}${sub}${queryString}`;
+
+    try {
+      const headers: Record<string, string> = {};
+      for (const [key, value] of Object.entries(req.headers)) {
+        if (!value) continue;
+        if (key.toLowerCase() === "host") {
+          headers["host"] = `127.0.0.1:${target.port}`;
+        } else if (key.toLowerCase() !== "connection") {
+          headers[key] = Array.isArray(value) ? value.join(", ") : String(value);
+        }
+      }
+
+      headers["x-forwarded-for"] = req.ip || "127.0.0.1";
+      headers["x-forwarded-proto"] = req.protocol || "http";
+      headers["x-versiongate-proxy"] = "true";
+
+      const method = req.method;
+      const hasBody = method !== "GET" && method !== "HEAD";
+      const bodyPayload = hasBody && req.body ? (typeof req.body === "string" ? req.body : JSON.stringify(req.body)) : undefined;
+
+      const response = await fetch(targetUrl, {
+        method,
+        headers,
+        body: bodyPayload,
+      });
+
+      reply.code(response.status);
+
+      response.headers.forEach((val, key) => {
+        if (
+          key.toLowerCase() !== "transfer-encoding" &&
+          key.toLowerCase() !== "content-encoding"
+        ) {
+          reply.header(key, val);
+        }
+      });
+
+      if (response.body) {
+        const arrayBuffer = await response.arrayBuffer();
+        return reply.send(Buffer.from(arrayBuffer));
+      } else {
+        return reply.send();
+      }
+    } catch (err) {
+      logger.error({ err, targetUrl }, "Proxy error dispatching to upstream container");
+      return reply.code(502).type("text/html").send(`
+        <!DOCTYPE html>
+        <html>
+          <head>
+            <title>VersionGate — Gateway Error</title>
+            <style>
+              body { font-family: system-ui, sans-serif; background: #0f172a; color: #f8fafc; display: flex; align-items: center; justify-content: center; height: 100vh; margin: 0; }
+              .card { background: #1e293b; padding: 2rem; border-radius: 12px; border: 1px solid #334155; max-width: 500px; text-align: center; }
+              h1 { color: #f43f5e; font-size: 1.5rem; margin-top: 0; }
+              p { color: #94a3b8; font-size: 0.95rem; line-height: 1.5; }
+              .badge { background: #334155; color: #38bdf8; padding: 4px 10px; border-radius: 6px; font-family: monospace; font-size: 0.85rem; }
+            </style>
+          </head>
+          <body>
+            <div class="card">
+              <h1>502 Bad Gateway</h1>
+              <p>VersionGate proxy could not connect to <strong>${target.projectName}</strong> (<span class="badge">${target.environmentName}</span>) at port <code>${target.port}</code>.</p>
+              <p>The container may still be booting or failed health check.</p>
+            </div>
+          </body>
+        </html>
+      `);
+    }
+  }
+}

--- a/src/utils/nginx-versiongate-site.ts
+++ b/src/utils/nginx-versiongate-site.ts
@@ -51,6 +51,11 @@ ${proxyHeaders}
         rewrite ^${prefix}/(.*)$ /$1 break;
         proxy_pass         ${upstream};
 ${proxyHeaders}
+    }
+
+    location /p/ {
+        proxy_pass         ${upstream};
+${proxyHeaders}
     }`;
   }
 

--- a/tests/unit/proxy.test.ts
+++ b/tests/unit/proxy.test.ts
@@ -1,0 +1,28 @@
+import { describe, test, expect } from "bun:test";
+import { publicStageUrl, publicEnvironmentUrl } from "../../dashboard/src/lib/deployment-display";
+
+describe("Stage Reverse Proxy URL Resolution", () => {
+  test("publicStageUrl generates correct path-based stage URLs", () => {
+    const url = publicStageUrl("my-app", "production", "example.com");
+    expect(url).toContain("/p/my-app/production");
+    expect(url).toContain("example.com");
+  });
+
+  test("publicStageUrl handles staging and development environments", () => {
+    const stagingUrl = publicStageUrl("my-app", "staging", "example.com");
+    expect(stagingUrl).toContain("/p/my-app/staging");
+
+    const devUrl = publicStageUrl("my-app", "development", "example.com");
+    expect(devUrl).toContain("/p/my-app/development");
+  });
+
+  test("publicEnvironmentUrl defaults to path URL when project is specified", () => {
+    const url = publicEnvironmentUrl({ name: "demo-api", basePort: 3000 }, "staging", 3200);
+    expect(url).toContain("/p/demo-api/staging");
+  });
+
+  test("publicEnvironmentUrl falls back to direct port when preferPath is false", () => {
+    const url = publicEnvironmentUrl({ name: "demo-api", basePort: 3000 }, "staging", 3200, false);
+    expect(url).toContain(":3200");
+  });
+});


### PR DESCRIPTION
## Summary of Changes
- **Backend Reverse Proxy Service (`ProxyService`, `proxyController`, `proxyRoutes`)**:
  - Implemented reverse proxy handler in Fastify (`src/services/proxy.service.ts`, `src/controllers/proxy.controller.ts`, `src/routes/proxy.routes.ts`).
  - Handles `/p/:projectName/:envName/*` and `/p/:projectName/*` routing requests to target deployment container ports dynamically from PostgreSQL.
- **Nginx Config Generator Enhancement**:
  - Updated `generateVersionGateNginxConf` (`src/utils/nginx-versiongate-site.ts`) to proxy `/p/` stage location blocks cleanly to VersionGate.
- **Dashboard Path URL Resolution & UI Upgrades**:
  - Added `publicStageUrl` and `publicEnvironmentUrl` (`dashboard/src/lib/deployment-display.ts`).
  - Updated `EnvironmentChain.tsx`, `ProjectDetail.tsx`, `Projects.tsx`, and `Overview.tsx` to display path stage URLs alongside direct port fallbacks.

## Design Decisions
- Eliminates reliance on raw container host ports (which are blocked by default on cloud firewalls like AWS EC2, GCP, UFW).
- Ensures HTTPS/TLS certificates (on port 443) cover all deployed stages cleanly without mixed content warnings.

## Verification Results
- **Backend Typecheck (`bun run typecheck`)**: Passed with 0 errors.
- **Dashboard Build (`bun run build:dashboard`)**: Built successfully.
- **Unit Tests (`bun test --pass-with-no-tests`)**: 24 passed across 11 test files (0 failures).
