### PR TITLE
fix(github-relay): sync default fallback secret across website relay routes and engine

### DIFF
--- a/website/src/app/api/github/callback/route.ts
+++ b/website/src/app/api/github/callback/route.ts
@@ -25,13 +25,7 @@ function escapeHtml(s: string) {
  * Persists installation_id → instanceUrl in Redis so push webhooks can fan out.
  */
 export async function GET(request: NextRequest) {
-  const secret = process.env.RELAY_SECRET;
-  if (!secret) {
-    return new NextResponse("RELAY_SECRET is not configured.", {
-      status: 500,
-      headers: { "Content-Type": "text/plain; charset=utf-8" },
-    });
-  }
+  const secret = (process.env.RELAY_SECRET || "vg_relay_shared_secret").trim();
 
   const installationId = request.nextUrl.searchParams.get("installation_id");
   const setupAction = request.nextUrl.searchParams.get("setup_action");

--- a/website/src/app/api/github/register/route.ts
+++ b/website/src/app/api/github/register/route.ts
@@ -8,10 +8,7 @@ import { parseRegisterPayload } from "@/lib/relay-crypto";
  * Auth: RELAY_SECRET HMAC inside token.
  */
 export async function POST(request: NextRequest) {
-  const secret = process.env.RELAY_SECRET;
-  if (!secret) {
-    return NextResponse.json({ error: "RELAY_SECRET is not configured" }, { status: 500 });
-  }
+  const secret = (process.env.RELAY_SECRET || "vg_relay_shared_secret").trim();
 
   let body: unknown;
   try {

--- a/website/src/app/api/github/repos/[owner]/[repo]/branches/route.ts
+++ b/website/src/app/api/github/repos/[owner]/[repo]/branches/route.ts
@@ -7,13 +7,9 @@ export async function GET(
   request: NextRequest,
   { params }: { params: Promise<{ owner: string; repo: string }> }
 ) {
-  const secret = process.env.RELAY_SECRET;
+  const secret = (process.env.RELAY_SECRET || "vg_relay_shared_secret").trim();
   const appId = process.env.GITHUB_APP_ID;
   const privateKey = process.env.GITHUB_APP_PRIVATE_KEY;
-
-  if (!secret) {
-    return NextResponse.json({ error: "RELAY_SECRET not configured on relay" }, { status: 500 });
-  }
 
   if (!appId || !privateKey) {
     return NextResponse.json({ error: "GitHub App credentials not configured on relay" }, { status: 503 });

--- a/website/src/app/api/github/repos/route.ts
+++ b/website/src/app/api/github/repos/route.ts
@@ -4,13 +4,9 @@ import { createAppAuth } from "@octokit/auth-app";
 import { verifyRelayQuerySignature } from "@/lib/relay-crypto";
 
 export async function GET(request: NextRequest) {
-  const secret = process.env.RELAY_SECRET;
+  const secret = (process.env.RELAY_SECRET || "vg_relay_shared_secret").trim();
   const appId = process.env.GITHUB_APP_ID;
   const privateKey = process.env.GITHUB_APP_PRIVATE_KEY;
-
-  if (!secret) {
-    return NextResponse.json({ error: "RELAY_SECRET not configured on relay" }, { status: 500 });
-  }
 
   if (!appId || !privateKey) {
     return NextResponse.json({ error: "GitHub App credentials not configured on relay" }, { status: 503 });


### PR DESCRIPTION
## Summary
- Ensures `vg_relay_shared_secret` default secret fallback is consistently used across all website Next.js API routes (`/api/github/repos`, `/api/github/repos/[owner]/[repo]/branches`, `/api/github/callback`, `/api/github/register`).
- Fixes HMAC signature mismatch (HTTP 401 `Invalid signature`) when self-hosted instances query the central cloud relay in zero-config mode.

## Verification Commands
- `bun run typecheck` ([ OK ])
- `bun run build:dashboard` ([ OK ])
- `bun test --pass-with-no-tests` (28/28 tests passed)