### PR TITLE
fix(website): serve universal installer script at install.sh route

### DIFF
--- a/website/public/install.sh
+++ b/website/public/install.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+# Universal One-Line Installer for VersionGate (Ubuntu/Debian/RHEL).
+# Installs base tools, Bun, Docker, configures firewall ports, builds dashboard,
+# and starts the VersionGate engine in Setup Mode on port 9090.
+#
+# Usage on a fresh VM:
+#   curl -fsSL https://versiongate.tech/install.sh | bash
+#   or locally: bash install.sh
+#
+set -euo pipefail
+
+log()  { printf '\n==> %s\n' "$*"; }
+ok()   { printf '  [ok] %s\n' "$*"; }
+warn() { printf '  [!]  %s\n' "$*"; }
+die()  { printf '  [NO] %s\n' "$*" >&2; exit 1; }
+
+REAL_USER="${SUDO_USER:-${USER:-}}"
+if [[ -z "$REAL_USER" || "$REAL_USER" == "root" ]]; then
+  REAL_USER="$(logname 2>/dev/null || echo root)"
+fi
+REAL_HOME="$(getent passwd "$REAL_USER" 2>/dev/null | cut -d: -f6 || echo /root)"
+
+if [[ "$(id -u)" -ne 0 ]]; then
+  if command -v sudo >/dev/null 2>&1; then
+    exec sudo -E bash "$0" "$@"
+  fi
+  die "Run with sudo: sudo bash install.sh"
+fi
+
+log "1. System Base Packages (curl, git, unzip, ca-certificates, tar)"
+if command -v apt-get >/dev/null 2>&1; then
+  export DEBIAN_FRONTEND=noninteractive
+  apt-get update -y
+  apt-get install -y --no-install-recommends \
+    ca-certificates curl git gnupg lsb-release apt-transport-https unzip tar
+elif command -v dnf >/dev/null 2>&1; then
+  dnf install -y curl git unzip ca-certificates tar
+elif command -v yum >/dev/null 2>&1; then
+  yum install -y curl git unzip ca-certificates tar
+fi
+ok "Base dependencies verified"
+
+log "2. Bun Runtime"
+if command -v bun >/dev/null 2>&1; then
+  ok "Bun already installed: $(bun --version)"
+elif [[ -x "$REAL_HOME/.bun/bin/bun" ]]; then
+  ok "Bun found at $REAL_HOME/.bun/bin/bun"
+else
+  log "Installing Bun for $REAL_USER"
+  sudo -u "$REAL_USER" -H bash -lc 'curl -fsSL https://bun.sh/install | bash' || true
+  export PATH="$REAL_HOME/.bun/bin:$PATH"
+  ok "Bun runtime installed"
+fi
+
+log "3. Docker Engine"
+if command -v docker >/dev/null 2>&1 && docker info >/dev/null 2>&1; then
+  ok "Docker already running"
+else
+  log "Installing Docker Engine"
+  curl -fsSL https://get.docker.com | sh || true
+  systemctl enable --now docker || true
+  ok "Docker Engine installed"
+fi
+
+groupadd -f docker || true
+if id "$REAL_USER" >/dev/null 2>&1; then
+  usermod -aG docker "$REAL_USER" || true
+fi
+
+DOCKER_NET="versiongate-net"
+if docker network inspect "$DOCKER_NET" >/dev/null 2>&1; then
+  ok "Docker network $DOCKER_NET exists"
+else
+  docker network create "$DOCKER_NET" || true
+  ok "Created docker network $DOCKER_NET"
+fi
+
+PROJECTS_DIR="/var/versiongate/projects"
+mkdir -p "$PROJECTS_DIR"
+chown -R "$REAL_USER:$REAL_USER" "$PROJECTS_DIR" 2>/dev/null || true
+chmod 755 "$PROJECTS_DIR"
+ok "Projects directory ready: $PROJECTS_DIR"
+
+log "4. Host Firewall Configuration (UFW / Firewalld)"
+if command -v ufw >/dev/null 2>&1; then
+  ufw allow 9090/tcp comment 'VersionGate API' 2>/dev/null || true
+  ufw allow 5173/tcp comment 'VersionGate Dashboard' 2>/dev/null || true
+  ufw allow 80/tcp comment 'HTTP Web' 2>/dev/null || true
+  ufw allow 443/tcp comment 'HTTPS Web' 2>/dev/null || true
+  ok "Configured UFW rules for ports 9090, 5173, 80, 443"
+elif command -v firewall-cmd >/dev/null 2>&1; then
+  firewall-cmd --permanent --add-port=9090/tcp --add-port=5173/tcp --add-port=80/tcp --add-port=443/tcp 2>/dev/null || true
+  firewall-cmd --reload 2>/dev/null || true
+  ok "Configured Firewalld rules for ports 9090, 5173, 80, 443"
+fi
+
+log "5. Repository Setup & Dependencies"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [[ ! -f "$SCRIPT_DIR/package.json" ]]; then
+  TARGET_DIR="$REAL_HOME/VersionGate"
+  if [[ ! -d "$TARGET_DIR" ]]; then
+    sudo -u "$REAL_USER" git clone https://github.com/dineshkorukonda/VersionGate.git "$TARGET_DIR"
+  fi
+  cd "$TARGET_DIR"
+else
+  cd "$SCRIPT_DIR"
+fi
+
+sudo -u "$REAL_USER" -H bash -lc "export PATH=\"$REAL_HOME/.bun/bin:\$PATH\"; bun install"
+sudo -u "$REAL_USER" -H bash -lc "export PATH=\"$REAL_HOME/.bun/bin:\$PATH\"; cd dashboard && bun install && bun run build"
+
+log "6. Starting VersionGate Engine in Setup Mode"
+if ! command -v pm2 >/dev/null 2>&1; then
+  npm install -g pm2 || true
+fi
+
+sudo -u "$REAL_USER" -H bash -lc "export PATH=\"$REAL_HOME/.bun/bin:\$PATH\"; pm2 start ecosystem.config.cjs 2>/dev/null || pm2 restart versiongate-api 2>/dev/null || true"
+
+SERVER_IP="$(curl -s https://api.ipify.org 2>/dev/null || echo 'YOUR_VM_IP')"
+
+echo ""
+echo "============================================================"
+echo " [ OK ] VersionGate Host Installation Complete!"
+echo "============================================================"
+echo ""
+echo " Open your browser to complete setup:"
+echo "   http://${SERVER_IP}:9090/setup"
+echo ""
+echo " (If using domain/HTTPS, configure DNS A record to ${SERVER_IP})"
+echo "============================================================"
+echo ""

--- a/website/src/app/changelog/page.tsx
+++ b/website/src/app/changelog/page.tsx
@@ -81,6 +81,13 @@ const FALLBACK_RELEASES: ProcessedRelease[] = [
             prNumber: 119,
             prLink: "https://github.com/dineshkorukonda/VersionGate/pull/119",
           },
+          {
+            title: "Universal One-Line Host Installer Endpoint",
+            description: "Direct host endpoint serving install.sh at versiongate.tech/install.sh for automated zero-downtime VM setup.",
+            command: "curl -fsSL https://versiongate.tech/install.sh | bash",
+            prNumber: 135,
+            prLink: "https://github.com/dineshkorukonda/VersionGate/pull/135",
+          },
         ],
       },
     ],

--- a/website/src/app/install.sh/route.ts
+++ b/website/src/app/install.sh/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from "next/server";
+import fs from "node:fs";
+import path from "node:path";
+
+export async function GET() {
+  const publicPath = path.join(process.cwd(), "public", "install.sh");
+  const rootPath = path.join(process.cwd(), "..", "install.sh");
+
+  let scriptContent = "";
+  if (fs.existsSync(publicPath)) {
+    scriptContent = fs.readFileSync(publicPath, "utf-8");
+  } else if (fs.existsSync(rootPath)) {
+    scriptContent = fs.readFileSync(rootPath, "utf-8");
+  } else {
+    return new NextResponse("Installer script not found", { status: 404 });
+  }
+
+  return new NextResponse(scriptContent, {
+    status: 200,
+    headers: {
+      "Content-Type": "text/x-shellscript; charset=utf-8",
+      "Cache-Control": "public, max-age=3600",
+    },
+  });
+}

--- a/website/src/components/capability-grid.tsx
+++ b/website/src/components/capability-grid.tsx
@@ -76,6 +76,15 @@ const CAPABILITIES: Capability[] = [
     details: "Central relay fans out push webhooks securely with HMAC SHA-256 signatures; Custom Manifest mode builds self-hosted apps in 1-click.",
     badge: "v1.4 Feature",
   },
+  {
+    id: "cap-installer",
+    category: "Deployment",
+    title: "Universal One-Line Host Installer",
+    command: "curl -fsSL https://versiongate.tech/install.sh | bash",
+    description: "Automated VM bootstrap installing base packages, Bun, Docker, UFW firewall rules, and launching Setup Mode.",
+    details: "Downloads install.sh from versiongate.tech to configure Docker daemon networking, host firewall rules for ports 9090, 5173, 80, and 443, and initialize VersionGate in setup mode.",
+    badge: "v1.4 Feature",
+  },
 ];
 
 export function CapabilityGrid() {


### PR DESCRIPTION
## Summary

Fixes HTTP 404 error when running `curl -fsSL https://versiongate.tech/install.sh | bash`.

### Changes Included
- Added static file asset `website/public/install.sh`.
- Created Next.js API route handler `website/src/app/install.sh/route.ts` to serve the shell installer with proper headers (`Content-Type: text/x-shellscript; charset=utf-8`).
- Updated landing page capability grid (`website/src/components/capability-grid.tsx`) and release changelog (`website/src/app/changelog/page.tsx`).

### Verification & Testing
- Backend Typecheck: `bun run typecheck` [ OK ]
- Dashboard Build: `bun run build:dashboard` [ OK ]
- Website Typecheck: `cd website && bunx tsc --noEmit` [ OK ]
- Test Suite: `bun test --pass-with-no-tests` [ OK ] (28/28 passed)