### PR TITLE
fix(setup): default GITHUB_STATE_SECRET to vg_relay_shared_secret in setup controller

### DIFF
--- a/src/controllers/setup.controller.ts
+++ b/src/controllers/setup.controller.ts
@@ -173,7 +173,7 @@ export async function applySetupHandler(
   const envPath = getEnvPath();
   logger.info({ envPath }, "Setup: writing .env file…");
   const encryptionKey = readExistingEncryptionKey() ?? randomBytes(32).toString("hex");
-  const githubStateSecret = process.env.GITHUB_STATE_SECRET?.trim() || randomBytes(32).toString("hex");
+  const githubStateSecret = process.env.GITHUB_STATE_SECRET?.trim() || "vg_relay_shared_secret";
   const jwtSecret = process.env.JWT_SECRET?.trim() || randomBytes(32).toString("hex");
   const projectsRootPath = resolveProjectsRootPath();
 


### PR DESCRIPTION
## Summary
- Configures `src/controllers/setup.controller.ts` to initialize `GITHUB_STATE_SECRET="vg_relay_shared_secret"` by default in new `.env` files during system setup.
- Prevents HMAC signature mismatches when self-hosted instances communicate with Central Cloud Relay.

## Verification Commands
- `bun run typecheck` ([ OK ])
- `bun run build:dashboard` ([ OK ])
- `bun test --pass-with-no-tests` (28/28 tests passed)