### PR TITLE
feat(website): redesign marketing landing page

### DIFF
--- a/website/src/app/changelog/page.tsx
+++ b/website/src/app/changelog/page.tsx
@@ -44,9 +44,33 @@ interface ProcessedRelease {
 
 const FALLBACK_RELEASES: ProcessedRelease[] = [
   {
+    version: "v1.6.0",
+    date: "August 10, 2026",
+    isLatest: true,
+    summary: "Editorial marketing landing redesign with brand-first hero, animated control-plane visual, and architecture narrative.",
+    categories: [
+      {
+        title: "Website & Marketing",
+        badge: "NEW",
+        items: [
+          {
+            title: "Landing page redesign",
+            description:
+              "CARF-caliber editorial landing: VersionGate brand as the hero signal, full-bleed animated blue/green control-plane visual, problem narrative, four-step architecture loop, install path, and refined capability directory.",
+          },
+          {
+            title: "Typography & atmosphere",
+            description:
+              "Space Grotesk display + DM Sans body + JetBrains Mono, VersionGate blue accent system, radial atmosphere, and intentional hero/log motion — no decorative iconography.",
+          },
+        ],
+      },
+    ],
+  },
+  {
     version: "v1.5.1",
     date: "August 5, 2026",
-    isLatest: true,
+    isLatest: false,
     summary: "PM2 worker deduplication, Drizzle naming alignment, job queue row locking, and Compose port fixes.",
     categories: [
       {

--- a/website/src/app/globals.css
+++ b/website/src/app/globals.css
@@ -2,70 +2,73 @@
 
 @layer base {
   :root {
-    --background: 0 0% 100%;
-    --foreground: 240 10% 3.9%;
-    --card: 0 0% 100%;
-    --card-foreground: 240 10% 3.9%;
-    --popover: 0 0% 100%;
-    --popover-foreground: 240 10% 3.9%;
-    --primary: 240 5.9% 10%;
-    --primary-foreground: 0 0% 98%;
-    --secondary: 240 4.8% 95.9%;
-    --secondary-foreground: 240 5.9% 10%;
-    --muted: 240 4.8% 95.9%;
-    --muted-foreground: 240 3.8% 46.1%;
-    --accent: 240 4.8% 95.9%;
-    --accent-foreground: 240 5.9% 10%;
+    --background: 222 28% 4%;
+    --foreground: 210 40% 98%;
+    --card: 222 24% 7%;
+    --card-foreground: 210 40% 98%;
+    --popover: 222 24% 7%;
+    --popover-foreground: 210 40% 98%;
+    --primary: 221 74% 52%;
+    --primary-foreground: 0 0% 100%;
+    --secondary: 222 16% 14%;
+    --secondary-foreground: 210 40% 96%;
+    --muted: 222 16% 12%;
+    --muted-foreground: 215 16% 65%;
+    --accent: 221 74% 52%;
+    --accent-foreground: 0 0% 100%;
     --destructive: 0 84.2% 60.2%;
     --destructive-foreground: 0 0% 98%;
-    --border: 240 5.9% 90%;
-    --input: 240 5.9% 90%;
-    --ring: 240 5.9% 10%;
-    --radius: 0.5rem;
+    --border: 220 16% 18%;
+    --input: 220 16% 18%;
+    --ring: 221 74% 52%;
+    --radius: 0.625rem;
+    --brand: 221 74% 52%;
+    --surface: 222 28% 5%;
   }
 
   .dark, [data-theme="dark"] {
-    --background: 240 10% 3.9%;
-    --foreground: 0 0% 98%;
-    --card: 240 10% 3.9%;
-    --card-foreground: 0 0% 98%;
-    --popover: 240 10% 3.9%;
-    --popover-foreground: 0 0% 98%;
-    --primary: 0 0% 98%;
-    --primary-foreground: 240 5.9% 10%;
-    --secondary: 240 3.7% 15.9%;
-    --secondary-foreground: 0 0% 98%;
-    --muted: 240 3.7% 15.9%;
-    --muted-foreground: 240 5% 64.9%;
-    --accent: 240 3.7% 15.9%;
-    --accent-foreground: 0 0% 98%;
+    --background: 222 28% 4%;
+    --foreground: 210 40% 98%;
+    --card: 222 24% 7%;
+    --card-foreground: 210 40% 98%;
+    --popover: 222 24% 7%;
+    --popover-foreground: 210 40% 98%;
+    --primary: 221 74% 52%;
+    --primary-foreground: 0 0% 100%;
+    --secondary: 222 16% 14%;
+    --secondary-foreground: 210 40% 96%;
+    --muted: 222 16% 12%;
+    --muted-foreground: 215 16% 65%;
+    --accent: 221 74% 52%;
+    --accent-foreground: 0 0% 100%;
     --destructive: 0 62.8% 30.6%;
     --destructive-foreground: 0 0% 98%;
-    --border: 240 3.7% 15.9%;
-    --input: 240 3.7% 15.9%;
-    --ring: 240 4.9% 83.9%;
+    --border: 220 16% 18%;
+    --input: 220 16% 18%;
+    --ring: 221 74% 52%;
   }
 
   .light, [data-theme="light"] {
-    --background: 0 0% 100%;
-    --foreground: 240 10% 3.9%;
+    --background: 210 40% 98%;
+    --foreground: 222 28% 8%;
     --card: 0 0% 100%;
-    --card-foreground: 240 10% 3.9%;
+    --card-foreground: 222 28% 8%;
     --popover: 0 0% 100%;
-    --popover-foreground: 240 10% 3.9%;
-    --primary: 240 5.9% 10%;
-    --primary-foreground: 0 0% 98%;
-    --secondary: 240 4.8% 95.9%;
-    --secondary-foreground: 240 5.9% 10%;
-    --muted: 240 4.8% 95.9%;
-    --muted-foreground: 240 3.8% 46.1%;
-    --accent: 240 4.8% 95.9%;
-    --accent-foreground: 240 5.9% 10%;
+    --popover-foreground: 222 28% 8%;
+    --primary: 221 74% 48%;
+    --primary-foreground: 0 0% 100%;
+    --secondary: 214 24% 93%;
+    --secondary-foreground: 222 28% 12%;
+    --muted: 214 24% 94%;
+    --muted-foreground: 215 16% 40%;
+    --accent: 221 74% 48%;
+    --accent-foreground: 0 0% 100%;
     --destructive: 0 84.2% 60.2%;
     --destructive-foreground: 0 0% 98%;
-    --border: 240 5.9% 90%;
-    --input: 240 5.9% 90%;
-    --ring: 240 5.9% 10%;
+    --border: 214 20% 88%;
+    --input: 214 20% 88%;
+    --ring: 221 74% 48%;
+    --surface: 210 40% 97%;
   }
 }
 
@@ -75,6 +78,10 @@ body {
   font-family: var(--font-sans), ui-sans-serif, system-ui, sans-serif;
   -webkit-font-smoothing: antialiased;
   transition: background-color 0.15s ease, color 0.15s ease;
+}
+
+.font-display {
+  font-family: var(--font-display), var(--font-sans), ui-sans-serif, system-ui, sans-serif;
 }
 
 .bg-background { background-color: hsl(var(--background)); }
@@ -89,9 +96,78 @@ body {
 .bg-primary { background-color: hsl(var(--primary)); }
 .text-primary-foreground { color: hsl(var(--primary-foreground)); }
 
+.landing-atmosphere {
+  background-color: hsl(var(--background));
+  background-image:
+    radial-gradient(ellipse 90% 55% at 50% -10%, hsl(var(--brand) / 0.22), transparent 55%),
+    radial-gradient(ellipse 50% 40% at 100% 20%, hsl(var(--brand) / 0.08), transparent 50%),
+    linear-gradient(to bottom, transparent, hsl(var(--background)));
+}
+
+.landing-section-rule {
+  border-color: hsl(var(--border) / 0.9);
+}
+
+.landing-eyebrow {
+  font-family: var(--font-mono), ui-monospace, monospace;
+  font-size: 11px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: hsl(var(--brand));
+}
+
+.landing-fade-up {
+  animation: landing-fade-up 0.9s cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+
+.landing-log-line {
+  animation: landing-log-in 0.35s ease-out both;
+}
+
+@keyframes landing-fade-up {
+  from {
+    opacity: 0;
+    transform: translateY(18px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes landing-log-in {
+  from {
+    opacity: 0;
+    transform: translateX(-6px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+@keyframes landing-reveal {
+  from {
+    opacity: 0;
+    transform: translateY(24px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.landing-reveal {
+  animation: landing-reveal 0.8s cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+
+.landing-hero-brand {
+  letter-spacing: -0.04em;
+}
+
 .bg-grid-pattern {
-  background-size: 32px 32px;
-  background-image: 
-    linear-gradient(to right, hsl(var(--border) / 0.5) 1px, transparent 1px),
-    linear-gradient(to bottom, hsl(var(--border) / 0.5) 1px, transparent 1px);
+  background-size: 40px 40px;
+  background-image:
+    linear-gradient(to right, hsl(var(--border) / 0.35) 1px, transparent 1px),
+    linear-gradient(to bottom, hsl(var(--border) / 0.35) 1px, transparent 1px);
 }

--- a/website/src/app/layout.tsx
+++ b/website/src/app/layout.tsx
@@ -1,14 +1,20 @@
 import type { Metadata } from "next";
-import { Inter, JetBrains_Mono } from "next/font/google";
+import { Space_Grotesk, DM_Sans, JetBrains_Mono } from "next/font/google";
 import "./globals.css";
 
-const inter = Inter({
+const display = Space_Grotesk({
+  subsets: ["latin"],
+  variable: "--font-display",
+  display: "swap",
+});
+
+const sans = DM_Sans({
   subsets: ["latin"],
   variable: "--font-sans",
   display: "swap",
 });
 
-const jetbrains = JetBrains_Mono({
+const mono = JetBrains_Mono({
   subsets: ["latin"],
   weight: ["400", "500", "600"],
   variable: "--font-mono",
@@ -39,7 +45,9 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: Readonly<{ children: React.ReactNode }>) {
   return (
     <html lang="en" className="dark" data-theme="dark">
-      <body className={`${inter.variable} ${jetbrains.variable} font-sans antialiased bg-background text-foreground`}>
+      <body
+        className={`${display.variable} ${sans.variable} ${mono.variable} font-sans antialiased bg-background text-foreground`}
+      >
         {children}
       </body>
     </html>

--- a/website/src/app/page.tsx
+++ b/website/src/app/page.tsx
@@ -7,134 +7,275 @@ import { CapabilityGrid } from "@/components/capability-grid";
 import { ExecutionSandbox } from "@/components/execution-sandbox";
 import { TopologyVisualizer } from "@/components/topology-visualizer";
 import { CommunityQnA } from "@/components/community-qna";
+import { HeroDeployVisual } from "@/components/hero-deploy-visual";
 
 const GITHUB_REPO = "https://github.com/dineshkorukonda/VersionGate";
+const INSTALL_CMD = "curl -fsSL https://versiongate.tech/install.sh | sudo bash";
 
-const QUICK_STATS = [
-  { label: "WARM ROLLBACK", value: "< 2 SEC", desc: "Local image warm swap" },
-  { label: "ZERO DOWNTIME", value: "0 MS", desc: "Atomic Nginx rewrite" },
-  { label: "SLOT ARCHITECTURE", value: "BLUE / GREEN", desc: "Isolated port allocation" },
-  { label: "INFRASTRUCTURE", value: "100% SELF-HOSTED", desc: "On-premise Postgres & Redis" },
+const LOOP = [
+  {
+    step: "01",
+    label: "Build",
+    title: "Idle slot compilation",
+    body: "Pull the commit, build on the idle blue or green slot, and keep live traffic on the active upstream.",
+  },
+  {
+    step: "02",
+    label: "Prove",
+    title: "Health-gated promotion",
+    body: "Hit the container health endpoint on the isolated host port. No rewrite until the new revision answers clean.",
+  },
+  {
+    step: "03",
+    label: "Swap",
+    title: "Atomic Nginx rewrite",
+    body: "Reload upstream mapping in place. Request loss stays at zero while the previous slot stays warm.",
+  },
+  {
+    step: "04",
+    label: "Recover",
+    title: "Warm-swap rollback",
+    body: "Reuse the cached image on the sibling slot. Rollbacks land in under two seconds without a rebuild.",
+  },
 ] as const;
 
 export default function Home() {
   return (
-    <div className="min-h-screen bg-background text-foreground bg-grid-pattern transition-colors">
+    <div className="min-h-screen landing-atmosphere text-foreground transition-colors">
       <SiteHeader />
 
-      {/* Hero Section */}
-      <section className="relative border-b border-border py-20 lg:py-28">
-        <div className="mx-auto max-w-7xl px-4 sm:px-6 space-y-12">
-          <div className="max-w-4xl space-y-6">
-            <div className="inline-flex items-center gap-3 rounded-full border border-border bg-muted/60 px-3 py-1 font-mono text-xs text-muted-foreground">
-              <span className="font-semibold text-foreground">Engine Release</span>
-              <span>VersionGate v1.4 Stable</span>
-            </div>
-
-            <h1 className="text-4xl font-extrabold tracking-tight sm:text-6xl lg:text-7xl leading-[1.05] text-foreground">
-              Command the Cluster.
-            </h1>
-
-            <p className="max-w-2xl text-base leading-relaxed text-muted-foreground font-sans">
-              Self-hosted zero-downtime deployment engine for your VPS. Blue-green slot swaps, instant warm-swap rollbacks, path-based stage routing, and Bearer token CI/CD pipelines.
+      {/* Hero — brand first, one composition, full-bleed visual */}
+      <section className="relative overflow-hidden border-b border-border">
+        <div className="absolute inset-0">
+          <HeroDeployVisual />
+        </div>
+        <div className="absolute inset-0 bg-gradient-to-r from-background via-background/85 to-background/20 lg:via-background/70 lg:to-transparent" />
+        <div className="relative mx-auto flex min-h-[88vh] max-w-7xl items-center px-4 py-20 sm:px-6 lg:min-h-[92vh]">
+          <div className="max-w-xl landing-fade-up">
+            <p className="font-display landing-hero-brand text-5xl font-bold tracking-tight text-foreground sm:text-6xl lg:text-7xl">
+              VersionGate
             </p>
-
-            <div className="flex flex-wrap items-center gap-3 pt-2">
+            <h1 className="mt-5 max-w-xl font-display text-2xl font-medium leading-snug tracking-tight text-foreground/90 sm:text-3xl lg:text-[2rem]">
+              Zero-downtime Docker deploys on metal you control.
+            </h1>
+            <p className="mt-4 max-w-md text-[15px] leading-relaxed text-muted-foreground">
+              Self-hosted blue-green engine. Push to GitHub — we build, health-check, and swap traffic with zero downtime.
+            </p>
+            <div className="mt-8 flex flex-wrap items-center gap-3">
               <Link
                 href="/docs"
-                className="rounded-md bg-primary px-6 py-3 font-sans text-xs font-semibold text-primary-foreground transition hover:opacity-90 shadow-sm"
+                className="rounded-md bg-primary px-5 py-2.5 text-sm font-semibold text-primary-foreground transition hover:opacity-90"
               >
-                Read Documentation
+                Read documentation
               </Link>
               <Link
                 href={GITHUB_REPO}
                 target="_blank"
                 rel="noreferrer"
-                className="rounded-md border border-border bg-card px-6 py-3 font-sans text-xs font-semibold text-foreground transition hover:bg-muted"
+                className="rounded-md border border-border bg-background/50 px-5 py-2.5 text-sm font-semibold text-foreground backdrop-blur-sm transition hover:bg-muted"
               >
-                GitHub Repository
+                GitHub repository
               </Link>
             </div>
           </div>
+        </div>
+      </section>
 
-          {/* Quick Stats Grid */}
-          <div className="grid grid-cols-2 gap-4 sm:grid-cols-4 pt-6 border-t border-border">
-            {QUICK_STATS.map((s) => (
-              <div key={s.label} className="space-y-1">
-                <p className="font-mono text-[10px] uppercase text-muted-foreground">{s.label}</p>
-                <p className="text-2xl font-black tracking-tight text-foreground font-sans">{s.value}</p>
-                <p className="text-xs text-muted-foreground font-mono">[ {s.desc} ]</p>
-              </div>
+      {/* Problem narrative */}
+      <section className="border-b border-border py-20 sm:py-24">
+        <div className="mx-auto max-w-3xl px-4 sm:px-6">
+          <p className="landing-eyebrow">The gap</p>
+          <h2 className="mt-4 font-display text-3xl font-semibold tracking-tight text-foreground sm:text-4xl">
+            Shipping got fast. Recovery stayed manual.
+          </h2>
+          <div className="mt-8 space-y-5 text-[15px] leading-relaxed text-muted-foreground">
+            <p>
+              CI/CD solved the push problem. Images land constantly, manifests churn, and every VPS becomes a miniature
+              fleet. What did not improve is the moment after a bad deploy — when traffic is already wrong and the
+              previous revision is a rebuild away.
+            </p>
+            <p>
+              Flat restart scripts treat a CSS tweak like a schema migration. Dashboards fire the same alarm for both,
+              or miss the outage entirely while someone digs for the last known-good tag.
+            </p>
+            <p className="text-foreground/90">
+              VersionGate is different. It keeps two slots warm, proves the next revision before the rewrite, and
+              makes rollback a local image swap — not a prayer and a rebuild.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      {/* Architecture loop */}
+      <section id="architecture-loop" className="border-b border-border py-20 sm:py-24">
+        <div className="mx-auto max-w-7xl px-4 sm:px-6">
+          <div className="max-w-2xl">
+            <p className="landing-eyebrow">Architecture</p>
+            <h2 className="mt-4 font-display text-3xl font-semibold tracking-tight text-foreground sm:text-4xl">
+              Four steps. One blue-green loop.
+            </h2>
+            <p className="mt-3 text-[15px] leading-relaxed text-muted-foreground">
+              From idle-slot build to warm-swap recovery, VersionGate executes with slot isolation and atomic upstream
+              rewrites.
+            </p>
+          </div>
+
+          <div className="mt-12 grid gap-px overflow-hidden rounded-xl border border-border bg-border sm:grid-cols-2 lg:grid-cols-4">
+            {LOOP.map((item) => (
+              <article key={item.step} className="bg-card p-6 sm:p-7">
+                <div className="flex items-baseline justify-between gap-3">
+                  <span className="font-mono text-xs text-primary">{item.step} //</span>
+                  <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-muted-foreground">
+                    {item.label}
+                  </span>
+                </div>
+                <h3 className="mt-4 font-display text-lg font-semibold tracking-tight text-foreground">
+                  {item.title}
+                </h3>
+                <p className="mt-2 text-sm leading-relaxed text-muted-foreground">{item.body}</p>
+              </article>
             ))}
           </div>
         </div>
       </section>
 
-      {/* Interactive Execution Sandbox */}
-      <section id="sandbox" className="border-b border-border py-20 bg-background">
+      {/* Live sandbox */}
+      <section id="sandbox" className="border-b border-border py-20 sm:py-24">
         <div className="mx-auto max-w-7xl px-4 sm:px-6 space-y-8">
-          <div>
-            <div className="mb-2 inline-flex items-center gap-2 rounded border border-border bg-muted px-2.5 py-0.5 font-mono text-[10px] font-semibold text-muted-foreground">
-              <span>Interactive CLI & API Sandbox</span>
-            </div>
-            <h2 className="text-2xl font-bold tracking-tight sm:text-3xl text-foreground">Live Execution Matrix</h2>
-            <p className="mt-1 font-sans text-xs text-muted-foreground">
-              Test execution scenarios and inspect real-time log outputs and JSON payloads.
+          <div className="max-w-2xl">
+            <p className="landing-eyebrow">Simulator</p>
+            <h2 className="mt-4 font-display text-3xl font-semibold tracking-tight text-foreground sm:text-4xl">
+              Watch a deploy, rollback, and token flow.
+            </h2>
+            <p className="mt-3 text-[15px] leading-relaxed text-muted-foreground">
+              Switch scenarios and inspect the same log grammar and JSON payloads the engine emits in production.
             </p>
           </div>
-
           <ExecutionSandbox />
         </div>
       </section>
 
-      {/* Capability Cards Directory */}
-      <section id="capabilities" className="border-b border-border py-20 bg-muted/30">
+      {/* Capabilities */}
+      <section id="capabilities" className="border-b border-border bg-muted/20 py-20 sm:py-24">
         <div className="mx-auto max-w-7xl px-4 sm:px-6 space-y-8">
-          <div>
-            <div className="mb-2 inline-flex items-center gap-2 rounded border border-border bg-muted px-2.5 py-0.5 font-mono text-[10px] font-semibold text-muted-foreground">
-              <span>Capability Directory</span>
-            </div>
-            <h2 className="text-2xl font-bold tracking-tight sm:text-3xl text-foreground">Engine Capabilities & CLI Commands</h2>
-            <p className="mt-1 font-sans text-xs text-muted-foreground">
-              Filter by capability category and inspect specification details.
+          <div className="max-w-2xl">
+            <p className="landing-eyebrow">Capabilities</p>
+            <h2 className="mt-4 font-display text-3xl font-semibold tracking-tight text-foreground sm:text-4xl">
+              Engine surface area, command-ready.
+            </h2>
+            <p className="mt-3 text-[15px] leading-relaxed text-muted-foreground">
+              Filter by category and copy the CLI that drives each capability.
             </p>
           </div>
-
           <CapabilityGrid />
         </div>
       </section>
 
-      {/* Infrastructure Node Topology Visualizer */}
-      <section id="architecture" className="border-b border-border py-20 bg-background">
+      {/* Topology */}
+      <section id="architecture" className="border-b border-border py-20 sm:py-24">
         <div className="mx-auto max-w-7xl px-4 sm:px-6 space-y-8">
-          <div>
-            <div className="mb-2 inline-flex items-center gap-2 rounded border border-border bg-muted px-2.5 py-0.5 font-mono text-[10px] font-semibold text-muted-foreground">
-              <span>Architecture Pipeline</span>
-            </div>
-            <h2 className="text-2xl font-bold tracking-tight sm:text-3xl text-foreground">Infrastructure Topology Map</h2>
-            <p className="mt-1 font-sans text-xs text-muted-foreground">
-              Trace request ingestion from git webhooks to atomic Nginx upstream reloads.
+          <div className="max-w-2xl">
+            <p className="landing-eyebrow">Pipeline</p>
+            <h2 className="mt-4 font-display text-3xl font-semibold tracking-tight text-foreground sm:text-4xl">
+              From signed webhook to Nginx reload.
+            </h2>
+            <p className="mt-3 text-[15px] leading-relaxed text-muted-foreground">
+              Trace ingestion through Redis locks, idle-slot builds, health gates, and atomic upstream swaps.
             </p>
           </div>
-
           <TopologyVisualizer />
         </div>
       </section>
 
-      {/* Community Q&A Knowledge Base */}
-      <section id="qna" className="border-b border-border py-20 bg-muted/30">
-        <div className="mx-auto max-w-7xl px-4 sm:px-6 space-y-8">
-          <div>
-            <div className="mb-2 inline-flex items-center gap-2 rounded border border-border bg-muted px-2.5 py-0.5 font-mono text-[10px] font-semibold text-muted-foreground">
-              <span>Community Q&A & Troubleshooting</span>
-            </div>
-            <h2 className="text-2xl font-bold tracking-tight sm:text-3xl text-foreground">Knowledge Base & Verified Solutions</h2>
-            <p className="mt-1 font-sans text-xs text-muted-foreground">
-              StackOverflow-style technical Q&A threads with code snippets and upvoted solutions.
+      {/* Install — two commands */}
+      <section id="install" className="border-b border-border py-20 sm:py-24">
+        <div className="mx-auto max-w-7xl px-4 sm:px-6">
+          <div className="max-w-2xl">
+            <p className="landing-eyebrow">Install</p>
+            <h2 className="mt-4 font-display text-3xl font-semibold tracking-tight text-foreground sm:text-4xl">
+              One host. One command. Your metal.
+            </h2>
+            <p className="mt-3 text-[15px] leading-relaxed text-muted-foreground">
+              Bootstrap Docker, Bun, firewall rules, and Setup Mode on a fresh VPS — then wire GitHub and ship.
             </p>
           </div>
 
+          <div className="mt-10 grid gap-4 lg:grid-cols-2">
+            <div className="rounded-xl border border-border bg-card p-5 sm:p-6">
+              <div className="flex items-center justify-between gap-3 border-b border-border pb-3">
+                <span className="font-mono text-xs text-muted-foreground">install.sh</span>
+                <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-primary">Step 1 of 2</span>
+              </div>
+              <pre className="mt-4 overflow-x-auto font-mono text-[13px] leading-relaxed text-foreground">
+                <code>{INSTALL_CMD}</code>
+              </pre>
+              <p className="mt-4 text-sm text-muted-foreground">
+                Installs host packages, configures ports 80/443/9090/5173, and launches Setup Mode.
+              </p>
+            </div>
+
+            <div className="rounded-xl border border-border bg-card p-5 sm:p-6">
+              <div className="flex items-center justify-between gap-3 border-b border-border pb-3">
+                <span className="font-mono text-xs text-muted-foreground">deploy.yml</span>
+                <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-primary">Step 2 of 2</span>
+              </div>
+              <pre className="mt-4 overflow-x-auto font-mono text-[13px] leading-relaxed text-foreground">
+                <code>{`# GitHub Actions
+- name: Deploy via VersionGate
+  run: |
+    curl -X POST "$VG_URL/api/v1/deploy" \\
+      -H "Authorization: Bearer $VG_TOKEN" \\
+      -H "Content-Type: application/json" \\
+      -d '{"project":"web-app","env":"production"}'`}</code>
+              </pre>
+              <p className="mt-4 text-sm text-muted-foreground">
+                Trigger deploys with Bearer tokens — no session cookies, no dashboard click required.
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Community */}
+      <section id="qna" className="border-b border-border bg-muted/20 py-20 sm:py-24">
+        <div className="mx-auto max-w-7xl px-4 sm:px-6 space-y-8">
+          <div className="max-w-2xl">
+            <p className="landing-eyebrow">Knowledge base</p>
+            <h2 className="mt-4 font-display text-3xl font-semibold tracking-tight text-foreground sm:text-4xl">
+              Verified answers from the field.
+            </h2>
+            <p className="mt-3 text-[15px] leading-relaxed text-muted-foreground">
+              Troubleshooting threads with concrete snippets for proxy paths, rollbacks, and token scopes.
+            </p>
+          </div>
           <CommunityQnA />
+        </div>
+      </section>
+
+      {/* Final CTA */}
+      <section className="border-b border-border py-20 sm:py-28">
+        <div className="mx-auto max-w-3xl px-4 text-center sm:px-6">
+          <p className="landing-eyebrow">Start small</p>
+          <h2 className="mt-4 font-display text-3xl font-semibold tracking-tight text-foreground sm:text-4xl">
+            Start with one service. One deploy window. See what zero downtime feels like on your own host.
+          </h2>
+          <p className="mx-auto mt-4 max-w-xl text-[15px] leading-relaxed text-muted-foreground">
+            Open documentation · Self-hosted installer · Live decision traces in the dashboard
+          </p>
+          <div className="mt-8 flex flex-wrap items-center justify-center gap-3">
+            <Link
+              href="/docs/quick-start"
+              className="rounded-md bg-primary px-5 py-2.5 text-sm font-semibold text-primary-foreground transition hover:opacity-90"
+            >
+              Quick start
+            </Link>
+            <Link
+              href="/changelog"
+              className="rounded-md border border-border bg-card/40 px-5 py-2.5 text-sm font-semibold text-foreground transition hover:bg-muted"
+            >
+              Changelog
+            </Link>
+          </div>
         </div>
       </section>
 

--- a/website/src/app/page.tsx
+++ b/website/src/app/page.tsx
@@ -49,22 +49,23 @@ export default function Home() {
         <div className="absolute inset-0">
           <HeroDeployVisual />
         </div>
-        <div className="absolute inset-0 bg-gradient-to-r from-background via-background/85 to-background/20 lg:via-background/70 lg:to-transparent" />
+        <div className="absolute inset-0 bg-gradient-to-r from-[#06080f] via-[#06080f]/88 to-transparent lg:via-[#06080f]/72" />
+        <div className="absolute inset-0 bg-gradient-to-t from-[#06080f] via-transparent to-[#06080f]/40 lg:hidden" />
         <div className="relative mx-auto flex min-h-[88vh] max-w-7xl items-center px-4 py-20 sm:px-6 lg:min-h-[92vh]">
           <div className="max-w-xl landing-fade-up">
-            <p className="font-display landing-hero-brand text-5xl font-bold tracking-tight text-foreground sm:text-6xl lg:text-7xl">
+            <p className="font-display landing-hero-brand text-5xl font-bold tracking-tight text-white sm:text-6xl lg:text-7xl">
               VersionGate
             </p>
-            <h1 className="mt-5 max-w-xl font-display text-2xl font-medium leading-snug tracking-tight text-foreground/90 sm:text-3xl lg:text-[2rem]">
+            <h1 className="mt-5 max-w-xl font-display text-2xl font-medium leading-snug tracking-tight text-white/90 sm:text-3xl lg:text-[2rem]">
               Zero-downtime Docker deploys on metal you control.
             </h1>
-            <p className="mt-4 max-w-md text-[15px] leading-relaxed text-muted-foreground">
+            <p className="mt-4 max-w-md text-[15px] leading-relaxed text-white/65">
               Self-hosted blue-green engine. Push to GitHub — we build, health-check, and swap traffic with zero downtime.
             </p>
             <div className="mt-8 flex flex-wrap items-center gap-3">
               <Link
                 href="/docs"
-                className="rounded-md bg-primary px-5 py-2.5 text-sm font-semibold text-primary-foreground transition hover:opacity-90"
+                className="rounded-md bg-[#2257e7] px-5 py-2.5 text-sm font-semibold text-white transition hover:opacity-90"
               >
                 Read documentation
               </Link>
@@ -72,7 +73,7 @@ export default function Home() {
                 href={GITHUB_REPO}
                 target="_blank"
                 rel="noreferrer"
-                className="rounded-md border border-border bg-background/50 px-5 py-2.5 text-sm font-semibold text-foreground backdrop-blur-sm transition hover:bg-muted"
+                className="rounded-md border border-white/20 bg-black/30 px-5 py-2.5 text-sm font-semibold text-white backdrop-blur-sm transition hover:bg-black/50"
               >
                 GitHub repository
               </Link>

--- a/website/src/components/capability-grid.tsx
+++ b/website/src/components/capability-grid.tsx
@@ -115,17 +115,16 @@ export function CapabilityGrid() {
 
   return (
     <div className="space-y-6">
-      {/* Filter Tabs */}
       <div className="flex flex-wrap items-center gap-2 border-b border-border pb-4">
-        <span className="font-mono text-xs text-muted-foreground mr-2">Filter:</span>
+        <span className="mr-2 font-mono text-xs text-muted-foreground">Filter:</span>
         {categories.map((cat) => (
           <button
             key={cat}
             onClick={() => setSelectedCategory(cat)}
-            className={`px-3 py-1 font-mono text-xs rounded-md transition ${
+            className={`rounded-md px-3 py-1 font-mono text-xs transition ${
               selectedCategory === cat
-                ? "bg-primary text-primary-foreground font-semibold"
-                : "bg-muted text-muted-foreground border border-border hover:text-foreground"
+                ? "bg-primary font-semibold text-primary-foreground"
+                : "border border-border bg-muted/50 text-muted-foreground hover:text-foreground"
             }`}
           >
             {cat}
@@ -133,47 +132,45 @@ export function CapabilityGrid() {
         ))}
       </div>
 
-      {/* Capabilities Grid */}
-      <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
         {filtered.map((cap) => (
           <div
             key={cap.id}
-            className="group relative rounded-lg border border-border bg-card p-6 transition-all duration-200 hover:border-foreground/40 flex flex-col justify-between"
+            className="group relative flex flex-col justify-between rounded-xl border border-border bg-card p-6 transition-all duration-200 hover:border-primary/40"
           >
             <div className="space-y-3">
-              <div className="flex items-center justify-between">
-                <span className="rounded bg-muted px-2 py-0.5 font-mono text-[10px] text-muted-foreground border border-border">
+              <div className="flex items-center justify-between gap-2">
+                <span className="rounded border border-border bg-muted/60 px-2 py-0.5 font-mono text-[10px] text-muted-foreground">
                   {cap.category}
                 </span>
-                <span className="rounded bg-muted px-2 py-0.5 font-mono text-[10px] text-foreground border border-border font-semibold">
+                <span className="rounded border border-primary/30 bg-primary/10 px-2 py-0.5 font-mono text-[10px] font-semibold text-primary">
                   {cap.badge}
                 </span>
               </div>
 
-              <h3 className="font-sans text-sm font-bold text-foreground">
+              <h3 className="font-display text-sm font-semibold tracking-tight text-foreground">
                 {cap.title}
               </h3>
 
-              <p className="font-sans text-xs text-muted-foreground leading-relaxed">
+              <p className="text-xs leading-relaxed text-muted-foreground">
                 {cap.description}
               </p>
 
-              {/* Command Code Box */}
-              <div className="relative mt-3 rounded-md bg-muted border border-border p-3 font-mono text-xs text-foreground overflow-x-auto">
+              <div className="relative mt-3 overflow-x-auto rounded-md border border-border bg-muted/50 p-3 font-mono text-xs text-foreground">
                 <code>{cap.command}</code>
               </div>
             </div>
 
-            <div className="mt-6 border-t border-border pt-3 flex items-center justify-between font-mono text-[11px]">
+            <div className="mt-6 flex items-center justify-between border-t border-border pt-3 font-mono text-[11px]">
               <button
                 onClick={() => handleCopy(cap.id, cap.command)}
-                className="text-muted-foreground hover:text-foreground transition"
+                className="text-muted-foreground transition hover:text-foreground"
               >
-                {copiedId === cap.id ? "[ Copied! ]" : "[ Copy Command ]"}
+                {copiedId === cap.id ? "[ Copied ]" : "[ Copy Command ]"}
               </button>
               <button
                 onClick={() => setActiveModalCap(cap)}
-                className="text-foreground font-semibold hover:underline"
+                className="font-semibold text-foreground hover:underline"
               >
                 [ Inspect Spec ]
               </button>

--- a/website/src/components/execution-sandbox.tsx
+++ b/website/src/components/execution-sandbox.tsx
@@ -74,16 +74,15 @@ export function ExecutionSandbox() {
 
   return (
     <div className="space-y-4">
-      {/* Scenario Selector Tabs */}
       <div className="flex flex-wrap items-center gap-2 border-b border-border pb-3">
         {(Object.keys(scenarios) as Scenario[]).map((key) => (
           <button
             key={key}
             onClick={() => setActiveScenario(key)}
-            className={`px-3 py-1.5 font-mono text-xs rounded-md transition ${
+            className={`rounded-md px-3 py-1.5 font-mono text-xs transition ${
               activeScenario === key
-                ? "bg-primary text-primary-foreground font-semibold"
-                : "bg-muted text-muted-foreground border border-border hover:text-foreground"
+                ? "bg-primary font-semibold text-primary-foreground"
+                : "border border-border bg-muted/50 text-muted-foreground hover:text-foreground"
             }`}
           >
             {key.toUpperCase()}
@@ -91,32 +90,29 @@ export function ExecutionSandbox() {
         ))}
       </div>
 
-      {/* Terminal Sandbox Display */}
       <div className="grid gap-4 lg:grid-cols-2">
-        {/* Terminal Log Stream */}
-        <div className="rounded-lg border border-border bg-card p-4 space-y-3 shadow-sm">
+        <div className="space-y-3 rounded-xl border border-border bg-card p-4">
           <div className="flex items-center justify-between border-b border-border pb-2">
             <span className="font-mono text-xs font-semibold text-foreground">{current.title}</span>
             <span className="font-mono text-[10px] text-muted-foreground">[ Real-time Stream ]</span>
           </div>
 
-          <div className="font-mono text-xs space-y-2 p-3 bg-muted rounded-md border border-border overflow-x-auto min-h-[220px]">
+          <div className="min-h-[220px] space-y-2 overflow-x-auto rounded-md border border-border bg-muted/50 p-3 font-mono text-xs">
             {current.logs.map((line, idx) => (
-              <div key={idx} className="text-foreground leading-relaxed">
+              <div key={idx} className="leading-relaxed text-foreground">
                 {line}
               </div>
             ))}
           </div>
         </div>
 
-        {/* JSON Telemetry Response */}
-        <div className="rounded-lg border border-border bg-card p-4 space-y-3 shadow-sm">
+        <div className="space-y-3 rounded-xl border border-border bg-card p-4">
           <div className="flex items-center justify-between border-b border-border pb-2">
             <span className="font-mono text-xs font-semibold text-foreground">API Telemetry Payload</span>
             <span className="font-mono text-[10px] text-muted-foreground">[ 200 OK ]</span>
           </div>
 
-          <pre className="p-3 bg-muted border border-border font-mono text-xs text-foreground rounded-md overflow-x-auto min-h-[220px]">
+          <pre className="min-h-[220px] overflow-x-auto rounded-md border border-border bg-muted/50 p-3 font-mono text-xs text-foreground">
             {JSON.stringify(current.jsonResponse, null, 2)}
           </pre>
         </div>

--- a/website/src/components/hero-deploy-visual.tsx
+++ b/website/src/components/hero-deploy-visual.tsx
@@ -1,0 +1,174 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+const LOG_LINES = [
+  "[ INFO ] Job #4912 enqueued · web-app / production",
+  "[ INFO ] Idle slot GREEN :3101 selected",
+  "[ OK ] Health check 200 · 14ms",
+  "[ OK ] Nginx upstream rewrite · 0 ms downtime",
+  "[ LIVE ] Traffic on GREEN · BLUE warm for rollback",
+] as const;
+
+export function HeroDeployVisual() {
+  const [phase, setPhase] = useState(0);
+  const [visibleLogs, setVisibleLogs] = useState(1);
+  const [activeSlot, setActiveSlot] = useState<"BLUE" | "GREEN">("BLUE");
+
+  useEffect(() => {
+    const timers: ReturnType<typeof setTimeout>[] = [];
+    const run = () => {
+      setPhase(0);
+      setVisibleLogs(1);
+      setActiveSlot("BLUE");
+
+      timers.push(
+        setTimeout(() => {
+          setPhase(1);
+          setVisibleLogs(2);
+        }, 900),
+        setTimeout(() => {
+          setPhase(2);
+          setVisibleLogs(3);
+        }, 1800),
+        setTimeout(() => {
+          setPhase(3);
+          setVisibleLogs(4);
+          setActiveSlot("GREEN");
+        }, 2700),
+        setTimeout(() => {
+          setPhase(4);
+          setVisibleLogs(5);
+        }, 3600),
+        setTimeout(run, 6200),
+      );
+    };
+
+    run();
+    return () => timers.forEach(clearTimeout);
+  }, []);
+
+  return (
+    <div className="relative h-full min-h-[88vh] w-full overflow-hidden lg:min-h-[92vh]">
+      <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_72%_42%,rgba(34,87,231,0.34),transparent_52%),radial-gradient(ellipse_at_15%_85%,rgba(34,87,231,0.12),transparent_40%),linear-gradient(180deg,#06080f_0%,#0a1020_55%,#06080f_100%)]" />
+      <div className="absolute inset-0 opacity-[0.3] [background-image:linear-gradient(rgba(255,255,255,0.05)_1px,transparent_1px),linear-gradient(90deg,rgba(255,255,255,0.05)_1px,transparent_1px)] [background-size:56px_56px] [mask-image:radial-gradient(ellipse_at_75%_45%,black_10%,transparent_70%)]" />
+
+      <div className="pointer-events-none absolute inset-y-0 right-0 hidden w-[58%] lg:block">
+        <div className="absolute left-[8%] top-[22%] right-[10%] landing-fade-up">
+          <div className="mb-6 flex items-end justify-between gap-4">
+            <div>
+              <p className="font-mono text-[11px] uppercase tracking-[0.2em] text-[#7aa2ff]">
+                Control plane
+              </p>
+              <p className="mt-1 font-display text-2xl font-semibold tracking-tight text-white">
+                Blue / Green slots
+              </p>
+            </div>
+            <p className="font-mono text-[11px] text-white/40">web-app · production</p>
+          </div>
+
+          <div className="grid grid-cols-2 gap-5">
+            <SlotPlane
+              name="BLUE"
+              port=":3100"
+              active={activeSlot === "BLUE"}
+              role={activeSlot === "BLUE" ? "ACTIVE" : "WARM"}
+            />
+            <SlotPlane
+              name="GREEN"
+              port=":3101"
+              active={activeSlot === "GREEN"}
+              role={activeSlot === "GREEN" ? "ACTIVE" : phase >= 1 ? "BUILDING" : "IDLE"}
+              building={phase >= 1 && phase < 3 && activeSlot !== "GREEN"}
+            />
+          </div>
+
+          <div className="relative mt-6 h-12 overflow-hidden border border-white/10 bg-black/30">
+            <div
+              className={`absolute inset-y-0 w-1/2 bg-[#2257e7]/25 transition-all duration-700 ease-out ${
+                activeSlot === "GREEN" ? "left-1/2" : "left-0"
+              }`}
+            />
+            <div
+              className={`absolute top-1/2 h-2 w-2 -translate-y-1/2 rounded-full bg-[#9db7ff] shadow-[0_0_24px_rgba(125,162,255,0.9)] transition-all duration-700 ease-out ${
+                activeSlot === "GREEN" ? "left-[72%]" : "left-[22%]"
+              }`}
+            />
+            <div className="absolute inset-0 flex items-center justify-center font-mono text-[11px] font-medium tracking-[0.14em] text-white/80">
+              UPSTREAM → {activeSlot} · 0 MS DOWNTIME
+            </div>
+          </div>
+
+          <div className="mt-6 space-y-1.5 border-t border-white/10 pt-5 font-mono text-[12px] leading-relaxed text-white/65">
+            {LOG_LINES.slice(0, visibleLogs).map((line) => (
+              <p key={line} className="landing-log-line">
+                {line}
+              </p>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {/* Mobile / tablet compact strip */}
+      <div className="absolute inset-x-0 bottom-0 p-4 lg:hidden">
+        <div className="border border-white/10 bg-black/50 p-4 backdrop-blur-sm">
+          <div className="flex items-center justify-between font-mono text-[10px] uppercase tracking-[0.16em] text-[#7aa2ff]">
+            <span>Upstream</span>
+            <span>{activeSlot}</span>
+          </div>
+          <div className="mt-3 grid grid-cols-2 gap-2">
+            <div className={`border px-3 py-2 ${activeSlot === "BLUE" ? "border-[#2257e7] bg-[#2257e7]/20" : "border-white/10"}`}>
+              <p className="font-mono text-[11px] text-white">BLUE</p>
+            </div>
+            <div className={`border px-3 py-2 ${activeSlot === "GREEN" ? "border-[#2257e7] bg-[#2257e7]/20" : "border-white/10"}`}>
+              <p className="font-mono text-[11px] text-white">GREEN</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function SlotPlane({
+  name,
+  port,
+  active,
+  role,
+  building = false,
+}: {
+  name: string;
+  port: string;
+  active: boolean;
+  role: string;
+  building?: boolean;
+}) {
+  return (
+    <div
+      className={`border p-5 transition-all duration-500 ${
+        active
+          ? "border-[#2257e7]/80 bg-[#2257e7]/15"
+          : "border-white/10 bg-white/[0.03]"
+      }`}
+    >
+      <div className="flex items-center justify-between">
+        <span className="font-display text-xl font-semibold tracking-tight text-white">{name}</span>
+        <span
+          className={`font-mono text-[10px] tracking-[0.12em] ${
+            active ? "text-[#9db7ff]" : building ? "text-amber-200/80" : "text-white/35"
+          }`}
+        >
+          {role}
+        </span>
+      </div>
+      <p className="mt-3 font-mono text-sm text-white/45">{port}</p>
+      <div className="mt-5 h-px w-full bg-white/10">
+        <div
+          className={`h-px transition-all duration-700 ${
+            active ? "w-full bg-[#7aa2ff]" : building ? "w-2/3 animate-pulse bg-[#2257e7]/80" : "w-1/5 bg-white/25"
+          }`}
+        />
+      </div>
+    </div>
+  );
+}

--- a/website/src/components/site-footer.tsx
+++ b/website/src/components/site-footer.tsx
@@ -13,14 +13,14 @@ const LINKS = [
 
 export function SiteFooter() {
   return (
-    <footer className="border-t border-border bg-background py-12 transition-colors">
+    <footer className="border-t border-border bg-background py-14 transition-colors">
       <div className="mx-auto flex max-w-7xl flex-col gap-6 px-4 sm:px-6 md:flex-row md:items-center md:justify-between">
         <div className="space-y-1">
-          <p className="font-sans text-xs text-foreground font-bold">
-            VersionGate Engine // Zero-Downtime Docker Deploys
+          <p className="font-display text-sm font-semibold tracking-tight text-foreground">
+            VersionGate
           </p>
           <p className="font-mono text-[11px] text-muted-foreground">
-            © {new Date().getFullYear()} Dinesh Korukonda · MIT Licensed
+            Zero-downtime Docker deploys · © {new Date().getFullYear()} Dinesh Korukonda · MIT
           </p>
         </div>
 

--- a/website/src/components/site-header.tsx
+++ b/website/src/components/site-header.tsx
@@ -28,55 +28,66 @@ export function SiteHeader({ active }: { active?: "features" | "docs" }) {
 
   return (
     <>
-      <header className="sticky top-0 z-40 border-b border-border bg-background/90 backdrop-blur-md transition-colors">
+      <header className="sticky top-0 z-40 border-b border-border/80 bg-background/80 backdrop-blur-md transition-colors">
         <div className="mx-auto flex h-14 max-w-7xl items-center justify-between px-4 sm:px-6">
-          <div className="flex items-center gap-6">
-            <Link href="/" className="font-sans text-base font-bold tracking-tight text-foreground flex items-center gap-2">
-              <span>VersionGate</span>
+          <div className="flex items-center gap-8">
+            <Link
+              href="/"
+              className="font-display text-[15px] font-bold tracking-tight text-foreground"
+            >
+              VersionGate
             </Link>
 
             <nav className="hidden items-center gap-6 md:flex">
               <Link
                 href="/#capabilities"
-                className={`font-sans text-xs transition ${
-                  active === "features" ? "text-foreground font-semibold" : "text-muted-foreground hover:text-foreground"
+                className={`text-xs transition ${
+                  active === "features"
+                    ? "font-semibold text-foreground"
+                    : "text-muted-foreground hover:text-foreground"
                 }`}
               >
                 Features
               </Link>
               <Link
+                href="/#architecture-loop"
+                className="text-xs text-muted-foreground transition hover:text-foreground"
+              >
+                Architecture
+              </Link>
+              <Link
                 href="/docs"
-                className={`font-sans text-xs transition ${
-                  active === "docs" ? "text-foreground font-semibold" : "text-muted-foreground hover:text-foreground"
+                className={`text-xs transition ${
+                  active === "docs"
+                    ? "font-semibold text-foreground"
+                    : "text-muted-foreground hover:text-foreground"
                 }`}
               >
                 Docs
               </Link>
               <Link
                 href="/changelog"
-                className="font-sans text-xs text-muted-foreground hover:text-foreground transition"
+                className="text-xs text-muted-foreground transition hover:text-foreground"
               >
                 Changelog
               </Link>
             </nav>
           </div>
 
-          <div className="flex items-center gap-3">
-            {/* Search Trigger Button */}
+          <div className="flex items-center gap-2 sm:gap-3">
             <button
               onClick={() => setSearchOpen(true)}
-              className="flex items-center gap-2 rounded-md border border-border bg-muted/50 px-3 py-1.5 font-sans text-xs text-muted-foreground hover:text-foreground hover:bg-muted transition"
+              className="flex items-center gap-2 rounded-md border border-border bg-muted/40 px-3 py-1.5 text-xs text-muted-foreground transition hover:bg-muted hover:text-foreground"
             >
               <span>Search</span>
-              <kbd className="rounded bg-background px-1.5 py-0.5 text-[10px] text-muted-foreground border border-border font-mono">
-                ⌘K
+              <kbd className="hidden rounded border border-border bg-background px-1.5 py-0.5 font-mono text-[10px] text-muted-foreground sm:inline">
+                Ctrl K
               </kbd>
             </button>
 
-            {/* Theme Switcher Button */}
             <button
               onClick={toggleTheme}
-              className="rounded-md border border-border bg-muted/50 px-3 py-1.5 font-mono text-xs text-foreground hover:bg-muted transition"
+              className="rounded-md border border-border bg-muted/40 px-3 py-1.5 font-mono text-xs text-foreground transition hover:bg-muted"
               title="Toggle Light/Dark Theme"
             >
               [ {theme === "dark" ? "Dark" : "Light"} ]
@@ -86,7 +97,7 @@ export function SiteHeader({ active }: { active?: "features" | "docs" }) {
               href={GITHUB_REPO}
               target="_blank"
               rel="noreferrer"
-              className="hidden rounded-md border border-border bg-muted/50 px-3.5 py-1.5 font-sans text-xs text-foreground transition hover:bg-muted sm:inline-flex"
+              className="hidden rounded-md bg-primary px-3.5 py-1.5 text-xs font-semibold text-primary-foreground transition hover:opacity-90 sm:inline-flex"
             >
               GitHub
             </Link>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Redesigns the VersionGate marketing landing page to a CARF-caliber editorial product experience — brand-first hero, full-bleed animated blue/green control plane, problem narrative, four-step architecture loop, install path, and refined capability presentation.

## Preview

[Hero (desktop)](https://cursor.com/agents/bc-0215e6b2-0697-466b-ac0c-891634e29fe3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Flanding-hero-dark.png)
[Architecture loop](https://cursor.com/agents/bc-0215e6b2-0697-466b-ac0c-891634e29fe3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Flanding-architecture.png)
[Mobile hero](https://cursor.com/agents/bc-0215e6b2-0697-466b-ac0c-891634e29fe3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Flanding-mobile.png)

[landing-page-redesign-demo-small.mp4](https://cursor.com/agents/bc-0215e6b2-0697-466b-ac0c-891634e29fe3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flanding-page-redesign-demo-small.mp4)

## Changes

- New full-bleed hero with `VersionGate` as the primary brand signal and animated slot-swap visual
- Narrative sections: problem gap, architecture loop (Build / Prove / Swap / Recover), simulator, capabilities, pipeline, install, knowledge base, final CTA
- Typography: Space Grotesk display + DM Sans body + JetBrains Mono
- VersionGate blue accent atmosphere (not a CARF orange clone)
- Hero copy locked to white over the dark visual so light theme stays readable
- Capability grid, execution sandbox, header/footer polish for the new system
- Changelog entry for the landing redesign (`v1.6.0` fallback)

## Scope

Landing page / marketing website only. Engine and dashboard behavior unchanged.

## Verification

- `bun run typecheck`
- `bun run build:dashboard`
- `bun test --pass-with-no-tests`
- `cd website && bun run build`
- Manual browser QA (desktop, mobile, light/dark hero contrast)

## Issue linking

No open GitHub issue existed for this request (direct product ask). Tracking via this PR.

## Labels

`enhancement`, `frontend` — please assign `@dineshkorukonda`.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0215e6b2-0697-466b-ac0c-891634e29fe3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0215e6b2-0697-466b-ac0c-891634e29fe3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

