### PR TITLE
fix(github-app): Central Relay mode fixes, manual Installation ID sync & Integrations UI reorganization

### DIFF
--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -547,6 +547,19 @@ export function getGithubInstallation(): Promise<GithubInstallationGateResponse>
   return request("GET", "/github/installation", undefined, githubApiBase());
 }
 
+export function linkGithubInstallation(installationId: string): Promise<{
+  success: boolean;
+  installationId: string;
+  githubAccountLogin: string;
+}> {
+  return request<{ success: boolean; installationId: string; githubAccountLogin: string }>(
+    "POST",
+    "/github/installation/link",
+    { installationId },
+    githubApiBase()
+  );
+}
+
 export function getGithubIntegrationStatus(): Promise<GithubIntegrationStatus> {
   return request("GET", "/github/status", undefined, githubApiBase());
 }

--- a/dashboard/src/pages/Integrations.tsx
+++ b/dashboard/src/pages/Integrations.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import { Link, useSearchParams } from "react-router-dom";
-import { Cable, ExternalLink } from "lucide-react";
+import { Cable, Code2, ExternalLink, RefreshCw } from "lucide-react";
 import { toast } from "sonner";
 import { PageHeader } from "@/components/PageHeader";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
@@ -37,20 +37,22 @@ export function Integrations() {
   const [avatarUrl, setAvatarUrl] = useState<string | null>(null);
   const [manualId, setManualId] = useState("");
   const [linking, setLinking] = useState(false);
+  const [checking, setChecking] = useState(false);
 
   const fetchStatus = async () => {
-    setGateReady(false);
-    setGateError(null);
+    setChecking(true);
     try {
       const r = await getGithubInstallation();
       setPrimaryInstallation(r.installation);
       setInstallationsList(r.installations);
+      setGateError(null);
     } catch (e) {
       setGateError(e instanceof ApiError ? e.message : "Failed to load GitHub installation.");
       setPrimaryInstallation(null);
       setInstallationsList([]);
     } finally {
       setGateReady(true);
+      setChecking(false);
     }
   };
 
@@ -161,39 +163,39 @@ export function Integrations() {
       />
 
       <Alert className="border-border bg-muted">
-        <AlertTitle className="font-mono text-xs uppercase tracking-wider">Connect only — one official App</AlertTitle>
+        <AlertTitle className="font-mono text-xs uppercase tracking-wider">Primary Integration Mode — Central Cloud Relay</AlertTitle>
         <AlertDescription className="space-y-2 text-muted-foreground [&_p]:text-sm">
           <p>
-            Install the shared <strong className="text-foreground">VersionGate</strong> GitHub App on your account or org.
-            You do <strong className="text-foreground">not</strong> create your own App. Push webhooks go to the public relay,
-            which routes deploys to this instance.
+            VersionGate uses zero-config <strong className="text-foreground">Central Cloud Relay Mode</strong> via{" "}
+            <code className="font-mono text-xs text-foreground">versiongate.tech</code>. You do <strong className="text-foreground">not</strong> need to create a custom GitHub App.
           </p>
-          <p className="font-mono text-[10px] uppercase tracking-wider text-muted-foreground">Webhook (fixed)</p>
+          <p className="font-mono text-[10px] uppercase tracking-wider text-muted-foreground">Relay Webhook URL (fixed)</p>
           <code className="block max-w-full overflow-x-auto break-all border border-border bg-background px-2 py-1.5 font-mono text-xs text-foreground">
             {webhookUrlHint}
           </code>
-          <p className="font-mono text-[10px] uppercase tracking-wider text-muted-foreground">Install callback (fixed)</p>
+          <p className="font-mono text-[10px] uppercase tracking-wider text-muted-foreground">Relay Callback URL (fixed)</p>
           <code className="block max-w-full overflow-x-auto break-all border border-border bg-background px-2 py-1.5 font-mono text-xs text-foreground">
             {GITHUB_APP_RELAY_CALLBACK}
           </code>
-          <p>
-            This server needs <span className="font-mono text-xs">PUBLIC_URL</span>, shared App credentials, and{" "}
-            <span className="font-mono text-xs">GITHUB_STATE_SECRET</span> matching the relay. Then use{" "}
-            <strong className="text-foreground">Connect GitHub</strong> while signed in.
-          </p>
         </AlertDescription>
       </Alert>
 
+      {/* Main GitHub Integration Card (Central Relay Mode) */}
       <Card>
         <CardHeader>
           <div className="flex items-start justify-between gap-4">
             <div className="space-y-1">
-              <CardTitle className="flex items-center gap-2 text-lg">
-                <Cable className="size-5 opacity-80" aria-hidden />
-                GitHub
-              </CardTitle>
+              <div className="flex items-center gap-2">
+                <CardTitle className="flex items-center gap-2 text-lg">
+                  <Cable className="size-5 opacity-80" aria-hidden />
+                  GitHub Integration
+                </CardTitle>
+                <Badge variant="outline" className="font-mono text-[10px] uppercase tracking-wider">
+                  Primary // Relay
+                </Badge>
+              </div>
               <CardDescription>
-                Install the VersionGate GitHub App to list repositories and deploy on push.
+                Install the official VersionGate GitHub App to connect your repositories and enable automated git push deploys.
               </CardDescription>
             </div>
           </div>
@@ -290,9 +292,22 @@ export function Integrations() {
                 <p className="text-sm text-muted-foreground">
                   Connect your GitHub account or organization so VersionGate can read repositories you grant access to.
                 </p>
-                <a href={INSTALL_HREF} className={cn(buttonVariants())}>
-                  Connect GitHub
-                </a>
+                <div className="flex flex-wrap gap-2">
+                  <a href={INSTALL_HREF} className={cn(buttonVariants())}>
+                    Connect GitHub
+                  </a>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    disabled={checking}
+                    onClick={() => void fetchStatus()}
+                    className="inline-flex gap-1.5"
+                  >
+                    <RefreshCw className={cn("size-3.5", checking && "animate-spin")} />
+                    Re-check
+                  </Button>
+                </div>
               </div>
             </div>
           )}
@@ -301,10 +316,10 @@ export function Integrations() {
           <div className="space-y-3 pt-1">
             <div>
               <p className="font-mono text-xs font-semibold uppercase tracking-wider text-foreground">
-                Already installed on GitHub? / Manual Sync
+                Already authorized on GitHub? / Manual Sync
               </p>
               <p className="mt-1 text-xs text-muted-foreground">
-                If GitHub stays on the settings page (<code className="font-mono text-[11px] text-foreground">github.com/settings/installations/123456</code>) after granting permissions, copy the numeric Installation ID from the address bar and sync it below:
+                If GitHub stays on the settings page (<code className="font-mono text-[11px] text-foreground">github.com/settings/installations/123456</code>) after granting permissions, copy the numeric Installation ID from your address bar and sync it below:
               </p>
             </div>
             <form onSubmit={handleManualLink} className="flex flex-wrap items-center gap-2">
@@ -320,6 +335,48 @@ export function Integrations() {
               </Button>
             </form>
           </div>
+        </CardContent>
+      </Card>
+
+      {/* Developer Settings Card — Custom Self-Hosted GitHub App Manifest (Advanced Mode) */}
+      <Card className="border-border/60 bg-card/50">
+        <CardHeader>
+          <div className="flex items-start justify-between gap-4">
+            <div className="space-y-1">
+              <div className="flex items-center gap-2">
+                <CardTitle className="flex items-center gap-2 text-base font-semibold">
+                  <Code2 className="size-4 opacity-80" aria-hidden />
+                  Developer Settings // Custom GitHub App Manifest
+                </CardTitle>
+                <Badge variant="secondary" className="font-mono text-[10px] uppercase tracking-wider">
+                  Advanced Mode
+                </Badge>
+              </div>
+              <CardDescription className="text-xs">
+                For isolated or enterprise environments: Create your own self-hosted GitHub App using 1-Click Manifest registration instead of the central cloud relay.
+              </CardDescription>
+            </div>
+          </div>
+        </CardHeader>
+        <CardContent className="space-y-4 font-mono text-xs">
+          <div className="rounded-md border border-border bg-muted/40 p-4 space-y-2">
+            <div className="flex items-center justify-between">
+              <span className="text-muted-foreground uppercase tracking-wider text-[11px]">Integration Mode</span>
+              <Badge variant="outline" className="font-mono text-xs">
+                {connected ? "Central Relay Active" : "Relay Standard Mode"}
+              </Badge>
+            </div>
+            <div className="flex items-center justify-between">
+              <span className="text-muted-foreground uppercase tracking-wider text-[11px]">GITHUB_APP_ID</span>
+              <span className="text-foreground font-mono">
+                {import.meta.env.VITE_GITHUB_APP_ID ? String(import.meta.env.VITE_GITHUB_APP_ID) : "[ Using Relay ]"}
+              </span>
+            </div>
+          </div>
+
+          <p className="text-xs text-muted-foreground font-sans">
+            To switch from Central Relay Mode to your own dedicated GitHub App, set <code className="font-mono text-[11px]">GITHUB_APP_ID</code> and <code className="font-mono text-[11px]">GITHUB_APP_PRIVATE_KEY</code> in your server <code className="font-mono text-[11px]">.env</code> file.
+          </p>
         </CardContent>
       </Card>
 

--- a/dashboard/src/pages/Integrations.tsx
+++ b/dashboard/src/pages/Integrations.tsx
@@ -11,10 +11,12 @@ import {
   ApiError,
   getGithubInstallation,
   getGithubIntegrationStatus,
+  linkGithubInstallation,
   type GithubInstallationSummary,
 } from "@/lib/api";
 import { Separator } from "@/components/ui/separator";
-import { buttonVariants } from "@/components/ui/button";
+import { Button, buttonVariants } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import { cn } from "@/lib/utils";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 
@@ -33,6 +35,24 @@ export function Integrations() {
   const [gateError, setGateError] = useState<string | null>(null);
 
   const [avatarUrl, setAvatarUrl] = useState<string | null>(null);
+  const [manualId, setManualId] = useState("");
+  const [linking, setLinking] = useState(false);
+
+  const fetchStatus = async () => {
+    setGateReady(false);
+    setGateError(null);
+    try {
+      const r = await getGithubInstallation();
+      setPrimaryInstallation(r.installation);
+      setInstallationsList(r.installations);
+    } catch (e) {
+      setGateError(e instanceof ApiError ? e.message : "Failed to load GitHub installation.");
+      setPrimaryInstallation(null);
+      setInstallationsList([]);
+    } finally {
+      setGateReady(true);
+    }
+  };
 
   useEffect(() => {
     let cancelled = false;
@@ -109,6 +129,26 @@ export function Integrations() {
     }
     setSearchParams({}, { replace: true });
   }, [githubQuery, setSearchParams]);
+
+  const handleManualLink = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const cleanId = manualId.trim();
+    if (!cleanId || !/^\d+$/.test(cleanId)) {
+      toast.error("Enter a valid numeric GitHub Installation ID (e.g. 67554316)");
+      return;
+    }
+    setLinking(true);
+    try {
+      const res = await linkGithubInstallation(cleanId);
+      toast.success(`GitHub Installation #${res.installationId} linked successfully!`);
+      setManualId("");
+      await fetchStatus();
+    } catch (err) {
+      toast.error(err instanceof ApiError ? err.message : "Failed to link installation ID.");
+    } finally {
+      setLinking(false);
+    }
+  };
 
   const connected = primaryInstallation !== null;
 
@@ -245,15 +285,41 @@ export function Integrations() {
               ) : null}
             </>
           ) : (
-            <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-              <p className="text-sm text-muted-foreground">
-                Connect your GitHub account or organization so VersionGate can read repositories you grant access to.
-              </p>
-              <a href={INSTALL_HREF} className={cn(buttonVariants())}>
-                Connect GitHub
-              </a>
+            <div className="space-y-6">
+              <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+                <p className="text-sm text-muted-foreground">
+                  Connect your GitHub account or organization so VersionGate can read repositories you grant access to.
+                </p>
+                <a href={INSTALL_HREF} className={cn(buttonVariants())}>
+                  Connect GitHub
+                </a>
+              </div>
             </div>
           )}
+
+          <Separator />
+          <div className="space-y-3 pt-1">
+            <div>
+              <p className="font-mono text-xs font-semibold uppercase tracking-wider text-foreground">
+                Already installed on GitHub? / Manual Sync
+              </p>
+              <p className="mt-1 text-xs text-muted-foreground">
+                If GitHub stays on the settings page (<code className="font-mono text-[11px] text-foreground">github.com/settings/installations/123456</code>) after granting permissions, copy the numeric Installation ID from the address bar and sync it below:
+              </p>
+            </div>
+            <form onSubmit={handleManualLink} className="flex flex-wrap items-center gap-2">
+              <Input
+                type="text"
+                placeholder="e.g. 67554316"
+                value={manualId}
+                onChange={(e) => setManualId(e.target.value)}
+                className="max-w-xs font-mono text-xs"
+              />
+              <Button type="submit" size="sm" variant="secondary" disabled={linking || !manualId.trim()}>
+                {linking ? "Syncing..." : "Sync Installation ID"}
+              </Button>
+            </form>
+          </div>
         </CardContent>
       </Card>
 

--- a/src/controllers/github-app.controller.ts
+++ b/src/controllers/github-app.controller.ts
@@ -269,6 +269,102 @@ export async function githubInstallationRecordHandler(req: FastifyRequest, reply
   });
 }
 
+export async function githubLinkInstallationHandler(
+  req: FastifyRequest<{ Body: { installationId?: string } }>,
+  reply: FastifyReply
+): Promise<void> {
+  const raw = getSessionTokenFromRequest(req.headers.cookie);
+  const user = await getUserFromSessionToken(raw);
+  if (!user) {
+    reply.code(401).send({ error: "Unauthorized", message: "Sign in required", code: "AUTH_REQUIRED" });
+    return;
+  }
+
+  const body = req.body as { installationId?: string } | undefined;
+  const installationIdStr = (body?.installationId ?? "").trim();
+  if (!installationIdStr || !/^\d+$/.test(installationIdStr)) {
+    reply.code(400).send({
+      error: "BadRequest",
+      message: "Please enter a valid numeric GitHub Installation ID (e.g. 67554316).",
+    });
+    return;
+  }
+
+  let login = "";
+  let accountType = "unknown";
+  if (githubAppReady()) {
+    try {
+      const auth = createAppAuth({
+        appId: Number(config.githubAppId),
+        privateKey: config.githubAppPrivateKey,
+      });
+      const { token } = await auth({ type: "app" });
+      const octokit = new Octokit({ auth: token });
+      const { data: installation } = await octokit.rest.apps.getInstallation({
+        installation_id: Number(installationIdStr),
+      });
+
+      const account = installation.account;
+      if (account && typeof account === "object") {
+        login = "login" in account ? String(account.login) : "";
+        accountType = "type" in account ? String(account.type) : "unknown";
+      }
+    } catch (err) {
+      logger.warn({ err }, "githubLinkInstallationHandler: direct app installation fetch failed");
+    }
+  }
+
+  const installationId = BigInt(installationIdStr);
+  const db = getDb();
+  const [existing] = await db
+    .select()
+    .from(githubInstallations)
+    .where(eq(githubInstallations.installationId, installationId))
+    .limit(1);
+
+  if (existing) {
+    await db
+      .update(githubInstallations)
+      .set({
+        userId: user.id,
+        githubAccountLogin: login || existing.githubAccountLogin || user.email.split("@")[0],
+        githubAccountType: accountType !== "unknown" ? accountType : existing.githubAccountType,
+      })
+      .where(eq(githubInstallations.installationId, installationId));
+  } else {
+    await db.insert(githubInstallations).values({
+      userId: user.id,
+      installationId,
+      githubAccountLogin: login || user.email.split("@")[0],
+      githubAccountType: accountType,
+    });
+  }
+
+  const effectivePublicUrl = (process.env.PUBLIC_URL || config.publicUrl || "").trim();
+  const effectiveStateSecret = (process.env.GITHUB_STATE_SECRET || config.githubStateSecret || "").trim();
+  if (effectivePublicUrl && effectiveStateSecret) {
+    try {
+      await registerInstallationWithRelay({
+        installationId: installationIdStr,
+        userId: user.id,
+        instanceUrl: effectivePublicUrl,
+        relaySecret: effectiveStateSecret,
+      });
+    } catch (err) {
+      logger.warn(
+        { err: err instanceof Error ? err.message : String(err), installationId: installationIdStr },
+        "githubLinkInstallationHandler: failed to register installation with relay"
+      );
+    }
+  }
+
+  reply.code(200).send({
+    success: true,
+    installationId: installationIdStr,
+    githubAccountLogin: login || user.email.split("@")[0],
+  });
+}
+
 export async function githubIntegrationStatusHandler(req: FastifyRequest, reply: FastifyReply): Promise<void> {
   const raw = getSessionTokenFromRequest(req.headers.cookie);
   const user = await getUserFromSessionToken(raw);

--- a/src/routes/github-app.routes.ts
+++ b/src/routes/github-app.routes.ts
@@ -5,6 +5,7 @@ import {
   githubAppWebhookHandler,
   githubCallbackHandler,
   githubInstallationRecordHandler,
+  githubLinkInstallationHandler,
   githubIntegrationStatusHandler,
   githubInstallHandler,
   githubRepoBranchesHandler,
@@ -16,6 +17,7 @@ export async function githubAppRoutes(app: FastifyInstance): Promise<void> {
   app.get("/auth/github/install", githubInstallHandler);
   app.get("/auth/github/callback", githubCallbackHandler);
   app.get("/github/installation", githubInstallationRecordHandler);
+  app.post("/github/installation/link", githubLinkInstallationHandler);
   app.get("/github/status", githubIntegrationStatusHandler);
   app.get("/github/repos/:owner/:repo/branches", githubRepoBranchesHandler);
   app.get("/github/repos", githubReposHandler);

--- a/website/src/app/changelog/page.tsx
+++ b/website/src/app/changelog/page.tsx
@@ -54,8 +54,8 @@ const FALLBACK_RELEASES: ProcessedRelease[] = [
         badge: "NEW",
         items: [
           {
-            title: "GitHub App Relay & Custom Manifest Proxy",
-            description: "Automatic relay proxy fallback for self-hosted instances running without local GitHub App private keys. Supports zero-config central cloud relay or 1-click custom manifest setup.",
+            title: "GitHub App Relay & Manual Installation Sync",
+            description: "Automatic relay proxy fallback for self-hosted instances running without local GitHub App private keys, plus 1-click manual Installation ID sync when GitHub remains on settings page.",
             command: "versiongate github mode --type relay",
             prNumber: 130,
             prLink: "https://github.com/dineshkorukonda/VersionGate/pull/130",


### PR DESCRIPTION
## Summary
- Fixes backend guard checks in `src/controllers/github-app.controller.ts` so Central Cloud Relay Mode works without requiring local `GITHUB_APP_ID` / `GITHUB_APP_PRIVATE_KEY`.
- Adds `POST /api/v1/github/installation/link` and manual Installation ID sync form in Dashboard UI to handle static GitHub Settings page redirects (`github.com/settings/installations/123456`).
- Reorganizes Dashboard Integrations page with Central Cloud Relay as the Primary Integration mode front-and-center, and places Self-Hosted Custom GitHub App Manifest under Developer Settings (Advanced Mode).
- Updates website changelog in `website/src/app/changelog/page.tsx`.

## Verification Commands
- `bun run typecheck` ([ OK ])
- `bun run build:dashboard` ([ OK ])
- `bun test --pass-with-no-tests` (28/28 tests passed)