### PR TITLE
fix(website): support GITHUB_APP_PRIVATE_KEY_BASE64 and base64 encoded PEM keys in relay

### DIFF
--- a/website/src/app/api/github/repos/[owner]/[repo]/branches/route.ts
+++ b/website/src/app/api/github/repos/[owner]/[repo]/branches/route.ts
@@ -9,7 +9,7 @@ export async function GET(
 ) {
   const secret = (process.env.RELAY_SECRET || "vg_relay_shared_secret").trim();
   const appId = process.env.GITHUB_APP_ID;
-  const rawPrivateKey = process.env.GITHUB_APP_PRIVATE_KEY;
+  const rawPrivateKey = process.env.GITHUB_APP_PRIVATE_KEY_BASE64 || process.env.GITHUB_APP_PRIVATE_KEY;
   const privateKey = formatPrivateKey(rawPrivateKey);
 
   if (!appId || !privateKey) {

--- a/website/src/app/api/github/repos/route.ts
+++ b/website/src/app/api/github/repos/route.ts
@@ -6,7 +6,7 @@ import { verifyRelayQuerySignature, formatPrivateKey } from "@/lib/relay-crypto"
 export async function GET(request: NextRequest) {
   const secret = (process.env.RELAY_SECRET || "vg_relay_shared_secret").trim();
   const appId = process.env.GITHUB_APP_ID;
-  const rawPrivateKey = process.env.GITHUB_APP_PRIVATE_KEY;
+  const rawPrivateKey = process.env.GITHUB_APP_PRIVATE_KEY_BASE64 || process.env.GITHUB_APP_PRIVATE_KEY;
   const privateKey = formatPrivateKey(rawPrivateKey);
 
   if (!appId || !privateKey) {

--- a/website/src/lib/relay-crypto.ts
+++ b/website/src/lib/relay-crypto.ts
@@ -83,6 +83,15 @@ export function formatPrivateKey(key: string | undefined): string {
   if (formatted.startsWith('"') && formatted.endsWith('"')) {
     formatted = formatted.slice(1, -1);
   }
+  // If base64 encoded (no PEM header), decode from base64
+  if (!formatted.includes("BEGIN") && formatted.length > 50) {
+    try {
+      const decoded = Buffer.from(formatted, "base64").toString("utf8");
+      if (decoded.includes("BEGIN")) {
+        formatted = decoded.trim();
+      }
+    } catch {}
+  }
   if (formatted.includes("\\n")) {
     formatted = formatted.replace(/\\n/g, "\n");
   }


### PR DESCRIPTION
## Summary
- Adds base64 decoding support in `website/src/lib/relay-crypto.ts` (`formatPrivateKey`) and adds support for `GITHUB_APP_PRIVATE_KEY_BASE64` environment variable on Vercel.
- Resolves Octokit 500 error when Vercel truncates multiline PEM private key environment variables.

## Verification Commands
- `bun run typecheck` ([ OK ])
- `bun run build:dashboard` ([ OK ])
- `bun test --pass-with-no-tests` (28/28 tests passed)