### PR TITLE
fix(website): format GITHUB_APP_PRIVATE_KEY multiline PEM strings in relay API routes

### DIFF
--- a/website/src/app/api/github/repos/[owner]/[repo]/branches/route.ts
+++ b/website/src/app/api/github/repos/[owner]/[repo]/branches/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { Octokit } from "@octokit/rest";
 import { createAppAuth } from "@octokit/auth-app";
-import { verifyRelayQuerySignature } from "@/lib/relay-crypto";
+import { verifyRelayQuerySignature, formatPrivateKey } from "@/lib/relay-crypto";
 
 export async function GET(
   request: NextRequest,
@@ -9,7 +9,8 @@ export async function GET(
 ) {
   const secret = (process.env.RELAY_SECRET || "vg_relay_shared_secret").trim();
   const appId = process.env.GITHUB_APP_ID;
-  const privateKey = process.env.GITHUB_APP_PRIVATE_KEY;
+  const rawPrivateKey = process.env.GITHUB_APP_PRIVATE_KEY;
+  const privateKey = formatPrivateKey(rawPrivateKey);
 
   if (!appId || !privateKey) {
     return NextResponse.json({ error: "GitHub App credentials not configured on relay" }, { status: 503 });

--- a/website/src/app/api/github/repos/route.ts
+++ b/website/src/app/api/github/repos/route.ts
@@ -1,12 +1,13 @@
 import { NextRequest, NextResponse } from "next/server";
 import { Octokit } from "@octokit/rest";
 import { createAppAuth } from "@octokit/auth-app";
-import { verifyRelayQuerySignature } from "@/lib/relay-crypto";
+import { verifyRelayQuerySignature, formatPrivateKey } from "@/lib/relay-crypto";
 
 export async function GET(request: NextRequest) {
   const secret = (process.env.RELAY_SECRET || "vg_relay_shared_secret").trim();
   const appId = process.env.GITHUB_APP_ID;
-  const privateKey = process.env.GITHUB_APP_PRIVATE_KEY;
+  const rawPrivateKey = process.env.GITHUB_APP_PRIVATE_KEY;
+  const privateKey = formatPrivateKey(rawPrivateKey);
 
   if (!appId || !privateKey) {
     return NextResponse.json({ error: "GitHub App credentials not configured on relay" }, { status: 503 });

--- a/website/src/lib/relay-crypto.ts
+++ b/website/src/lib/relay-crypto.ts
@@ -77,6 +77,18 @@ export function verifyRelayQuerySignature(
   return false;
 }
 
+export function formatPrivateKey(key: string | undefined): string {
+  if (!key) return "";
+  let formatted = key.trim();
+  if (formatted.startsWith('"') && formatted.endsWith('"')) {
+    formatted = formatted.slice(1, -1);
+  }
+  if (formatted.includes("\\n")) {
+    formatted = formatted.replace(/\\n/g, "\n");
+  }
+  return formatted;
+}
+
 /** Signed register body for POST /api/github/register */
 export interface RegisterPayload {
   instanceUrl: string;


### PR DESCRIPTION
## Summary
- Adds `formatPrivateKey` in `website/src/lib/relay-crypto.ts` to parse single-line \n escaped `GITHUB_APP_PRIVATE_KEY` environment variables on Vercel into valid multi-line RSA PEM strings.
- Fixes HTTP 500 error from Octokit: `The 'privateKey' option contains only the first line '-----BEGIN RSA PRIVATE KEY-----'`.

## Verification Commands
- `bun run typecheck` ([ OK ])
- `bun run build:dashboard` ([ OK ])
- `bun test --pass-with-no-tests` (28/28 tests passed)