### PR TITLE
docs(website): add v1.5.0 changelog release and in-process worker capability grid item

### DIFF
--- a/website/src/app/changelog/page.tsx
+++ b/website/src/app/changelog/page.tsx
@@ -44,9 +44,41 @@ interface ProcessedRelease {
 
 const FALLBACK_RELEASES: ProcessedRelease[] = [
   {
+    version: "v1.5.0",
+    date: "July 30, 2026",
+    isLatest: true,
+    summary: "Automated Worker Self-Healing, Base-Href HTML Proxying, Auto-Detect Build Context & Relay Fixes.",
+    categories: [
+      {
+        title: "New Features & Infrastructure",
+        badge: "NEW",
+        items: [
+          {
+            title: "Automated In-Process Worker Engine",
+            description: "Embedded background worker started automatically on server boot, eliminating queue delays and removing the requirement for manual PM2 terminal restarts.",
+            command: "versiongate worker status",
+            prNumber: 149,
+          },
+          {
+            title: "Base Href HTML Response Proxying",
+            description: "Automatic injection of base href tags into proxied HTML responses for seamless CSS, JS, and static asset rendering across Next.js and Vite apps.",
+            command: "versiongate proxy test",
+            prNumber: 149,
+          },
+          {
+            title: "Smart Repository Context Auto-Detection",
+            description: "Vercel-style auto-fill of project names and subdirectory detection (website, dashboard, frontend) upon picking GitHub repositories.",
+            command: "versiongate project create",
+            prNumber: 149,
+          },
+        ],
+      },
+    ],
+  },
+  {
     version: "v1.4.0",
     date: "July 29, 2026",
-    isLatest: true,
+    isLatest: false,
     summary: "GitHub App Relay Proxying, Stage Path Reverse Proxy, Warm-Swap Rollbacks, API Bearer Tokens & Health Audit.",
     categories: [
       {

--- a/website/src/components/capability-grid.tsx
+++ b/website/src/components/capability-grid.tsx
@@ -50,6 +50,15 @@ const CAPABILITIES: Capability[] = [
     badge: "v1.4 Feature",
   },
   {
+    id: "cap-autohealing",
+    category: "Monitoring",
+    title: "In-Process Worker & Base Href Proxy",
+    command: "versiongate worker start --auto-heal",
+    description: "Self-healing background worker engine with base-href HTML proxying for flawless asset loading.",
+    details: "Runs an embedded background worker inside the API process to eliminate idle queue delays, while injecting base href tags into proxied HTML responses for perfect CSS/image asset resolution.",
+    badge: "v1.5 Feature",
+  },
+  {
     id: "cap-healthmonitor",
     category: "Monitoring",
     title: "Native Background Health Audit",


### PR DESCRIPTION
## Summary
- Updates `website/src/app/changelog/page.tsx` with v1.5.0 release notes (Automated In-Process Worker Engine, Base Href HTML Response Proxying, Smart Repository Context Auto-Detection).
- Updates `website/src/components/capability-grid.tsx` with v1.5.0 feature capability item per AGENTS.md Rule #8.

## Verification Commands
- `bun run typecheck` ([ OK ])
- `bun run build:dashboard` ([ OK ])
- `bun test --pass-with-no-tests` (28/28 tests passed)