### PR TITLE
fix(proxy): rewrite HTML asset paths for Next.js and Vite, silent zero-downtime auto-update

### DIFF
--- a/dashboard/src/components/UpdateAvailableBanner.tsx
+++ b/dashboard/src/components/UpdateAvailableBanner.tsx
@@ -1,23 +1,20 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { Link } from "react-router-dom";
-import { toast } from "sonner";
 import { applySelfUpdateFromSettings, getSelfUpdateSettings } from "@/lib/api";
-import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
-import { Button, buttonVariants } from "@/components/ui/button";
+import { toast } from "sonner";
+import { X } from "lucide-react";
 
 const POLL_MS = 120_000;
 const DISMISS_KEY = "vg-update-banner-dismissed";
 const TOAST_PREFIX = "vg-update-toast-remote-";
 
 /**
- * Shows when self-update is enabled and origin is ahead of local (e.g. after merging to the tracked branch).
- * Polls the same endpoint Settings uses; apply matches Settings → Application updates.
+ * Slim update banner that appears when the server clone is behind origin.
+ * Applies silently via pm2 reload --update-env (graceful, zero-downtime).
+ * No window.confirm() dialog — update is applied immediately on click.
  */
 export function UpdateAvailableBanner() {
   const [show, setShow] = useState(false);
   const [branch, setBranch] = useState("");
-  const [remoteTip, setRemoteTip] = useState("");
-  const [localTip, setLocalTip] = useState("");
   const [applying, setApplying] = useState(false);
   const dismissedRef = useRef(sessionStorage.getItem(DISMISS_KEY) === "1");
 
@@ -30,10 +27,8 @@ export function UpdateAvailableBanner() {
       }
       const behind = su.git.behind;
       const remote = su.git.remoteCommit ?? "";
-      const local = su.git.currentCommit ?? "";
+
       setBranch(su.branch);
-      setRemoteTip(remote);
-      setLocalTip(local);
 
       if (!behind) {
         sessionStorage.removeItem(DISMISS_KEY);
@@ -45,9 +40,9 @@ export function UpdateAvailableBanner() {
       const toastKey = remote ? `${TOAST_PREFIX}${remote.slice(0, 40)}` : "";
       if (toastKey && !sessionStorage.getItem(toastKey)) {
         sessionStorage.setItem(toastKey, "1");
-        toast.info("Application update available", {
-          description: `New commits on ${su.branch}. You can apply from the banner or Settings.`,
-          duration: 10_000,
+        toast.info("Update available", {
+          description: `New commits detected on ${su.branch}. Apply from the banner above.`,
+          duration: 8_000,
         });
       }
 
@@ -70,27 +65,39 @@ export function UpdateAvailableBanner() {
   };
 
   const onApply = async () => {
-    if (
-      !window.confirm(
-        "Pull latest code, rebuild the dashboard, and reload PM2? The UI may disconnect briefly."
-      )
-    ) {
-      return;
-    }
     setApplying(true);
+    const tid = toast.loading("Applying update — the server will reload gracefully...");
     try {
       const r = await applySelfUpdateFromSettings();
+      toast.dismiss(tid);
       if (r.ok) {
-        toast.success("Update applied — PM2 reload scheduled. Refresh this page in a few seconds.");
-        dismissedRef.current = false;
-        sessionStorage.removeItem(DISMISS_KEY);
-        await poll();
+        toast.success("Update applied. Reconnecting...", { duration: 4_000 });
+        setShow(false);
+        // Auto-reconnect: poll API until it responds again after reload
+        let attempts = 0;
+        const reconnect = window.setInterval(async () => {
+          attempts++;
+          try {
+            const res = await fetch("/api/v1/setup/status");
+            if (res.ok) {
+              window.clearInterval(reconnect);
+              window.location.reload();
+            }
+          } catch {
+            // server still reloading
+          }
+          if (attempts > 30) {
+            window.clearInterval(reconnect);
+            window.location.reload();
+          }
+        }, 2000);
       } else {
         toast.error(r.error ?? "Update failed", {
-          description: r.steps?.length ? r.steps.slice(-3).join(" → ") : undefined,
+          description: r.steps?.length ? r.steps.slice(-3).join(" > ") : undefined,
         });
       }
     } catch (e) {
+      toast.dismiss(tid);
       toast.error(e instanceof Error ? e.message : "Update failed");
     } finally {
       setApplying(false);
@@ -100,45 +107,32 @@ export function UpdateAvailableBanner() {
   if (!show) return null;
 
   return (
-    <div className="border-b border-amber-500/25 bg-amber-500/10 px-4 py-3 md:px-6">
-      <Alert className="border-amber-500/35 bg-amber-500/5">
-        <AlertTitle className="text-amber-950">Update available</AlertTitle>
-        <AlertDescription className="flex flex-col gap-3 text-amber-950/90">
-          <p>
-            This server&apos;s clone is behind <span className="font-medium text-foreground">origin/{branch}</span>
-            {remoteTip ? (
-              <>
-                {" "}
-                (remote <span className="font-mono text-xs">{remoteTip.slice(0, 7)}</span>
-                {localTip ? (
-                  <>
-                    {" "}
-                    vs local <span className="font-mono text-xs">{localTip.slice(0, 7)}</span>
-                  </>
-                ) : null}
-                ).
-              </>
-            ) : (
-              "."
-            )}{" "}
-            Merge on GitHub is detected after the next check (or open Settings and run &quot;Check for updates&quot;).
-          </p>
-          <div className="flex flex-wrap items-center gap-2">
-            <Button type="button" size="sm" disabled={applying} onClick={() => void onApply()}>
-              {applying ? "Applying…" : "Apply update now"}
-            </Button>
-            <Link
-              to="/settings#application-updates"
-              className={buttonVariants({ variant: "outline", size: "sm" })}
-            >
-              Open Settings
-            </Link>
-            <Button type="button" size="sm" variant="ghost" className="text-muted-foreground" onClick={onDismiss}>
-              Dismiss
-            </Button>
-          </div>
-        </AlertDescription>
-      </Alert>
+    <div className="flex items-center justify-between border-b border-[#2a2a2a] bg-[#111] px-4 py-2.5">
+      <div className="flex items-center gap-3">
+        <span className="inline-block h-2 w-2 rounded-full bg-[#0070f3]" />
+        <span className="text-sm text-[#a1a1a1]">
+          Update available on{" "}
+          <span className="font-medium text-white">origin/{branch}</span>
+        </span>
+      </div>
+      <div className="flex items-center gap-2">
+        <button
+          type="button"
+          disabled={applying}
+          onClick={() => void onApply()}
+          className="rounded-md bg-white px-3 py-1 text-xs font-medium text-black transition-colors hover:bg-zinc-100 disabled:opacity-50"
+        >
+          {applying ? "Applying..." : "Apply update"}
+        </button>
+        <button
+          type="button"
+          onClick={onDismiss}
+          className="rounded-md p-1 text-[#737373] transition-colors hover:bg-[#1a1a1a] hover:text-white"
+          aria-label="Dismiss"
+        >
+          <X className="h-3.5 w-3.5" />
+        </button>
+      </div>
     </div>
   );
 }

--- a/src/services/proxy.service.ts
+++ b/src/services/proxy.service.ts
@@ -9,6 +9,7 @@ export interface ResolvedProxyTarget {
   environmentName: string;
   port: number;
   healthPath: string;
+  proxyPrefix: string;
 }
 
 export class ProxyService {
@@ -62,12 +63,41 @@ export class ProxyService {
       return null;
     }
 
+    const proxyPrefix = `/p/${project.name}/${environment.name}`;
+
     return {
       projectName: project.name,
       environmentName: environment.name,
       port: depRows[0].port,
       healthPath: project.healthPath,
+      proxyPrefix,
     };
+  }
+
+  /**
+   * Rewrites absolute-path asset references in HTML so they route through
+   * the VersionGate reverse proxy prefix. Handles Next.js (_next/), Vite (/assets/),
+   * and generic root-relative paths (/static/).
+   */
+  private rewriteHtmlAssetPaths(html: string, proxyPrefix: string): string {
+    // Inject <base> tag so relative paths also resolve correctly
+    if (!html.includes("<base ")) {
+      html = html.replace(/<head(\s[^>]*)?>/i, (m) => `${m}<base href="${proxyPrefix}/">`);
+    }
+
+    // Next.js: rewrite assetPrefix in __NEXT_DATA__ JSON
+    html = html.replace(/"assetPrefix":""/g, `"assetPrefix":"${proxyPrefix}"`);
+
+    // Rewrite src="/_next/... and href="/_next/... (Next.js static assets)
+    html = html.replace(/(src|href)="\/_next\//gi, `$1="${proxyPrefix}/_next/`);
+
+    // Rewrite /assets/ (Vite output)
+    html = html.replace(/(src|href)="\/assets\//gi, `$1="${proxyPrefix}/assets/`);
+
+    // Rewrite /static/ (CRA and misc setups)
+    html = html.replace(/(src|href)="\/static\//gi, `$1="${proxyPrefix}/static/`);
+
+    return html;
   }
 
   async proxyRequest(
@@ -95,10 +125,14 @@ export class ProxyService {
       headers["x-forwarded-for"] = req.ip || "127.0.0.1";
       headers["x-forwarded-proto"] = req.protocol || "http";
       headers["x-versiongate-proxy"] = "true";
+      // Signal basePath to Next.js SSR
+      headers["x-forwarded-prefix"] = target.proxyPrefix;
 
       const method = req.method;
       const hasBody = method !== "GET" && method !== "HEAD";
-      const bodyPayload = hasBody && req.body ? (typeof req.body === "string" ? req.body : JSON.stringify(req.body)) : undefined;
+      const bodyPayload = hasBody && req.body
+        ? (typeof req.body === "string" ? req.body : JSON.stringify(req.body))
+        : undefined;
 
       const response = await fetch(targetUrl, {
         method,
@@ -124,14 +158,7 @@ export class ProxyService {
 
         if (contentType.includes("text/html")) {
           let html = buf.toString("utf8");
-          const baseHref = `/p/${target.projectName}/`;
-          if (!html.includes("<base ")) {
-            if (html.includes("<head>")) {
-              html = html.replace("<head>", `<head><base href="${baseHref}">`);
-            } else if (html.includes("<HEAD>")) {
-              html = html.replace("<HEAD>", `<HEAD><base href="${baseHref}">`);
-            }
-          }
+          html = this.rewriteHtmlAssetPaths(html, target.proxyPrefix);
           buf = Buffer.from(html, "utf8");
           reply.header("content-length", buf.length.toString());
         }
@@ -146,7 +173,7 @@ export class ProxyService {
         <!DOCTYPE html>
         <html>
           <head>
-            <title>VersionGate — Gateway Error</title>
+            <title>VersionGate Gateway Error</title>
             <style>
               body { font-family: system-ui, sans-serif; background: #0f172a; color: #f8fafc; display: flex; align-items: center; justify-content: center; height: 100vh; margin: 0; }
               .card { background: #1e293b; padding: 2rem; border-radius: 12px; border: 1px solid #334155; max-width: 500px; text-align: center; }


### PR DESCRIPTION
## Summary

### CSS / Asset Loading Fix (Deployed Apps)
The root cause of CSS not loading in deployed projects:

Next.js and Vite emit **absolute** asset paths like `/_next/static/chunks/app.js` and `/assets/index.css` in their HTML. When served via the VersionGate reverse proxy at `/p/:projectName/:envName/*`, the browser resolves these against the server root (`57.158.26.34/_next/...`) instead of through the proxy route.

**Fix in `src/services/proxy.service.ts`:**
- Added `proxyPrefix` field (`/p/name/env`) to `ResolvedProxyTarget`
- Added `rewriteHtmlAssetPaths()` method that:
  - Injects `<base href>` for relative paths
  - Rewrites `src="/_next/`  to `src="/p/proj/env/_next/`
  - Rewrites `/assets/` for Vite
  - Rewrites `/static/` for CRA
  - Sets `assetPrefix` in Next.js `__NEXT_DATA__` JSON
  - Sends `x-forwarded-prefix` header for SSR basePath awareness

### Auto-Update Silent Apply
**Fix in `dashboard/src/components/UpdateAvailableBanner.tsx`:**
- Removed `window.confirm()` blocking dialog
- Slim 40px Vercel-style banner instead of large Alert component
- Apply triggers immediately with progress toast
- Auto-reconnect polling: polls `/api/v1/setup/status` after apply until API responds, then reloads
- pm2 reload already uses `--update-env` (graceful, zero-downtime)

## Verification
- `bun run typecheck` [ OK ]
- `bun run build:dashboard` [ OK ]
- `bun test --pass-with-no-tests` [ OK ] 28/28 tests passed