### PR TITLE
fix(website): prioritize valid GITHUB_APP_PRIVATE_KEY_BASE64 over truncated raw key in getRelayPrivateKey

### DIFF
--- a/website/src/app/api/github/repos/[owner]/[repo]/branches/route.ts
+++ b/website/src/app/api/github/repos/[owner]/[repo]/branches/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { Octokit } from "@octokit/rest";
 import { createAppAuth } from "@octokit/auth-app";
-import { verifyRelayQuerySignature, formatPrivateKey } from "@/lib/relay-crypto";
+import { verifyRelayQuerySignature, getRelayPrivateKey } from "@/lib/relay-crypto";
 
 export async function GET(
   request: NextRequest,
@@ -9,8 +9,7 @@ export async function GET(
 ) {
   const secret = (process.env.RELAY_SECRET || "vg_relay_shared_secret").trim();
   const appId = process.env.GITHUB_APP_ID;
-  const rawPrivateKey = process.env.GITHUB_APP_PRIVATE_KEY_BASE64 || process.env.GITHUB_APP_PRIVATE_KEY;
-  const privateKey = formatPrivateKey(rawPrivateKey);
+  const privateKey = getRelayPrivateKey();
 
   if (!appId || !privateKey) {
     return NextResponse.json({ error: "GitHub App credentials not configured on relay" }, { status: 503 });

--- a/website/src/app/api/github/repos/route.ts
+++ b/website/src/app/api/github/repos/route.ts
@@ -1,13 +1,12 @@
 import { NextRequest, NextResponse } from "next/server";
 import { Octokit } from "@octokit/rest";
 import { createAppAuth } from "@octokit/auth-app";
-import { verifyRelayQuerySignature, formatPrivateKey } from "@/lib/relay-crypto";
+import { verifyRelayQuerySignature, getRelayPrivateKey } from "@/lib/relay-crypto";
 
 export async function GET(request: NextRequest) {
   const secret = (process.env.RELAY_SECRET || "vg_relay_shared_secret").trim();
   const appId = process.env.GITHUB_APP_ID;
-  const rawPrivateKey = process.env.GITHUB_APP_PRIVATE_KEY_BASE64 || process.env.GITHUB_APP_PRIVATE_KEY;
-  const privateKey = formatPrivateKey(rawPrivateKey);
+  const privateKey = getRelayPrivateKey();
 
   if (!appId || !privateKey) {
     return NextResponse.json({ error: "GitHub App credentials not configured on relay" }, { status: 503 });

--- a/website/src/lib/relay-crypto.ts
+++ b/website/src/lib/relay-crypto.ts
@@ -83,19 +83,31 @@ export function formatPrivateKey(key: string | undefined): string {
   if (formatted.startsWith('"') && formatted.endsWith('"')) {
     formatted = formatted.slice(1, -1);
   }
-  // If base64 encoded (no PEM header), decode from base64
-  if (!formatted.includes("BEGIN") && formatted.length > 50) {
-    try {
-      const decoded = Buffer.from(formatted, "base64").toString("utf8");
-      if (decoded.includes("BEGIN")) {
-        formatted = decoded.trim();
-      }
-    } catch {}
-  }
   if (formatted.includes("\\n")) {
     formatted = formatted.replace(/\\n/g, "\n");
   }
+  if (formatted.includes("BEGIN") && formatted.includes("END")) {
+    return formatted;
+  }
+  try {
+    const decoded = Buffer.from(key.trim(), "base64").toString("utf8").trim();
+    if (decoded.includes("BEGIN") && decoded.includes("END")) {
+      return decoded;
+    }
+  } catch {}
   return formatted;
+}
+
+export function getRelayPrivateKey(): string {
+  const base64 = process.env.GITHUB_APP_PRIVATE_KEY_BASE64;
+  if (base64) {
+    const formatted = formatPrivateKey(base64);
+    if (formatted.includes("BEGIN") && formatted.includes("END")) {
+      return formatted;
+    }
+  }
+  const raw = process.env.GITHUB_APP_PRIVATE_KEY;
+  return formatPrivateKey(raw);
 }
 
 /** Signed register body for POST /api/github/register */


### PR DESCRIPTION
## Summary
- Introduces `getRelayPrivateKey()` in `website/src/lib/relay-crypto.ts` to check `GITHUB_APP_PRIVATE_KEY_BASE64` first, validating that formatted PEM keys contain both `BEGIN` and `END` markers.
- Fixes Octokit 500 error when Vercel environment variables contain truncated single-line `GITHUB_APP_PRIVATE_KEY`.

## Verification Commands
- `bun run typecheck` ([ OK ])
- `bun run build:dashboard` ([ OK ])
- `bun test --pass-with-no-tests` (28/28 tests passed)